### PR TITLE
feat: allow multiple publishes

### DIFF
--- a/.changes/multiple-publish.md
+++ b/.changes/multiple-publish.md
@@ -1,0 +1,7 @@
+---
+"covector": patch
+"@covector/command": minor
+"@covector/assemble": minor
+---
+
+Allow multiple publish sequences. Any command beginning with `publish` will invoke the related `getPublishedVersion`, e.g. `publishNPM` would look for and check `getPublishedVersionNPM`. This allows separation of concerns and re-run-ability for multiple deploy targets.

--- a/__fixtures__/integration.js-with-subcommands/.changes/config.json
+++ b/__fixtures__/integration.js-with-subcommands/.changes/config.json
@@ -1,0 +1,21 @@
+{
+  "pkgManagers": {
+    "javascript": {
+      "version": true,
+      "getPublishedVersion-primary": "echo 2.3.1",
+      "publish-primary": { "command": "echo publish", "pipe": true },
+      "getPublishedVersionSecondary": "echo 1.9.0",
+      "publishSecondary": { "command": "echo publish", "pipe": true }
+    }
+  },
+  "packages": {
+    "package-one": {
+      "path": "./packages/package-one",
+      "manager": "javascript"
+    },
+    "package-two": {
+      "path": "./packages/package-two",
+      "manager": "javascript"
+    }
+  }
+}

--- a/__fixtures__/integration.js-with-subcommands/package.json
+++ b/__fixtures__/integration.js-with-subcommands/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "workspace",
+  "description": "This is React. Trust.",
+  "version": "0.0.0",
+  "license": "MIT",
+  "workspaces": [
+    "packages/*"
+  ]
+}

--- a/__fixtures__/integration.js-with-subcommands/packages/package-one/package.json
+++ b/__fixtures__/integration.js-with-subcommands/packages/package-one/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "package-one",
+  "version": "2.3.1",
+  "license": "MIT",
+  "scripts": {
+    "build": "yarn info tauri@0.8.0 description",
+    "test": "yarn info covector@0.1.0 license"
+  }
+}

--- a/__fixtures__/integration.js-with-subcommands/packages/package-two/package.json
+++ b/__fixtures__/integration.js-with-subcommands/packages/package-two/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "package-two",
+  "version": "1.9.0",
+  "license": "MIT",
+  "scripts": {
+    "build": "echo this command is not piped, it is run from scripts for pk2",
+    "test": "echo this command is not piped, it is run from the test script"
+  }
+}

