### PR TITLE
chore: remove lerna config file

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,0 @@
-{
-  "npmClient": "yarn",
-  "packages": [
-    "packages/*"
-  ],
-  "version": "independent"
-}


### PR DESCRIPTION
We don't need to use it anymore as covector can handle this function now.