### PR TITLE
feat: reorder GitHub release step

### DIFF
--- a/.changes/allow-running-functions.md
+++ b/.changes/allow-running-functions.md
@@ -1,0 +1,6 @@
+---
+"command": minor
+"assemble": patch
+---
+
+Allow running functions as a command instead of assuming everything runs in a shell. This is mostly for internal use to be used within the Github Action.

--- a/.changes/allow-running-functions.md
+++ b/.changes/allow-running-functions.md
@@ -1,6 +1,6 @@
 ---
-"command": minor
-"assemble": patch
+"@covector/command": minor
+"@covector/assemble": patch
 ---
 
 Allow running functions as a command instead of assuming everything runs in a shell. This is mostly for internal use to be used within the Github Action.

--- a/.changes/config.json
+++ b/.changes/config.json
@@ -6,7 +6,11 @@
       "getPublishedVersion": "npm view ${ pkg.pkg } version",
       "prepublish": [{ "command": "npm pack", "dryRunCommand": true }],
       "publish": [
-        "echo # Package Publish",
+        {
+          "command": "echo # Package Publish",
+          "dryRunCommand": "echo # Package Publish",
+          "pipe": true
+        },
         {
           "command": "npm publish --access public",
           "dryRunCommand": "echo publish here",

--- a/.changes/reorder-github-release-creation.md
+++ b/.changes/reorder-github-release-creation.md
@@ -1,0 +1,6 @@
+---
+"covector": minor
+"action": minor
+---
+
+Add `modifyConfig` property that takes a function which can modify the config file that is loaded. This will likely only be used in the Github Action to inject a JavaScript function into the publish sequences which creates a Github Release.

--- a/.changes/reorder-github-release-creation.md
+++ b/.changes/reorder-github-release-creation.md
@@ -1,7 +1,6 @@
 ---
 "covector": minor
 "action": minor
-"boop": patch
 ---
 
 Add `modifyConfig` property that takes a function which can modify the config file that is loaded. This will likely only be used in the Github Action to inject a JavaScript function into the publish sequences which creates a Github Release.

--- a/.changes/reorder-github-release-creation.md
+++ b/.changes/reorder-github-release-creation.md
@@ -1,6 +1,7 @@
 ---
 "covector": minor
 "action": minor
+"boop": patch
 ---
 
 Add `modifyConfig` property that takes a function which can modify the config file that is loaded. This will likely only be used in the Github Action to inject a JavaScript function into the publish sequences which creates a Github Release.

--- a/packages/action/action.yml
+++ b/packages/action/action.yml
@@ -1,14 +1,14 @@
-name: 'covector'
-description: 'Sane change management in polyglot, monorepos, single'
+name: "covector"
+description: "Sane change management in polyglot, monorepos, single"
 inputs:
   command:
-    description: 'covector cli command to run'
+    description: "covector cli command to run"
     required: false
-    default: 'status'
+    default: "status"
   token:
     description: Github Token or PAT for creating releases / posting messages
     required: false
-    default: ''
+    default: ""
   createRelease:
     description: Opt-in to create a release on publish
     required: false
@@ -20,7 +20,7 @@ inputs:
   filterPackages:
     description: A comma separated list (no spaces) of packages to run commands on rather than everything listed in the config.
     required: false
-    default: ''
+    default: ""
 outputs:
   change:
     description: The changes that were applied
@@ -31,8 +31,8 @@ outputs:
   packagesPublished:
     description: Comma separated list of all of the packages that published. Most useful for chaining runs together to act on the filtered list.
 runs:
-  using: 'node12'
-  main: 'dist/index.js'
+  using: "node12"
+  main: "dist/index.js"
 branding:
-  icon: 'sliders'  
-  color: 'green'
+  icon: "sliders"
+  color: "green"

--- a/packages/action/index.js
+++ b/packages/action/index.js
@@ -2,7 +2,12 @@ const core = require("@actions/core");
 const github = require("@actions/github");
 const { main } = require("@effection/node");
 const { covector } = require("../covector");
-const { commandText, packageListToArray } = require("./utils");
+const {
+  commandText,
+  packageListToArray,
+  injectPublishFunctions,
+  createReleases,
+} = require("./utils");
 const fs = require("fs");
 
 main(function* run() {
@@ -22,18 +27,14 @@ main(function* run() {
         command = "version";
       }
     }
-    const covectored = yield covector({ command, filterPackages });
 
     core.setOutput("commandRan", command);
     let successfulPublish = false;
-    if (command === "publish") {
-      for (let pkg of Object.keys(covectored)) {
-        if (covectored[pkg].command !== false) successfulPublish = true;
-      }
-    }
-    core.setOutput("successfulPublish", successfulPublish);
 
     if (command === "version") {
+      const covectored = yield covector({ command, filterPackages });
+      core.setOutput("successfulPublish", successfulPublish);
+
       const covectoredSmushed = Object.keys(covectored).reduce((text, pkg) => {
         if (typeof covectored[pkg].command === "string") {
           text = `${text}\n\n\n# ${pkg}\n\n${commandText(covectored[pkg])}`;
@@ -43,65 +44,43 @@ main(function* run() {
       core.setOutput("change", covectoredSmushed);
       const payload = JSON.stringify(covectoredSmushed, undefined, 2);
       console.log(`The covector output: ${payload}`);
-    } else if (
-      command === "publish" &&
-      core.getInput("createRelease") === "true"
-    ) {
+    } else if (command === "publish") {
+      if (core.getInput("createRelease") === "true") {
+        const octokit = github.getOctokit(token);
+        const { owner, repo } = github.context.repo;
+        let releases = {};
+
+        const covectored = yield covector({
+          command,
+          filterPackages,
+          modifyConfig: injectPublishFunctions([
+            createReleases.bind({ octokit, owner, repo }),
+          ]),
+        });
+
+        let packagesPublished = Object.keys(covectored).reduce((pub, pkg) => {
+          if (!covectored[pkg].published) {
+            return pub;
+          } else {
+            return `${pub}${pkg}`;
+          }
+        }, "");
+        core.setOutput("packagesPublished", packagesPublished);
+      } else {
+        const covectored = yield covector({
+          command,
+          filterPackages,
+        });
+      }
+
+      for (let pkg of Object.keys(covectored)) {
+        if (covectored[pkg].command !== false) successfulPublish = true;
+      }
+      core.setOutput("successfulPublish", successfulPublish);
+
       core.setOutput("change", covectored);
       const payload = JSON.stringify(covectored, undefined, 2);
       console.log(`The covector output: ${payload}`);
-      const octokit = github.getOctokit(token);
-      const { owner, repo } = github.context.repo;
-
-      let releases = {};
-      let packagesPublished = "";
-      for (let pkg of Object.keys(covectored)) {
-        if (covectored[pkg].command !== false) {
-          console.log(
-            `creating release for ${pkg}@${covectored[pkg].pkg.pkgFile.version}`
-          );
-          const createReleaseResponse = yield octokit.repos.createRelease({
-            owner,
-            repo,
-            tag_name: `${pkg}-v${covectored[pkg].pkg.pkgFile.version}`,
-            name: `${pkg} v${covectored[pkg].pkg.pkgFile.version}`,
-            body: commandText(covectored[pkg]),
-            draft: core.getInput("draftRelease") === "true" ? true : false,
-          });
-          const { data } = createReleaseResponse;
-          core.setOutput(`${pkg}-published`, "true");
-          if (packagesPublished === "") {
-            packagesPublished = pkg;
-          } else {
-            packagesPublished = `${packagesPublished},${pkg}`;
-          }
-          console.log("release created: ", data);
-          releases[pkg] = data; // { id: releaseId, html_url: htmlUrl, upload_url: uploadUrl }
-
-          const { id: releaseId } = data;
-
-          if (covectored[pkg].pkg.assets) {
-            try {
-              for (let asset of covectored[pkg].pkg.assets) {
-                console.log(
-                  `uploading asset ${asset.name} for ${pkg}@${covectored[pkg].pkg.pkgFile.version}`
-                );
-                const uploadedAsset = yield octokit.repos.uploadReleaseAsset({
-                  owner,
-                  repo,
-                  release_id: releaseId,
-                  name: asset.name,
-                  data: fs.readFileSync(asset.path),
-                });
-              }
-            } catch (error) {
-              console.error(error);
-            }
-          }
-        }
-      }
-
-      core.setOutput("packagesPublished", packagesPublished);
     }
   } catch (error) {
     core.setFailed(error.message);

--- a/packages/action/index.js
+++ b/packages/action/index.js
@@ -8,10 +8,9 @@ const {
   injectPublishFunctions,
   createReleases,
 } = require("./utils");
-const fs = require("fs");
 
-main(function* run() {
-  try {
+try {
+  main(function* run() {
     const token =
       core.getInput("token") === ""
         ? process.env.GITHUB_TOKEN
@@ -82,7 +81,7 @@ main(function* run() {
       const payload = JSON.stringify(covectored, undefined, 2);
       console.log(`The covector output: ${payload}`);
     }
-  } catch (error) {
-    core.setFailed(error.message);
-  }
-});
+  });
+} catch (error) {
+  core.setFailed(error.message);
+}

--- a/packages/action/index.js
+++ b/packages/action/index.js
@@ -9,8 +9,8 @@ const {
   createReleases,
 } = require("./utils");
 
-try {
-  main(function* run() {
+main(function* run() {
+  try {
     const token =
       core.getInput("token") === ""
         ? process.env.GITHUB_TOKEN
@@ -30,7 +30,9 @@ try {
     core.setOutput("commandRan", command);
     let successfulPublish = false;
 
-    if (command === "version") {
+    if (command === "status") {
+      const covectored = yield covector({ command, filterPackages });
+    } else if (command === "version") {
       const covectored = yield covector({ command, filterPackages });
       core.setOutput("successfulPublish", successfulPublish);
 
@@ -81,7 +83,7 @@ try {
       const payload = JSON.stringify(covectored, undefined, 2);
       console.log(`The covector output: ${payload}`);
     }
-  });
-} catch (error) {
-  core.setFailed(error.message);
-}
+  } catch (error) {
+    core.setFailed(error.message);
+  }
+});

--- a/packages/action/utils.js
+++ b/packages/action/utils.js
@@ -1,3 +1,5 @@
+const fs = require("fs");
+
 const commandText = (pkg) => {
   const { precommand, command, postcommand } = pkg;
   let text = "";

--- a/packages/action/utils.js
+++ b/packages/action/utils.js
@@ -25,4 +25,76 @@ const packageListToArray = (list) => {
   }
 };
 
-module.exports = { commandText, packageListToArray };
+const injectPublishFunctions = curry((functionsToInject, config) => {
+  return Object.keys(config.pkgManagers).reduce((finalConfig, pkgManager) => {
+    finalConfig.pkgManagers[pkgManager] = Object.keys(
+      config.pkgManagers[pkgManager]
+    ).reduce((pm, p) => {
+      if (p.startsWith("publish")) {
+        pm[p] = Array.isArray(pm[p])
+          ? pm[p].concat(functionsToInject)
+          : [pm[p]].concat(functionsToInject);
+      }
+      return pm;
+    }, config.pkgManagers[pkgManager]);
+
+    return finalConfig;
+  }, config);
+});
+
+function curry(func) {
+  return function f1(...args1) {
+    if (args1.length >= func.length) {
+      return new Promise((resolve) => resolve(func.apply(null, args1)));
+    } else {
+      return function f2(...args2) {
+        return f1.apply(null, args1.concat(args2));
+      };
+    }
+  };
+}
+
+const createReleases = async (pkg) => {
+  const { octokit, owner, repo } = this;
+  console.log(`creating release for ${pkg.pkg}@${pkg.pkgFile.version}`);
+  const createReleaseResponse = await octokit.repos.createRelease({
+    owner,
+    repo,
+    tag_name: `${pkg.pkg}-v${pkg.pkgFile.version}`,
+    name: `${pkg.pkg} v${pkg.pkgFile.version}`,
+    body: commandText(pkg),
+    draft: core.getInput("draftRelease") === "true" ? true : false,
+  });
+  const { data } = createReleaseResponse;
+
+  core.setOutput(`${pkg.pkg}-published`, "true");
+
+  console.log("release created: ", data);
+  const { id: releaseId } = data;
+
+  if (pkg.assets) {
+    try {
+      for (let asset of pkg.assets) {
+        console.log(
+          `uploading asset ${asset.name} for ${pkg.pkg}@${pkg.pkgFile.version}`
+        );
+        const uploadedAsset = await octokit.repos.uploadReleaseAsset({
+          owner,
+          repo,
+          release_id: releaseId,
+          name: asset.name,
+          data: fs.readFileSync(asset.path),
+        });
+      }
+    } catch (error) {
+      console.error(error);
+    }
+  }
+};
+
+module.exports = {
+  commandText,
+  packageListToArray,
+  injectPublishFunctions,
+  createReleases,
+};

--- a/packages/assemble/index.js
+++ b/packages/assemble/index.js
@@ -344,7 +344,7 @@ const templateCommands = (command, pipe, complexCommands) => {
         }, {}),
       };
     } else {
-      return template(c)(pipe);
+      return typeof c === "function" ? c : template(c)(pipe);
     }
   });
 };

--- a/packages/command/index.js
+++ b/packages/command/index.js
@@ -49,12 +49,10 @@ const attemptCommands = function* ({
       if (runningCommand.shouldRunCommand) {
         if (typeof runningCommand.command === "function") {
           try {
-            yield runningCommand.command();
+            yield runningCommand.command(pkg);
 
             if (pubCommand.pipe) {
-              console.warn(
-                `We cannot pipe the function command in ${pkg.name}`
-              );
+              console.warn(`We cannot pipe the function command in ${pkg.pkg}`);
             }
           } catch (e) {
             console.error(e);

--- a/packages/command/index.js
+++ b/packages/command/index.js
@@ -6,7 +6,7 @@ const path = require("path");
 const attemptCommands = function* ({
   cwd,
   commands,
-  command,
+  command, // is this used?
   commandPrefix = "",
   pkgCommandsRan,
   dryRun,
@@ -16,6 +16,7 @@ const attemptCommands = function* ({
     if (!pkg[`${commandPrefix}command`]) continue;
     const pubCommands =
       typeof pkg[`${commandPrefix}command`] === "string" ||
+      typeof pkg[`${commandPrefix}command`] === "function" ||
       !Array.isArray(pkg[`${commandPrefix}command`])
         ? [pkg[`${commandPrefix}command`]]
         : pkg[`${commandPrefix}command`];
@@ -46,18 +47,32 @@ const attemptCommands = function* ({
       }
 
       if (runningCommand.shouldRunCommand) {
-        const ranCommand = yield runCommand({
-          command: runningCommand.command,
-          cwd,
-          pkg: pkg.pkg,
-          pkgPath: runningCommand.runFromRoot === true ? "" : pkg.path,
-          log: `${pkg.pkg} [${commandPrefix}${command}${
-            runningCommand.runFromRoot === true ? " run from the cwd" : ""
-          }]: ${runningCommand.command}`,
-        });
+        if (typeof runningCommand.command === "function") {
+          try {
+            yield runningCommand.command();
 
-        if (pubCommand.pipe) {
-          stdout = `${stdout}${ranCommand}\n`;
+            if (pubCommand.pipe) {
+              console.warn(
+                `We cannot pipe the function command in ${pkg.name}`
+              );
+            }
+          } catch (e) {
+            console.error(e);
+          }
+        } else {
+          const ranCommand = yield runCommand({
+            command: runningCommand.command,
+            cwd,
+            pkg: pkg.pkg,
+            pkgPath: runningCommand.runFromRoot === true ? "" : pkg.path,
+            log: `${pkg.pkg} [${commandPrefix}${command}${
+              runningCommand.runFromRoot === true ? " run from the cwd" : ""
+            }]: ${runningCommand.command}`,
+          });
+
+          if (pubCommand.pipe) {
+            stdout = `${stdout}${ranCommand}\n`;
+          }
         }
       } else {
         console.log(

--- a/packages/command/index.test.js
+++ b/packages/command/index.test.js
@@ -1,0 +1,55 @@
+const { attemptCommands, runCommand } = require("./index");
+const toVFile = require("to-vfile");
+const mockConsole = require("jest-mock-console");
+const fixtures = require("fixturez");
+const f = fixtures(__dirname);
+
+describe("command", () => {
+  let restoreConsole;
+  beforeEach(() => {
+    restoreConsole = mockConsole(["log", "dir"]);
+  });
+  afterEach(() => {
+    restoreConsole();
+  });
+
+  describe("attemptCommand", () => {
+    it("invokes a function", function* () {
+      yield attemptCommands({
+        commands: [
+          {
+            name: "pkg-nickname",
+            version: "0.5.6",
+            command: async () => console.log("boop"),
+          },
+        ],
+      });
+
+      expect(console.log.mock.calls).toEqual([["boop"]]);
+    });
+
+    it("invokes an array of functions", function* () {
+      yield attemptCommands({
+        commands: [
+          {
+            name: "pkg-nickname",
+            version: "0.5.6",
+            command: [
+              async () => console.log("boop"),
+              async () => console.log("booop"),
+              async () => console.log("boooop"),
+              async () => console.log("booooop"),
+            ],
+          },
+        ],
+      });
+
+      expect(console.log.mock.calls).toEqual([
+        ["boop"],
+        ["booop"],
+        ["boooop"],
+        ["booooop"],
+      ]);
+    });
+  });
+});

--- a/packages/command/index.test.js
+++ b/packages/command/index.test.js
@@ -51,5 +51,44 @@ describe("command", () => {
         ["booooop"],
       ]);
     });
+
+    it("invokes a function using package values", function* () {
+      yield attemptCommands({
+        commands: [
+          {
+            name: "pkg-nickname",
+            version: "0.5.6",
+            command: async (pkg) =>
+              console.log(`boop ${pkg.name}@${pkg.version}`),
+          },
+        ],
+      });
+
+      expect(console.log.mock.calls).toEqual([["boop pkg-nickname@0.5.6"]]);
+    });
+
+    it("invokes an array of functions using package values", function* () {
+      yield attemptCommands({
+        commands: [
+          {
+            name: "pkg-nickname",
+            version: "0.5.6",
+            command: [
+              async (pkg) => console.log(`boop ${pkg.name}@${pkg.version}`),
+              async (pkg) => console.log(`booop ${pkg.name}@${pkg.version}`),
+              async (pkg) => console.log(`boooop ${pkg.name}@${pkg.version}`),
+              async (pkg) => console.log(`booooop ${pkg.name}@${pkg.version}`),
+            ],
+          },
+        ],
+      });
+
+      expect(console.log.mock.calls).toEqual([
+        ["boop pkg-nickname@0.5.6"],
+        ["booop pkg-nickname@0.5.6"],
+        ["boooop pkg-nickname@0.5.6"],
+        ["booooop pkg-nickname@0.5.6"],
+      ]);
+    });
   });
 });

--- a/packages/covector/__snapshots__/index.test.js.snap
+++ b/packages/covector/__snapshots__/index.test.js.snap
@@ -6693,6 +6693,158 @@ Object {
 }
 `;
 
+exports[`integration test in production mode allows modifying the config 1`] = `
+Array [
+  Array [
+    "Checking if tauri-bundler@0.6.0 is already published with: echo 0.5.2",
+  ],
+  Array [
+    "0.5.2",
+  ],
+  Array [
+    "Checking if tauri@0.5.2 is already published with: echo 0.5.2",
+  ],
+  Array [
+    "0.5.2",
+  ],
+  Array [
+    "tauri@0.5.2 is already published. Skipping.",
+  ],
+  Array [
+    "Checking if tauri-api@0.5.1 is already published with: echo 0.5.2",
+  ],
+  Array [
+    "0.5.2",
+  ],
+  Array [
+    "Checking if tauri-utils@0.5.0 is already published with: echo 0.5.2",
+  ],
+  Array [
+    "0.5.2",
+  ],
+  Array [
+    "begin with only boops",
+  ],
+  Array [
+    "begin with only boops",
+  ],
+  Array [
+    "begin with only boops",
+  ],
+  Array [
+    "tauri.js [publish]: echo publishing tauri.js would happen here",
+  ],
+  Array [
+    "publishing tauri.js would happen here",
+  ],
+  Array [
+    "deboop",
+  ],
+  Array [
+    "tauri-bundler [publish]: echo publishing tauri-bundler would happen here",
+  ],
+  Array [
+    "publishing tauri-bundler would happen here",
+  ],
+  Array [
+    "tauri-bundler [publish]: echo running in ./cli/tauri-bundler",
+  ],
+  Array [
+    "running in ./cli/tauri-bundler",
+  ],
+  Array [
+    "tauri-bundler [publish run from the cwd]: ls",
+  ],
+  Array [
+    "cli
+tauri
+tauri-api
+tauri-updater
+tauri-utils",
+  ],
+  Array [
+    "tauri-bundler [publish]: ls",
+  ],
+  Array [
+    "Cargo.toml",
+  ],
+  Array [
+    "deboop",
+  ],
+  Array [
+    "tauri-api [publish]: echo publishing tauri-api would happen here",
+  ],
+  Array [
+    "publishing tauri-api would happen here",
+  ],
+  Array [
+    "tauri-api [publish]: echo running in ./tauri-api",
+  ],
+  Array [
+    "running in ./tauri-api",
+  ],
+  Array [
+    "tauri-api [publish run from the cwd]: ls",
+  ],
+  Array [
+    "cli
+tauri
+tauri-api
+tauri-updater
+tauri-utils",
+  ],
+  Array [
+    "tauri-api [publish]: ls",
+  ],
+  Array [
+    "Cargo.toml",
+  ],
+  Array [
+    "deboop",
+  ],
+  Array [
+    "tauri-utils [publish]: echo publishing tauri-utils would happen here",
+  ],
+  Array [
+    "publishing tauri-utils would happen here",
+  ],
+  Array [
+    "tauri-utils [publish]: echo running in ./tauri-utils",
+  ],
+  Array [
+    "running in ./tauri-utils",
+  ],
+  Array [
+    "tauri-utils [publish run from the cwd]: ls",
+  ],
+  Array [
+    "cli
+tauri
+tauri-api
+tauri-updater
+tauri-utils",
+  ],
+  Array [
+    "tauri-utils [publish]: ls",
+  ],
+  Array [
+    "Cargo.toml",
+  ],
+  Array [
+    "deboop",
+  ],
+  Array [
+    "ends with overwrites using boops",
+  ],
+  Array [
+    "ends with overwrites using boops",
+  ],
+  Array [
+    "ends with overwrites using boops",
+  ],
+]
+`;
+
 exports[`integration test in production mode fails status for non-existant package 1`] = `
 Object {
   "consoleDir": Array [],
@@ -8413,6 +8565,188 @@ Object {
     },
   },
 }
+`;
+
+exports[`integration test in production mode uses the action config modification 1`] = `
+Array [
+  Array [
+    "Checking if tauri-bundler@0.6.0 is already published with: echo 0.5.2",
+  ],
+  Array [
+    "0.5.2",
+  ],
+  Array [
+    "Checking if tauri@0.5.2 is already published with: echo 0.5.2",
+  ],
+  Array [
+    "0.5.2",
+  ],
+  Array [
+    "tauri@0.5.2 is already published. Skipping.",
+  ],
+  Array [
+    "Checking if tauri-api@0.5.1 is already published with: echo 0.5.2",
+  ],
+  Array [
+    "0.5.2",
+  ],
+  Array [
+    "Checking if tauri-utils@0.5.0 is already published with: echo 0.5.2",
+  ],
+  Array [
+    "0.5.2",
+  ],
+  Array [
+    "tauri-bundler [prepublish]: echo premode for tauri-bundler",
+  ],
+  Array [
+    "premode for tauri-bundler",
+  ],
+  Array [
+    "tauri-api [prepublish]: echo premode for tauri-api",
+  ],
+  Array [
+    "premode for tauri-api",
+  ],
+  Array [
+    "tauri-utils [prepublish]: echo premode for tauri-utils",
+  ],
+  Array [
+    "premode for tauri-utils",
+  ],
+  Array [
+    "tauri.js [publish]: echo publishing tauri.js would happen here",
+  ],
+  Array [
+    "publishing tauri.js would happen here",
+  ],
+  Array [
+    "push log into publish for tauri.js-v0.6.2",
+  ],
+  Array [
+    "push another log",
+  ],
+  Array [
+    "tauri-bundler [publish]: echo publishing tauri-bundler would happen here",
+  ],
+  Array [
+    "publishing tauri-bundler would happen here",
+  ],
+  Array [
+    "tauri-bundler [publish]: echo running in ./cli/tauri-bundler",
+  ],
+  Array [
+    "running in ./cli/tauri-bundler",
+  ],
+  Array [
+    "tauri-bundler [publish run from the cwd]: ls",
+  ],
+  Array [
+    "cli
+tauri
+tauri-api
+tauri-updater
+tauri-utils",
+  ],
+  Array [
+    "tauri-bundler [publish]: ls",
+  ],
+  Array [
+    "Cargo.toml",
+  ],
+  Array [
+    "push log into publish for tauri-bundler-v0.6.0",
+  ],
+  Array [
+    "push another log",
+  ],
+  Array [
+    "tauri-api [publish]: echo publishing tauri-api would happen here",
+  ],
+  Array [
+    "publishing tauri-api would happen here",
+  ],
+  Array [
+    "tauri-api [publish]: echo running in ./tauri-api",
+  ],
+  Array [
+    "running in ./tauri-api",
+  ],
+  Array [
+    "tauri-api [publish run from the cwd]: ls",
+  ],
+  Array [
+    "cli
+tauri
+tauri-api
+tauri-updater
+tauri-utils",
+  ],
+  Array [
+    "tauri-api [publish]: ls",
+  ],
+  Array [
+    "Cargo.toml",
+  ],
+  Array [
+    "push log into publish for tauri-api-v0.5.1",
+  ],
+  Array [
+    "push another log",
+  ],
+  Array [
+    "tauri-utils [publish]: echo publishing tauri-utils would happen here",
+  ],
+  Array [
+    "publishing tauri-utils would happen here",
+  ],
+  Array [
+    "tauri-utils [publish]: echo running in ./tauri-utils",
+  ],
+  Array [
+    "running in ./tauri-utils",
+  ],
+  Array [
+    "tauri-utils [publish run from the cwd]: ls",
+  ],
+  Array [
+    "cli
+tauri
+tauri-api
+tauri-updater
+tauri-utils",
+  ],
+  Array [
+    "tauri-utils [publish]: ls",
+  ],
+  Array [
+    "Cargo.toml",
+  ],
+  Array [
+    "push log into publish for tauri-utils-v0.5.0",
+  ],
+  Array [
+    "push another log",
+  ],
+  Array [
+    "tauri-bundler [postpublish]: echo postmode for tauri-bundler",
+  ],
+  Array [
+    "postmode for tauri-bundler",
+  ],
+  Array [
+    "tauri-api [postpublish]: echo postmode for tauri-api",
+  ],
+  Array [
+    "postmode for tauri-api",
+  ],
+  Array [
+    "tauri-utils [postpublish]: echo postmode for tauri-utils",
+  ],
+  Array [
+    "postmode for tauri-utils",
+  ],
+]
 `;
 
 exports[`integration test to invoke sub commands runs publish-primary in prod mode 1`] = `

--- a/packages/covector/index.test.js
+++ b/packages/covector/index.test.js
@@ -6,9 +6,18 @@ const mockConsole = require("jest-mock-console");
 const fixtures = require("fixturez");
 const f = fixtures(__dirname);
 
+const { injectPublishFunctions } = require("./../action/utils");
+
 describe("integration test in production mode", () => {
+  let restoreConsole;
+  beforeEach(() => {
+    restoreConsole = mockConsole(["log", "dir", "info", "error"]);
+  });
+  afterEach(() => {
+    restoreConsole();
+  });
+
   it("passes correct config for js and rust", async () => {
-    const restoreConsole = mockConsole(["log", "dir"]);
     const fullIntegration = f.copy("integration.js-and-rust-with-changes");
     const covectored = await main(
       covector({
@@ -21,11 +30,9 @@ describe("integration test in production mode", () => {
       consoleDir: console.dir.mock.calls,
       covectorReturn: covectored,
     }).toMatchSnapshot();
-    restoreConsole();
   });
 
   it("fails status for non-existant package", async () => {
-    const restoreConsole = mockConsole(["log", "dir"]);
     const fullIntegration = f.copy("integration.js-with-change-file-error");
     const covectored = main(
       covector({
@@ -40,11 +47,9 @@ describe("integration test in production mode", () => {
       consoleDir: console.dir.mock.calls,
       covectorReturn: covectored,
     }).toMatchSnapshot();
-    restoreConsole();
   }, 60000); // increase timeout to 60s, windows seems to take forever on a fail
 
   it("runs version for js and rust", async () => {
-    const restoreConsole = mockConsole(["log", "info"]);
     const fullIntegration = f.copy("integration.js-and-rust-with-changes");
     const covectored = await main(
       covector({
@@ -82,12 +87,9 @@ describe("integration test in production mode", () => {
         "## [0.7.0]\n\n" +
         "-   Summary about the changes in tauri\n"
     );
-
-    restoreConsole();
   });
 
   it("runs publish for js and rust", async () => {
-    const restoreConsole = mockConsole(["log", "info"]);
     const fullIntegration = f.copy("integration.js-and-rust-with-changes");
     const covectored = await main(
       covector({
@@ -100,11 +102,9 @@ describe("integration test in production mode", () => {
       consoleInfo: console.info.mock.calls,
       covectorReturn: scrubVfile(covectored),
     }).toMatchSnapshot();
-    restoreConsole();
   });
 
   it("fails with error", async () => {
-    const restoreConsole = mockConsole(["log", "info", "error"]);
     const fullIntegration = f.copy("integration.js-with-publish-error");
     const covectored = main(
       covector({
@@ -118,11 +118,9 @@ describe("integration test in production mode", () => {
       consoleInfo: console.info.mock.calls,
       // covectorReturn: covectored, // skip this as npm publish has fs dep output which creates false positives
     }).toMatchSnapshot();
-    restoreConsole();
   }, 60000); // increase timeout to 60s, windows seems to take forever on a fail
 
   it("runs test for js and rust", async () => {
-    const restoreConsole = mockConsole(["log", "info"]);
     const fullIntegration = f.copy("integration.js-and-rust-with-changes");
     const covectored = await main(
       covector({
@@ -135,11 +133,9 @@ describe("integration test in production mode", () => {
       consoleInfo: console.info.mock.calls,
       covectorReturn: covectored,
     }).toMatchSnapshot();
-    restoreConsole();
   });
 
   it("runs build for js and rust", async () => {
-    const restoreConsole = mockConsole(["log", "info"]);
     const fullIntegration = f.copy("integration.js-and-rust-with-changes");
     const covectored = await main(
       covector({
@@ -152,7 +148,67 @@ describe("integration test in production mode", () => {
       consoleInfo: console.info.mock.calls,
       covectorReturn: scrubVfile(covectored),
     }).toMatchSnapshot();
-    restoreConsole();
+  });
+
+  it("allows modifying the config", async () => {
+    const fullIntegration = f.copy("integration.js-and-rust-with-changes");
+    const modifyConfig = async (pullConfig) => {
+      const config = await pullConfig;
+      return Object.keys(config.pkgManagers).reduce(
+        (finalConfig, pkgManager) => {
+          finalConfig.pkgManagers[pkgManager] = Object.keys(
+            config.pkgManagers[pkgManager]
+          ).reduce((pm, p) => {
+            if (p.startsWith("publish")) {
+              const functionInject = async () => console.log("deboop");
+              pm[p] = Array.isArray(pm[p])
+                ? pm[p].concat(functionInject)
+                : [pm[p], functionInject];
+            } else if (p.startsWith("pre")) {
+              const functionInject = async () =>
+                console.log("begin with only boops");
+              pm[p] = [functionInject];
+            } else if (p.startsWith("post")) {
+              const functionInject = async () =>
+                console.log("ends with overwrites using boops");
+              pm[p] = functionInject;
+            }
+            return pm;
+          }, config.pkgManagers[pkgManager]);
+
+          return finalConfig;
+        },
+        config
+      );
+    };
+
+    const covectored = await main(
+      covector({
+        command: "publish",
+        cwd: fullIntegration,
+        modifyConfig,
+      })
+    );
+    expect(console.log.mock.calls).toMatchSnapshot();
+  });
+
+  it("uses the action config modification", async () => {
+    const fullIntegration = f.copy("integration.js-and-rust-with-changes");
+
+    const covectored = await main(
+      covector({
+        command: "publish",
+        cwd: fullIntegration,
+        modifyConfig: injectPublishFunctions([
+          async (pkg) =>
+            console.log(
+              `push log into publish for ${pkg.pkg}-v${pkg.pkgFile.version}`
+            ),
+          async () => console.log(`push another log`),
+        ]),
+      })
+    );
+    expect(console.log.mock.calls).toMatchSnapshot();
   });
 });
 

--- a/packages/covector/src/run.js
+++ b/packages/covector/src/run.js
@@ -18,8 +18,9 @@ module.exports.covector = function* covector({
   dryRun = false,
   cwd = process.cwd(),
   filterPackages = [],
+  modifyConfig = async (c) => c,
 }) {
-  const config = yield configFile({ cwd });
+  const config = yield modifyConfig(yield configFile({ cwd }));
   const changesPaths = yield changeFiles({
     cwd,
     changeFolder: config.changeFolder,


### PR DESCRIPTION
## Motivation

When multiple packages are published, it is possible that one or more succeeds followed by a failure to publish. When a failure occurred in this instance, the packages that were published would not have a Github Release created as they were created after all `prepublish`/`publish`/`postpublish` steps were run. This PR adjusts the functionality to create the release after the `publish` step completes for each package.

## Approach

We added an API to allow modifying the config by passing a function. This let's us inject functions that can be run.

### Possible Drawbacks or Risks

It will be difficult for the user to pass a function without any errors (and it might likely require tests). I don't presume that this will be used outside of the action though.
