### PR TITLE
fix: piped commands

### DIFF
--- a/.changes/bump-effection-v1.md
+++ b/.changes/bump-effection-v1.md
@@ -1,0 +1,7 @@
+---
+"covector": patch
+"@covector/command": patch
+"action": patch
+---
+
+Bump effection to stable v1.

--- a/.changes/temp-execa-shell.md
+++ b/.changes/temp-execa-shell.md
@@ -1,0 +1,5 @@
+---
+"@covector/command": patch
+---
+
+Temporarily use execa to shell for any commands with a pipe, `|`.

--- a/packages/action/package.json
+++ b/packages/action/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@actions/core": "^1.2.6",
     "@actions/github": "^4.0.0",
-    "@effection/node": "0.9.1"
+    "@effection/node": "1.0.1"
   },
   "devDependencies": {
     "@vercel/ncc": "^0.27.0",

--- a/packages/command/index.test.ts
+++ b/packages/command/index.test.ts
@@ -1,9 +1,7 @@
-import { attemptCommands } from "./index";
+import { attemptCommands, sh } from "./index";
 import mockConsole, { RestoreConsole } from "jest-mock-console";
 import fixtures from "fixturez";
 const f = fixtures(__dirname);
-
-import { PipeTemplate } from "../assemble/index";
 
 describe("command", () => {
   let restoreConsole: RestoreConsole;
@@ -103,5 +101,23 @@ describe("command", () => {
         ["booooop pkg-nickname@0.5.6"],
       ]);
     });
+  });
+
+  describe("sh", () => {
+    it("considers piped commands", function* (): Generator<any> {
+      const out = yield sh(
+        "echo this thing | echo but actually this",
+        {},
+        false
+      );
+      expect(out).toBe("but actually this");
+    });
+
+    // it("issues simple commands", function* (): Generator<any> {
+    // this errors out for some reason? error below
+    // TypeError: Cannot read property 'link' of undefined
+    // const out = yield sh("ls", {}, false);
+    // expect(out).toBe("this thing");
+    // });
   });
 });

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -17,6 +17,7 @@
     "prepublishOnly": "rollup --config"
   },
   "dependencies": {
+    "effection": "^1.0.0",
     "execa": "^5.0.0",
     "strip-ansi": "^6.0.0"
   },

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -17,7 +17,7 @@
     "prepublishOnly": "rollup --config"
   },
   "dependencies": {
-    "effection": "^0.7.0",
+    "execa": "^5.0.0",
     "strip-ansi": "^6.0.0"
   },
   "devDependencies": {

--- a/packages/covector/package.json
+++ b/packages/covector/package.json
@@ -26,7 +26,7 @@
     "@covector/changelog": "0.2.2",
     "@covector/command": "0.2.0",
     "@covector/files": "0.2.1",
-    "@effection/node": "0.9.1",
+    "@effection/node": "1.0.1",
     "globby": "^11.0.1",
     "inquirer": "^7.3.3",
     "yargs": "^15.3.1"


### PR DESCRIPTION
Piped commands need to shell out. We receive a string, so we can just search for the pipe operator. Temp use `execa` to handle this.