### PR TITLE
chore: bump devDeps and fix tsconfig/rollup issues

### DIFF
--- a/.changes/add-missing-hoisted-deps.md
+++ b/.changes/add-missing-hoisted-deps.md
@@ -1,0 +1,7 @@
+---
+"@covector/apply": patch
+"@covector/command": patch
+"covector": patch
+---
+
+Add missing dependencies that likely worked due to hoisting.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
+  preset: "ts-jest",
+  testEnvironment: "node",
+  modulePathIgnorePatterns: ["__fixtures__"],
 };

--- a/package.json
+++ b/package.json
@@ -16,13 +16,13 @@
     "packages/**/*"
   ],
   "devDependencies": {
-    "@types/jest": "^26.0.3",
-    "jest": "^26.1.0",
+    "@types/jest": "^26.0.21",
+    "jest": "^26.6.3",
     "jest-mock-console": "^1.0.1",
-    "patch-package": "^6.2.2",
+    "patch-package": "^6.4.7",
     "postinstall-postinstall": "^2.1.0",
-    "prettier": "^2.0.5",
-    "ts-jest": "^26.1.1"
+    "prettier": "^2.2.1",
+    "ts-jest": "^26.5.4"
   },
   "volta": {
     "node": "14.16.0",

--- a/packages/apply/package.json
+++ b/packages/apply/package.json
@@ -17,13 +17,14 @@
     "prepublishOnly": "rollup --config"
   },
   "dependencies": {
-    "@covector/files": "0.3.0",
     "@covector/assemble": "0.5.0",
+    "@covector/files": "0.3.0",
+    "lodash": "^4.17.21",
     "semver": "^7.3.2"
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^8.2.0",
-    "rollup": "^2.41.4",
+    "rollup": "^2.42.4",
     "tslib": "^2.1.0",
     "typescript": "^4.2.3"
   },

--- a/packages/apply/rollup.config.js
+++ b/packages/apply/rollup.config.js
@@ -11,10 +11,11 @@ export default {
     entryFileNames: "[name].js",
     exports: "named",
   },
-  plugins: [typescript({ module: "CommonJS", exclude: ["**.test.ts"] })],
+  plugins: [typescript()],
   external: [
     ...Object.keys(pkg.dependencies || {}),
     ...Object.keys(pkg.peerDependencies || {}),
+    "path",
   ],
   watch: {
     chokidar: true,

--- a/packages/apply/tsconfig.json
+++ b/packages/apply/tsconfig.json
@@ -1,1 +1,8 @@
-{ "extends": "../../tsconfig.json" }
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": ["index.ts"]
+}

--- a/packages/assemble/package.json
+++ b/packages/assemble/package.json
@@ -31,7 +31,7 @@
     "@types/js-yaml": "^4.0.0",
     "@types/lodash": "^4.14.168",
     "fixturez": "^1.1.0",
-    "rollup": "^2.41.4",
+    "rollup": "^2.42.4",
     "tslib": "^2.1.0",
     "typescript": "^4.2.3"
   },

--- a/packages/assemble/rollup.config.js
+++ b/packages/assemble/rollup.config.js
@@ -11,10 +11,11 @@ export default {
     entryFileNames: "[name].js",
     exports: "named",
   },
-  plugins: [typescript({ module: "CommonJS", exclude: ["**.test.ts"] })],
+  plugins: [typescript()],
   external: [
     ...Object.keys(pkg.dependencies || {}),
     ...Object.keys(pkg.peerDependencies || {}),
+    "path",
   ],
   watch: {
     chokidar: true,

--- a/packages/assemble/tsconfig.json
+++ b/packages/assemble/tsconfig.json
@@ -1,1 +1,8 @@
-{ "extends": "../../tsconfig.json" }
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": ["index.ts"]
+}

--- a/packages/changelog/package.json
+++ b/packages/changelog/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^8.2.0",
-    "rollup": "^2.41.4",
+    "rollup": "^2.42.4",
     "tslib": "^2.1.0",
     "typescript": "^4.2.3"
   },

--- a/packages/changelog/rollup.config.js
+++ b/packages/changelog/rollup.config.js
@@ -11,10 +11,11 @@ export default {
     entryFileNames: "[name].js",
     exports: "named",
   },
