### PR TITLE
feat: add action output to better show which packages published

### DIFF
--- a/.changes/extra-package-output.md
+++ b/.changes/extra-package-output.md
@@ -1,0 +1,5 @@
+---
+"action": patch
+---
+
+Add extra outputs for which packages published and a list of packages. This is useful for chaining runs of the action together.

--- a/packages/action/action.yml
+++ b/packages/action/action.yml
@@ -28,6 +28,8 @@ outputs:
     description: The command ran (particularly useful for 'version-or-publish' input option).
   successfulPublish:
     description: Boolean as a string if we published anything. Useful to skip follow-on steps with nothing published.
+  packagesPublished:
+    description: Comma separated list of all of the packages that published. Most useful for chaining runs together to act on the filtered list.
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/packages/action/index.js
+++ b/packages/action/index.js
@@ -54,6 +54,7 @@ main(function* run() {
       const { owner, repo } = github.context.repo;
 
       let releases = {};
+      let packagesPublished = "";
       for (let pkg of Object.keys(covectored)) {
         if (covectored[pkg].command !== false) {
           console.log(
@@ -68,6 +69,12 @@ main(function* run() {
             draft: core.getInput("draftRelease") === "true" ? true : false,
           });
           const { data } = createReleaseResponse;
+          core.setOutput(`${pkg}-published`, "true");
+          if (packagesPublished === "") {
+            packagesPublished = pkg;
+          } else {
+            packagesPublished = `${packagesPublished},${pkg}`;
+          }
           console.log("release created: ", data);
           releases[pkg] = data; // { id: releaseId, html_url: htmlUrl, upload_url: uploadUrl }
 
@@ -93,6 +100,8 @@ main(function* run() {
           }
         }
       }
+
+      core.setOutput("packagesPublished", packagesPublished);
     }
   } catch (error) {
     core.setFailed(error.message);


### PR DESCRIPTION
Add extra outputs for which packages published and a list of packages. This is useful for chaining runs of the action together.