### PR TITLE
fix: improve init output for easier onboarding

### DIFF
--- a/.changes/init-simplify-and-nicknames.md
+++ b/.changes/init-simplify-and-nicknames.md
@@ -1,0 +1,5 @@
+---
+"covector": patch
+---
+
+Update `init` to only use simple string based commands. These are easier to grok for users first starting with covector and looking to understand what the `init` has created. Also prefer the `pkgFile` based names in the publish step to make it easier for someone to switch to using nicknames for packages easier (and less foot-guns).

--- a/packages/covector/src/init.ts
+++ b/packages/covector/src/init.ts
@@ -106,25 +106,15 @@ export const init = function* init({
 
   const javascript = {
     version: true,
-    getPublishedVersion: "npm view ${ pkg.pkg } version",
-    publish: [
-      {
-        command: "npm publish --access public",
-        dryRunCommand: "echo publish here",
-      },
-    ],
+    getPublishedVersion: "npm view ${ pkgFile.pkg.name } version",
+    publish: ["npm publish --access public"],
   };
 
   const rust = {
     version: true,
     getPublishedVersion:
       'cargo search ${ pkg.pkg } --limit 1 | sed -nE \'s/^[^"]*"//; s/".*//1p\' -',
-    publish: [
-      {
-        command: "cargo publish --no-verify",
-        dryRunCommand: "cargo publish --no-verify --dry-run --allow-dirty",
-      },
-    ],
+    publish: ["cargo publish"],
   };
 
   const githubAction = {


### PR DESCRIPTION
# Motivation

This PR adjust the `init` command to remove the complex commands as I realized chatting with @minkimcello in #167. It also adjusts the publish check to use the package.json name which makes it easier to switch to using nicknames (which I suspect will be one of the first customizations someone might consider). This came up in https://github.com/thefrontside/simulacrum/pull/30.