-  plugins: [typescript({ module: "CommonJS", exclude: ["**.test.ts"] })],
+  plugins: [typescript()],
   external: [
     ...Object.keys(pkg.dependencies || {}),
     ...Object.keys(pkg.peerDependencies || {}),
+    "path",
   ],
   watch: {
     chokidar: true,

--- a/packages/changelog/tsconfig.json
+++ b/packages/changelog/tsconfig.json
@@ -1,1 +1,8 @@
-{ "extends": "../../tsconfig.json" }
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": ["index.ts"]
+}

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -17,6 +17,7 @@
     "prepublishOnly": "rollup --config"
   },
   "dependencies": {
+    "@effection/node": "^1.0.1",
     "effection": "^1.0.0",
     "execa": "^5.0.0",
     "strip-ansi": "^6.0.0"
@@ -24,7 +25,7 @@
   "devDependencies": {
     "@covector/assemble": "0.5.0",
     "@rollup/plugin-typescript": "^8.2.0",
-    "rollup": "^2.41.4",
+    "rollup": "^2.42.4",
     "tslib": "^2.1.0",
     "typescript": "^4.2.3"
   },

--- a/packages/command/rollup.config.js
+++ b/packages/command/rollup.config.js
@@ -11,10 +11,11 @@ export default {
     entryFileNames: "[name].js",
     exports: "named",
   },
-  plugins: [typescript({ module: "CommonJS", exclude: ["**.test.ts"] })],
+  plugins: [typescript()],
   external: [
     ...Object.keys(pkg.dependencies || {}),
     ...Object.keys(pkg.peerDependencies || {}),
+    "path",
   ],
   watch: {
     chokidar: true,

--- a/packages/command/tsconfig.json
+++ b/packages/command/tsconfig.json
@@ -1,1 +1,8 @@
-{ "extends": "../../tsconfig.json" }
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": ["index.ts"]
+}

--- a/packages/covector/package.json
+++ b/packages/covector/package.json
@@ -26,15 +26,16 @@
     "@covector/changelog": "0.3.0",
     "@covector/command": "0.3.0",
     "@covector/files": "0.3.0",
-    "@effection/node": "1.0.1",
+    "@effection/node": "^1.0.1",
     "globby": "^11.0.1",
     "inquirer": "^7.3.3",
     "yargs": "^15.3.1"
   },
   "devDependencies": {
+    "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-typescript": "^8.2.0",
     "@types/inquirer": "^7.3.1",
-    "rollup": "^2.41.4",
+    "rollup": "^2.42.4",
     "tslib": "^2.1.0",
     "typescript": "^4.2.3"
   },

--- a/packages/covector/rollup.config.js
+++ b/packages/covector/rollup.config.js
@@ -1,4 +1,5 @@
 import typescript from "@rollup/plugin-typescript";
+import json from "@rollup/plugin-json";
 import pkg from "./package.json";
 
 export default {
@@ -16,10 +17,12 @@ export default {
     entryFileNames: "[name].js",
     exports: "named",
   },
-  plugins: [typescript({ module: "CommonJS", exclude: ["**.test.ts"] })],
+  plugins: [json(), typescript()],
   external: [
     ...Object.keys(pkg.dependencies || {}),
     ...Object.keys(pkg.peerDependencies || {}),
+    "fs",
+    "path",
   ],
   watch: {
     chokidar: true,

--- a/packages/covector/tsconfig.json
+++ b/packages/covector/tsconfig.json
@@ -1,1 +1,8 @@
-{ "extends": "../../tsconfig.json" }
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": ["./src/**/*.ts"]
+}

--- a/packages/files/package.json
+++ b/packages/files/package.json
@@ -25,10 +25,10 @@
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^8.2.0",
-    "@types/jest": "^26.0.3",
+    "@types/jest": "^26.0.21",
     "@types/semver": "^7.3.4",
     "fixturez": "^1.1.0",
-    "rollup": "^2.41.4",
+    "rollup": "^2.42.4",
     "tslib": "^2.1.0",
     "typescript": "^4.2.3"
   },

--- a/packages/files/rollup.config.js
+++ b/packages/files/rollup.config.js
@@ -11,10 +11,12 @@ export default {
     entryFileNames: "[name].js",
     exports: "named",
   },
-  plugins: [typescript({ module: "CommonJS", exclude: ["**.test.ts"] })],
+  plugins: [typescript()],
   external: [
     ...Object.keys(pkg.dependencies || {}),
     ...Object.keys(pkg.peerDependencies || {}),
+    "fs",
+    "path",
   ],
   watch: {
     chokidar: true,

--- a/packages/files/tsconfig.json
+++ b/packages/files/tsconfig.json
@@ -1,1 +1,8 @@
-{ "extends": "../../tsconfig.json" }
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": ["index.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,12 @@
     "moduleResolution": "node",
     "importHelpers": true
   },
-  "include": ["."],
-  "exclude": ["__fixtures__", "**/*.config.js", "**/dist/**", "**/bin/**"]
+  "baseUrl": ".",
+  "exclude": [
+    "__fixtures__",
+    "**/*.config.js",
+    "**/dist/**",
+    "**/bin/**",
+    "**/*.test.ts"
+  ]
 }


### PR DESCRIPTION
Fixing latent rollup and tsconfig issues as discovered with @dagda1. Bump the remaining devDeps. Fix a few missing deps that were only working due to hoisting.