### PR TITLE
fix: setup node in publish workflow

### DIFF
--- a/.github/workflows/run-version-or-publish.yml
+++ b/.github/workflows/run-version-or-publish.yml
@@ -10,6 +10,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
       - name: covector version-or-publish
         uses: ./packages/action
         id: covector


### PR DESCRIPTION
This is needed to handle the signing into npm for publishing.