### PR TITLE
fix: publish login needs registry url

### DIFF
--- a/.github/workflows/run-version-or-publish.yml
+++ b/.github/workflows/run-version-or-publish.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 12
+          registry-url: 'https://registry.npmjs.org'
       - name: covector version-or-publish
         uses: ./packages/action
         id: covector


### PR DESCRIPTION
The registry url is needed in setup-node to login to npm.