### PR TITLE
feat: extra bump types

### DIFF
--- a/.changes/allow-special-bump-types.md
+++ b/.changes/allow-special-bump-types.md
@@ -1,0 +1,5 @@
+---
+"@covector/assemble": patch
+---
+
+Throw a hard error on an invalid bump types. If you specify something other than `major`, `minor`, or `patch`. You will receive an error in the `status` and `version` commands. Also adds a new config option, `additionalBumpTypes`, which allows specifying other bump types (that are ignored in versioning) but do not throw an error. This allows one to always require a change file even if the code does not require a version bump. This is generally easier to enforce then conditionally requiring a change file.

--- a/.changes/config.json
+++ b/.changes/config.json
@@ -1,5 +1,6 @@
 {
   "gitSiteUrl": "https://www.github.com/jbolda/covector/",
+  "additionalBumpTypes": ["housekeeping"],
   "pkgManagers": {
     "javascript": {
       "version": true,

--- a/packages/assemble/__snapshots__/index.test.js.snap
+++ b/packages/assemble/__snapshots__/index.test.js.snap
@@ -369,3 +369,132 @@ Array [
 `;
 
 exports[`merge filtered config test merges version 1`] = `Array []`;
+
+exports[`special bump types valid additional bump types 1`] = `
+Object {
+  "changes": Array [
+    Object {
+      "releases": Object {
+        "assemble1": "patch",
+        "assemble2": "patch",
+      },
+      "summary": "This is a test.",
+    },
+    Object {
+      "releases": Object {
+        "assemble1": "minor",
+        "assemble2": "patch",
+      },
+      "summary": "This is a test.",
+    },
+    Object {
+      "releases": Object {
+        "assemble1": "patch",
+        "assemble2": "major",
+      },
+      "summary": "This is a test.",
+    },
+    Object {
+      "releases": Object {
+        "@namespaced/assemble2": "patch",
+        "assemble1": "patch",
+      },
+      "summary": "This is a test. We might link out to a [website](https://www.jacobbolda.com).",
+    },
+    Object {
+      "releases": Object {
+        "assemble1": "housekeeping",
+        "assemble2": "workflows",
+      },
+      "summary": "This is a test.",
+    },
+  ],
+  "releases": Object {
+    "@namespaced/assemble2": Object {
+      "changes": Array [
+        Object {
+          "releases": Object {
+            "@namespaced/assemble2": "patch",
+            "assemble1": "patch",
+          },
+          "summary": "This is a test. We might link out to a [website](https://www.jacobbolda.com).",
+        },
+      ],
+      "type": "patch",
+    },
+    "assemble1": Object {
+      "changes": Array [
+        Object {
+          "releases": Object {
+            "assemble1": "patch",
+            "assemble2": "patch",
+          },
+          "summary": "This is a test.",
+        },
+        Object {
+          "releases": Object {
+            "assemble1": "minor",
+            "assemble2": "patch",
+          },
+          "summary": "This is a test.",
+        },
+        Object {
+          "releases": Object {
+            "assemble1": "patch",
+            "assemble2": "major",
+          },
+          "summary": "This is a test.",
+        },
+        Object {
+          "releases": Object {
+            "@namespaced/assemble2": "patch",
+            "assemble1": "patch",
+          },
+          "summary": "This is a test. We might link out to a [website](https://www.jacobbolda.com).",
+        },
+        Object {
+          "releases": Object {
+            "assemble1": "housekeeping",
+            "assemble2": "workflows",
+          },
+          "summary": "This is a test.",
+        },
+      ],
+      "type": "housekeeping",
+    },
+    "assemble2": Object {
+      "changes": Array [
+        Object {
+          "releases": Object {
+            "assemble1": "patch",
+            "assemble2": "patch",
+          },
+          "summary": "This is a test.",
+        },
+        Object {
+          "releases": Object {
+            "assemble1": "minor",
+            "assemble2": "patch",
+          },
+          "summary": "This is a test.",
+        },
+        Object {
+          "releases": Object {
+            "assemble1": "patch",
+            "assemble2": "major",
+          },
+          "summary": "This is a test.",
+        },
+        Object {
+          "releases": Object {
+            "assemble1": "housekeeping",
+            "assemble2": "workflows",
+          },
+          "summary": "This is a test.",
+        },
+      ],
+      "type": "workflows",
+    },
+  },
+}
+`;


### PR DESCRIPTION
Adds a hard error for an bump type that is not valid, and adds a config option to add more options.

One might add more options that encompass actions in the repo (such as `housekeeping`) that require a PR, but don't necessarily change the code and require incrementing the version number. This would enable _always_ requiring a change file on a PR which improves the ability to enforce it.


closes #131, closes #132