### PR TITLE
fix package.json fields and base tsconfig.json

### DIFF
--- a/packages/apply/package.json
+++ b/packages/apply/package.json
@@ -8,10 +8,8 @@
     "type": "git",
     "url": "https://github.com/jbolda/covector.git"
   },
-  "main": "dist",
-  "files": [
-    "dist/**/*"
-  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc -b",
     "clean": "rimraf dist node_modules",

--- a/packages/apply/tsconfig.json
+++ b/packages/apply/tsconfig.json
@@ -3,6 +3,5 @@
   "compilerOptions": {
     "outDir": "dist"
   },
-  "include": ["index.ts"],
-  "references": []
+  "include": ["index.ts"]
 }

--- a/packages/assemble/package.json
+++ b/packages/assemble/package.json
@@ -8,10 +8,8 @@
     "type": "git",
     "url": "https://github.com/jbolda/covector.git"
   },
-  "main": "dist",
-  "files": [
-    "dist/**/*"
-  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc -b",
     "clean": "rimraf dist node_modules",

--- a/packages/assemble/tsconfig.json
+++ b/packages/assemble/tsconfig.json
@@ -3,6 +3,5 @@
   "compilerOptions": {
     "outDir": "dist"
   },
-  "include": ["index.ts"],
-  "references": []
+  "include": ["index.ts"]
 }

--- a/packages/changelog/package.json
+++ b/packages/changelog/package.json
@@ -8,10 +8,8 @@
     "type": "git",
     "url": "https://github.com/jbolda/covector.git"
   },
-  "main": "dist",
-  "files": [
-    "dist/**/*"
-  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/changelog/tsconfig.json
+++ b/packages/changelog/tsconfig.json
@@ -3,6 +3,5 @@
   "compilerOptions": {
     "outDir": "dist"
   },
-  "include": ["index.ts"],
-  "references": []
+  "include": ["index.ts"]
 }

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -8,10 +8,8 @@
     "type": "git",
     "url": "https://github.com/jbolda/covector.git"
   },
-  "main": "dist",
-  "files": [
-    "dist/**/*"
-  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc -b",
     "clean": "rimraf dist node_modules",

--- a/packages/command/tsconfig.json
+++ b/packages/command/tsconfig.json
@@ -3,6 +3,5 @@
   "compilerOptions": {
     "outDir": "dist"
   },
-  "include": ["index.ts"],
-  "references": []
+  "include": ["index.ts"]
 }

--- a/packages/covector/package.json
+++ b/packages/covector/package.json
@@ -8,11 +8,8 @@
     "type": "git",
     "url": "https://github.com/jbolda/covector.git"
   },
-  "main": "dist",
-  "files": [
-    "bin/*",
-    "dist/**/*"
-  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "bin": {
     "covector": "./bin/covector.js"
   },

--- a/packages/covector/package.json
+++ b/packages/covector/package.json
@@ -13,6 +13,9 @@
   "bin": {
     "covector": "./bin/covector.js"
   },
+  "files": [
+    "bin/*"
+  ],
   "scripts": {
     "build": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/covector/tsconfig.json
+++ b/packages/covector/tsconfig.json
@@ -4,6 +4,5 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["./src/**/*.ts"],
-  "references": []
+  "include": ["./src/**/*.ts"]
 }

--- a/packages/files/package.json
+++ b/packages/files/package.json
@@ -8,10 +8,8 @@
     "type": "git",
     "url": "https://github.com/jbolda/covector.git"
   },
-  "main": "dist",
-  "files": [
-    "dist/**/*"
-  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc -b",
     "clean": "rimraf dist node_modules",

--- a/packages/files/tsconfig.json
+++ b/packages/files/tsconfig.json
@@ -3,6 +3,5 @@
   "compilerOptions": {
     "outDir": "dist"
   },
-  "include": ["index.ts"],
-  "references": []
+  "include": ["index.ts"]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,19 +4,14 @@
     "strict": true,
     "module": "commonjs",
     "target": "es6",
-    "allowJs": true,
     "pretty": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "moduleResolution": "node",
-    "declarationMap": true,
-    "importHelpers": true
-  },
-  "exclude": [
-    "__fixtures__",
-    "**/*.config.js",
-    "**/dist/**",
-    "**/bin/**",
-    "**/*.test.ts"
-  ]
+    "checkJs": false,
+    "preserveSymlinks": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true
+  }
 }


### PR DESCRIPTION
## Motivation

There were a few things that needed to change to stop `tsc` getting confused

## Approach

Change

```json
  "main": "dist/index.js",
  "files": [
    "dist/**/*"
  ],
```

to

```json
  "main": "dist/index.js",
  "types": "dist/index.d.ts",
```

The `tsconfig.base.json` was updated to set things like `"declaration": true`

### Alternate Designs

I would put all application code in `./src` in each package.
