### PR TITLE
feat: filter pkgs

### DIFF
--- a/.changes/filter-packages.md
+++ b/.changes/filter-packages.md
@@ -1,0 +1,6 @@
+---
+"covector": patch
+"@covector/assemble": minor
+---
+
+Some workflows require different actions for different packages. Most of this can be codified into config. However there are cases where you may need to run a command for a dynamic set of packages.

--- a/.changes/filter-packages.md
+++ b/.changes/filter-packages.md
@@ -1,6 +1,7 @@
 ---
 "covector": patch
 "@covector/assemble": minor
+"action": minor
 ---
 
 Some workflows require different actions for different packages. Most of this can be codified into config. However there are cases where you may need to run a command for a dynamic set of packages.

--- a/__fixtures__/assemble/packages/assemble1/package.json
+++ b/__fixtures__/assemble/packages/assemble1/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "assemble1",
+  "version": "0.0.0"
+}

--- a/__fixtures__/assemble/packages/assemble2/package.json
+++ b/__fixtures__/assemble/packages/assemble2/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "assemble2",
+  "version": "0.0.0"
+}

--- a/__fixtures__/assemble/packages/namespaced-assemble1/package.json
+++ b/__fixtures__/assemble/packages/namespaced-assemble1/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@namedspaced/assemble1",
+  "version": "0.0.0"
+}

--- a/__fixtures__/assemble/packages/namespaced-assemble2/package.json
+++ b/__fixtures__/assemble/packages/namespaced-assemble2/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@namedspaced/assemble2",
+  "version": "0.0.0"
+}

--- a/packages/action/action.yml
+++ b/packages/action/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: When creating a release, set it as a draft.
     required: false
     default: false
+  filterPackages:
+    description: A comma separated list (no spaces) of packages to run commands on rather than everything listed in the config.
+    required: false
+    default: ''
 outputs:
   change:
     description: The changes that were applied

--- a/packages/action/index.js
+++ b/packages/action/index.js
@@ -2,6 +2,7 @@ const core = require("@actions/core");
 const github = require("@actions/github");
 const { main } = require("@effection/node");
 const { covector } = require("../covector");