--- a/packages/command/index.js
+++ b/packages/command/index.js
@@ -75,17 +75,22 @@ const attemptCommands = function* ({
   return _pkgCommandsRan;
 };
 
-const confirmCommandsToRun = function* ({ cwd, commands }) {
+const confirmCommandsToRun = function* ({ cwd, commands, command }) {
+  let subPublishCommand = command.slice(7, 999);
   let commandsToRun = [];
   for (let pkg of commands) {
-    if (!!pkg.getPublishedVersion) {
+    if (!!pkg[`getPublishedVersion${subPublishCommand}`]) {
       const version = yield runCommand({
-        command: pkg.getPublishedVersion,
+        command: pkg[`getPublishedVersion${subPublishCommand}`],
         cwd,
         pkg: pkg.pkg,
         pkgPath: pkg.path,
         stdio: "pipe",
-        log: `Checking if ${pkg.pkg}@${pkg.pkgFile.version} is already published with: ${pkg.getPublishedVersion}`,
+        log: `Checking if ${pkg.pkg}@${
+          pkg.pkgFile.version
+        } is already published with: ${
+          pkg[`getPublishedVersion${subPublishCommand}`]
+        }`,
       });
 
       if (pkg.pkgFile.version === version) {

--- a/packages/covector/__snapshots__/index.test.js.snap
+++ b/packages/covector/__snapshots__/index.test.js.snap
@@ -8403,3 +8403,199 @@ Object {
   },
 }
 `;
+
+exports[`integration test to invoke sub commands runs publish-primary in prod mode 1`] = `
+Object {
+  "consoleInfo": Array [],
+  "consoleLog": Array [
+    Array [
+      "package-one [publish-primary]: echo publish",
+    ],
+    Array [
+      "publish",
+    ],
+    Array [
+      "package-two [publish-primary]: echo publish",
+    ],
+    Array [
+      "publish",
+    ],
+  ],
+  "covectorReturn": Object {
+    "package-one": Object {
+      "command": "publish
+",
+      "pkg": Object {
+        "command": Array [
+          Object {
+            "command": "echo publish",
+            "dryRunCommand": undefined,
+            "pipe": true,
+          },
+        ],
+        "dependencies": undefined,
+        "manager": "javascript",
+        "path": "./packages/package-one",
+        "pkg": "package-one",
+        "pkgFile": Object {
+          "name": "package-one",
+          "pkg": Object {
+            "license": "MIT",
+            "name": "package-one",
+            "scripts": Object {
+              "build": "yarn info tauri@0.8.0 description",
+              "test": "yarn info covector@0.1.0 license",
+            },
+            "version": "2.3.1",
+          },
+          "version": "2.3.1",
+          "versionMajor": 2,
+          "versionMinor": 3,
+          "versionPatch": 1,
+        },
+        "postcommand": null,
+        "precommand": null,
+        "type": null,
+      },
+      "postcommand": false,
+      "precommand": false,
+    },
+    "package-two": Object {
+      "command": "publish
+",
+      "pkg": Object {
+        "command": Array [
+          Object {
+            "command": "echo publish",
+            "dryRunCommand": undefined,
+            "pipe": true,
+          },
+        ],
+        "dependencies": undefined,
+        "manager": "javascript",
+        "path": "./packages/package-two",
+        "pkg": "package-two",
+        "pkgFile": Object {
+          "name": "package-two",
+          "pkg": Object {
+            "license": "MIT",
+            "name": "package-two",
+            "scripts": Object {
+              "build": "echo this command is not piped, it is run from scripts for pk2",
+              "test": "echo this command is not piped, it is run from the test script",
+            },
+            "version": "1.9.0",
+          },
+          "version": "1.9.0",
+          "versionMajor": 1,
+          "versionMinor": 9,
+          "versionPatch": 0,
+        },
+        "postcommand": null,
+        "precommand": null,
+        "type": null,
+      },
+      "postcommand": false,
+      "precommand": false,
+    },
+  },
+}
+`;
+
+exports[`integration test to invoke sub commands runs publishSecondary in prod mode 1`] = `
+Object {
+  "consoleInfo": Array [],
+  "consoleLog": Array [
+    Array [
+      "package-one [publishSecondary]: echo publish",
+    ],
+    Array [
+      "publish",
+    ],
+    Array [
+      "package-two [publishSecondary]: echo publish",
+    ],
+    Array [
+      "publish",
+    ],
+  ],
+  "covectorReturn": Object {
+    "package-one": Object {
+      "command": "publish
+",
+      "pkg": Object {
+        "command": Array [
+          Object {
+            "command": "echo publish",
+            "dryRunCommand": undefined,
+            "pipe": true,
+          },
+        ],
+        "dependencies": undefined,
+        "manager": "javascript",
+        "path": "./packages/package-one",
+        "pkg": "package-one",
+        "pkgFile": Object {
+          "name": "package-one",
+          "pkg": Object {
+            "license": "MIT",
+            "name": "package-one",
+            "scripts": Object {
+              "build": "yarn info tauri@0.8.0 description",
+              "test": "yarn info covector@0.1.0 license",
+            },
+            "version": "2.3.1",
+          },
+          "version": "2.3.1",
+          "versionMajor": 2,
+          "versionMinor": 3,
+          "versionPatch": 1,
+        },
+        "postcommand": null,
+        "precommand": null,
+        "type": null,
+      },
+      "postcommand": false,
+      "precommand": false,
+    },
+    "package-two": Object {
+      "command": "publish
+",
+      "pkg": Object {
+        "command": Array [
+          Object {
+            "command": "echo publish",
+            "dryRunCommand": undefined,
+            "pipe": true,
+          },
+        ],
+        "dependencies": undefined,
+        "manager": "javascript",
+        "path": "./packages/package-two",
+        "pkg": "package-two",
+        "pkgFile": Object {
+          "name": "package-two",
+          "pkg": Object {
+            "license": "MIT",
+            "name": "package-two",
+            "scripts": Object {
+              "build": "echo this command is not piped, it is run from scripts for pk2",
+              "test": "echo this command is not piped, it is run from the test script",
+            },
+            "version": "1.9.0",
+          },
+          "version": "1.9.0",
+          "versionMajor": 1,
+          "versionMinor": 9,
+          "versionPatch": 0,
+        },
+        "postcommand": null,
+        "precommand": null,
+        "type": null,
+      },
+      "postcommand": false,
+      "precommand": false,
+    },
+  },
+}
+`;

--- a/packages/covector/index.test.js
+++ b/packages/covector/index.test.js
@@ -450,3 +450,39 @@ const scrubVfile = (covectored) => {
     return c;
   }, covectored);
 };
+
+describe("integration test to invoke sub commands", () => {
+  it("runs publish-primary in prod mode", async () => {
+    const restoreConsole = mockConsole(["log", "info"]);
+    const fullIntegration = f.copy("integration.js-with-subcommands");
+    const covectored = await main(
+      covector({
+        command: "publish-primary",
+        cwd: fullIntegration,
+      })
+    );
+    expect({
+      consoleLog: console.log.mock.calls,
+      consoleInfo: console.info.mock.calls,
+      covectorReturn: scrubVfile(covectored),
+    }).toMatchSnapshot();
+    restoreConsole();
+  });
+
+  it("runs publishSecondary in prod mode", async () => {
+    const restoreConsole = mockConsole(["log", "info"]);
+    const fullIntegration = f.copy("integration.js-with-subcommands");
+    const covectored = await main(
+      covector({
+        command: "publishSecondary",
+        cwd: fullIntegration,
+      })
+    );
+    expect({
+      consoleLog: console.log.mock.calls,
+      consoleInfo: console.info.mock.calls,
+      covectorReturn: scrubVfile(covectored),
+    }).toMatchSnapshot();
+    restoreConsole();
+  });
+});

--- a/packages/covector/src/run.js
+++ b/packages/covector/src/run.js
@@ -149,7 +149,11 @@ module.exports.covector = function* covector({
       return `No commands configured to run on [${command}].`;
     }
 
-    const commandsToRun = yield confirmCommandsToRun({ cwd, commands });
+    const commandsToRun = yield confirmCommandsToRun({
+      cwd,
+      commands,
+      command,
+    });
 
     let pkgCommandsRan = commands.reduce((pkgs, pkg) => {
       pkgs[pkg.pkg] = {


### PR DESCRIPTION
Any command prepended with publish will now invoke the related version check command prepended with getPublishedVersion.