### PR TITLE
fix: update preview workflow

### DIFF
--- a/.github/workflows/run-preview.yml
+++ b/.github/workflows/run-preview.yml
@@ -9,10 +9,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - run: yarn
-      - run: yarn build
+      - uses: volta-cli/action@v1
+      - run: npm ci --ignore-scripts
+      - run: npm run build
       - name: covector preview
-        uses: jbolda/covector/packages/action@mk/previews
+        uses: ./packages/action
         id: covector
         with:
           command: preview

--- a/.github/workflows/run-preview.yml
+++ b/.github/workflows/run-preview.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: volta-cli/action@v1
       - run: npm ci --ignore-scripts
       - run: npm run build
+      - run: npm run pkg -w action
       - name: covector preview
         uses: ./packages/action
         id: covector


### PR DESCRIPTION
## Motivation

The covector action is being called from a branch that no longer exists and therefore the preview workflow is failing. These changes have already been addressed in #187 but it's broken for all the other PRs.

## Approach

- Replaced yarn scripts with npm
- Added volta action
- Call action locally and not remotely