+const { commandText, packageListToArray } = require("./utils");
 const fs = require("fs");
 
 main(function* run() {
@@ -11,6 +12,7 @@ main(function* run() {
         ? process.env.GITHUB_TOKEN
         : core.getInput("token");
     const inputCommand = core.getInput("command");
+    const filterPackages = packageListToArray(core.getInput("filterPackages"));
     let command = inputCommand;
     if (inputCommand === "version-or-publish") {
       if ((yield covector({ command: "status" })) === "No changes.") {
@@ -20,7 +22,7 @@ main(function* run() {
         command = "version";
       }
     }
-    const covectored = yield covector({ command });
+    const covectored = yield covector({ command, filterPackages });
 
     core.setOutput("commandRan", command);
     let successfulPublish = false;
@@ -96,22 +98,3 @@ main(function* run() {
     core.setFailed(error.message);
   }
 });
-
-const commandText = (pkg) => {
-  const { precommand, command, postcommand } = pkg;
-  let text = "";
-
-  if (typeof precommand !== "boolean") {
-    text = `${text}${precommand}\n`;
-  }
-
-  if (typeof command !== "boolean") {
-    text = `${text}${command}\n`;
-  }
-
-  if (typeof postcommand !== "boolean") {
-    text = `${text}${postcommand}\n`;
-  }
-
-  return text === "" ? "Publish complete." : text;
-};

--- a/packages/action/index.test.js
+++ b/packages/action/index.test.js
@@ -1,0 +1,24 @@
+const { packageListToArray } = require("./utils");
+
+describe("packageListToArray", () => {
+  it("returns empty array on empty string", () => {
+    const list = "";
+    const pkgArray = packageListToArray(list);
+    expect(pkgArray.length).toBe(0);
+  });
+
+  it("splits on comma", () => {
+    const list = "package1,package2,package3";
+    const pkgArray = packageListToArray(list);
+    expect(pkgArray[0]).toBe("package1");
+    expect(pkgArray[1]).toBe("package2");
+    expect(pkgArray[2]).toBe("package3");
+  });
+
+  it("considers a single package", () => {
+    const list = "package17";
+    const pkgArray = packageListToArray(list);
+    expect(pkgArray[0]).toBe("package17");
+    expect(pkgArray[1]).toBe(undefined);
+  });
+});

--- a/packages/action/utils.js
+++ b/packages/action/utils.js
@@ -1,0 +1,28 @@
+const commandText = (pkg) => {
+  const { precommand, command, postcommand } = pkg;
+  let text = "";
+
+  if (typeof precommand !== "boolean") {
+    text = `${text}${precommand}\n`;
+  }
+
+  if (typeof command !== "boolean") {
+    text = `${text}${command}\n`;
+  }
+
+  if (typeof postcommand !== "boolean") {
+    text = `${text}${postcommand}\n`;
+  }
+
+  return text === "" ? "Publish complete." : text;
+};
+
+const packageListToArray = (list) => {
+  if (list === "") {
+    return [];
+  } else {
+    return list.split(",");
+  }
+};
+
+module.exports = { commandText, packageListToArray };

--- a/packages/assemble/__snapshots__/index.test.js.snap
+++ b/packages/assemble/__snapshots__/index.test.js.snap
@@ -180,6 +180,88 @@ Array [
 ]
 `;
 
+exports[`merge config test merges publish 1`] = `
+Array [
+  Object {
+    "command": Array [
+      "npm publish",
+    ],
+    "dependencies": Array [
+      "all",
+    ],
+    "manager": "javascript",
+    "path": "./packages/assemble1",
+    "pkg": "assemble1",
+    "pkgFile": Object {
+      "name": "assemble1",
+      "pkg": Object {
+        "name": "assemble1",
+        "version": "0.0.0",
+      },
+      "version": "0.0.0",
+      "versionMajor": 0,
+      "versionMinor": 0,
+      "versionPatch": 0,
+    },
+    "postcommand": null,
+    "precommand": null,
+    "type": null,
+  },
+  Object {
+    "command": Array [
+      "cargo publish",
+    ],
+    "dependencies": Array [
+      "assemble1",
+      "all",
+    ],
+    "manager": "cargo",
+    "path": "./packages/namespaced-assemble2",
+    "pkg": "@namespaced/assemble1",
+    "pkgFile": Object {
+      "name": "@namespaced/assemble1",
+      "pkg": Object {
+        "name": "@namedspaced/assemble2",
+        "version": "0.0.0",
+      },
+      "version": "0.0.0",
+      "versionMajor": 0,
+      "versionMinor": 0,
+      "versionPatch": 0,
+    },
+    "postcommand": null,
+    "precommand": null,
+    "type": null,
+  },
+  Object {
+    "command": Array [
+      "cargo publish",
+    ],
+    "dependencies": Array [
+      "assemble2",
+      "all",
+    ],
+    "manager": "cargo",
+    "path": "./packages/namespaced-assemble2",
+    "pkg": "@namespaced/assemble2",
+    "pkgFile": Object {
+      "name": "@namespaced/assemble2",
+      "pkg": Object {
+        "name": "@namedspaced/assemble2",
+        "version": "0.0.0",
+      },
+      "version": "0.0.0",
+      "versionMajor": 0,
+      "versionMinor": 0,
+      "versionPatch": 0,
+    },
+    "postcommand": null,
+    "precommand": null,
+    "type": null,
+  },
+]
+`;
+
 exports[`merge config test merges version 1`] = `
 Array [
   Object {
@@ -229,3 +311,61 @@ Array [
 `;
 
 exports[`merge config test merges version without command 1`] = `Array []`;
+
+exports[`merge filtered config test merges publish 1`] = `
+Array [
+  Object {
+    "command": Array [
+      "npm publish",
+    ],
+    "dependencies": Array [
+      "all",
+    ],
+    "manager": "javascript",
+    "path": "./packages/assemble1",
+    "pkg": "assemble1",
+    "pkgFile": Object {
+      "name": "assemble1",
+      "pkg": Object {
+        "name": "assemble1",
+        "version": "0.0.0",
+      },
+      "version": "0.0.0",
+      "versionMajor": 0,
+      "versionMinor": 0,
+      "versionPatch": 0,
+    },
+    "postcommand": null,
+    "precommand": null,
+    "type": null,
+  },
+  Object {
+    "command": Array [
+      "cargo publish",
+    ],
+    "dependencies": Array [
+      "assemble1",
+      "all",
+    ],
+    "manager": "cargo",
+    "path": "./packages/namespaced-assemble2",
+    "pkg": "@namespaced/assemble1",
+    "pkgFile": Object {
+      "name": "@namespaced/assemble1",
+      "pkg": Object {
+        "name": "@namedspaced/assemble2",
+        "version": "0.0.0",
+      },
+      "version": "0.0.0",
+      "versionMajor": 0,
+      "versionMinor": 0,
+      "versionPatch": 0,
+    },
+    "postcommand": null,
+    "precommand": null,
+    "type": null,
+  },
+]
+`;
+
+exports[`merge filtered config test merges version 1`] = `Array []`;

--- a/packages/assemble/index.js
+++ b/packages/assemble/index.js
@@ -134,6 +134,7 @@ module.exports.mergeIntoConfig = function* ({
   command,
   cwd,
   dryRun = false,
+  filterPackages = [],
 }) {
   // build in assembledChanges to only issue commands with ones with changes
   // and pipe in data to template function
@@ -190,7 +191,10 @@ module.exports.mergeIntoConfig = function* ({
   const pipeOutput = {};
   let commands = [];
   for (let pkg of Object.keys(
-    command !== "version" ? pkgCommands : assembledChanges.releases
+    uesPackageSubset(
+      command !== "version" ? pkgCommands : assembledChanges.releases,
+      filterPackages
+    )
   )) {
     if (!pkgCommands[pkg]) continue;
 
@@ -311,6 +315,18 @@ const mergeCommand = ({ pkg, pkgManager, command, config }) => {
 
   return mergedCommand;
 };
+
+const uesPackageSubset = (commands, subset = []) =>
+  !!subset && subset.length === 0
+    ? commands
+    : subset.reduce((pkgCommands, pkg) => {
+        if (!commands[pkg]) {
+          return pkgCommands;
+        } else {
+          pkgCommands[pkg] = commands[pkg];
+          return pkgCommands;
+        }
+      }, {});
 
 const templateCommands = (command, pipe, complexCommands) => {
   if (!command) return null;

--- a/packages/assemble/package.json
+++ b/packages/assemble/package.json
@@ -13,5 +13,8 @@
     "remark-parse-yaml": "^0.0.3",
     "remark-stringify": "^8.0.0",
     "unified": "^9.0.0"
+  },
+  "devDependencies": {
+    "fixturez": "^1.1.0"
   }
 }

--- a/packages/covector/src/run.js
+++ b/packages/covector/src/run.js
@@ -17,6 +17,7 @@ module.exports.covector = function* covector({
   command,
   dryRun = false,
   cwd = process.cwd(),
+  filterPackages = [],
 }) {
   const config = yield configFile({ cwd });
   const changesPaths = yield changeFiles({
@@ -26,6 +27,7 @@ module.exports.covector = function* covector({
   const changesVfiles = changeFilesToVfile({
     cwd,
     paths: changesPaths,
+    filterPackages,
   });
   const assembledChanges = yield assemble({
     cwd,
@@ -64,6 +66,7 @@ module.exports.covector = function* covector({
       config,
       command,
       dryRun,
+      filterPackages,
     });
 
     if (dryRun) {
@@ -137,6 +140,7 @@ module.exports.covector = function* covector({
       command,
       cwd,
       dryRun,
+      filterPackages,
     });
 
     if (dryRun) {


### PR DESCRIPTION
Some workflows require different actions for different packages. Most of this can be codified into config. However there are cases where you may need to run a command for a dynamic set of packages.