### PR TITLE
fix: workflow version mode check

### DIFF
--- a/.github/workflows/run-version-or-publish.yml
+++ b/.github/workflows/run-version-or-publish.yml
@@ -38,7 +38,7 @@ jobs:
       - name: create pull request
         id: cpr
         uses: peter-evans/create-pull-request@v2
-        if: ${{ steps.covector.outputs.command }} == 'version'
+        if: steps.covector.outputs.commandRan == 'version'
         with:
           title: "Publish New Versions"
           commit-message: "publish new versions"


### PR DESCRIPTION
It was always "failing" the check which effectively ignores the `if`. Fix for proper check.