### PR TITLE
bug: Fix bumping error

### DIFF
--- a/.changes/config.json
+++ b/.changes/config.json
@@ -44,7 +44,7 @@
         }
       ]
     },
-    "apply": {
+    "@covector/apply": {
       "path": "./packages/apply",
       "manager": "javascript",
       "dependencies": ["@covector/files", "@covector/assemble", "all"],
@@ -55,7 +55,7 @@
         }
       ]
     },
-    "assemble": {
+    "@covector/assemble": {
       "path": "./packages/assemble",
       "manager": "javascript",
       "dependencies": ["@covector/command", "@covector/files", "all"],
@@ -66,7 +66,7 @@
         }
       ]
     },
-    "changelog": {
+    "@covector/changelog": {
       "path": "./packages/changelog",
       "manager": "javascript",
       "dependencies": ["@covector/files", "all"],
@@ -77,7 +77,7 @@
         }
       ]
     },
-    "files": {
+    "@covector/files": {
       "path": "./packages/files",
       "manager": "javascript",
       "dependencies": ["all"],
@@ -88,7 +88,7 @@
         }
       ]
     },
-    "command": {
+    "@covector/command": {
       "path": "./packages/command",
       "manager": "javascript",
       "dependencies": ["@covector/files", "@covector/assemble", "all"],

--- a/.changes/npm-and-ts-project-ref.md
+++ b/.changes/npm-and-ts-project-ref.md
@@ -1,11 +1,11 @@
 ---
 "action": patch
-"apply": patch
-"assemble": patch
-"changelog": patch
-"command": patch
+"@covector/apply": patch
+"@covector/assemble": patch
+"@covector/changelog": patch
+"@covector/command": patch
 "covector": patch
-"files": patch
+"@covector/files": patch
 ---
 
 This switches to using Typescript project references to build (previously rollup). It should affect the underlying packages or use.

--- a/.changes/preview-action-bump.md
+++ b/.changes/preview-action-bump.md
@@ -1,7 +1,7 @@
 ---
 "action": minor
 "covector": minor
-"apply": minor
+"@covector/apply": minor
 ---
 
 Add preview command for versioning and publishing preview packages

--- a/__fixtures__/integration.js-and-rust-with-changes/tauri/Cargo.toml
+++ b/__fixtures__/integration.js-and-rust-with-changes/tauri/Cargo.toml
@@ -1,0 +1,67 @@
+[package]
+name = "tauri"
+version = "0.5.2"
+authors = "test"
+license = "MIT"
+homepage = "https://tauri.studio"
+repository = "https://github.com/tauri-apps/tauri"
+description = "Make tiny, secure apps for all desktop platforms with Tauri"
+edition = "2018"
+exclude = ["test/fixture/**"]
+
+[dependencies]
+serde_json = "1.0"
+serde = { version = "1.0", features = ["derive"] }
+webview-sys = "=0.5.0"
+web-view = "=0.6.2"
+tauri_includedir = "0.5.0"
+phf = "0.8.0"
+base64 = "0.12.1"
+webbrowser = "0.5.2"
+lazy_static = "1.4.0"
+tiny_http = { version = "0.7", optional = true }
+threadpool = "1.8"
+uuid = { version = "0.8.1", features = ["v4"] }
+anyhow = "1.0.31"
+thiserror = "1.0.19"
+envmnt = "0.8.2"
+
+tauri-api = { version = "0.5",  path = "../tauri-api" }
+
+[build-dependencies]
+tauri_includedir_codegen = "0.5.2"
+
+[dev-dependencies]
+proptest = "0.9.6"
+serde_json = "1.0"
+tauri = {path = ".", features = [ "all-api", "edge" ]}
+serde = { version = "1.0", features = [ "derive" ] }
+
+[features]
+edge = ["web-view/edge"]
+embedded-server = ["tiny_http"]
+no-server = []
+all-api = []
+read-text-file = []
+read-binary-file = []
+write-file = []
+read-dir = []
+copy-file = []
+create-dir = []
+remove-dir = []
+remove-file = []
+rename-file = []
+set-title = []
+execute = []
+open = []
+event = []
+updater = []
+open-dialog = []
+save-dialog = []
+
+[package.metadata.docs.rs]
+features = ["all-api"]
+
+[[example]]
+name = "communication"
+path = "examples/communication/src-tauri/src/main.rs"

--- a/packages/apply/index.ts
+++ b/packages/apply/index.ts
@@ -381,7 +381,7 @@ const bumpDeps = ({
         if (pkg.vfile!.extname === ".json") {
           // for javascript
           // @ts-ignore TODO deal with ReleaseType
-          let version =  previewVersion ? semver.valid(`${pkg.pkg.version}-${previewVersion}`) : semver.inc(pkg.pkg.devDependencies[dep], bumpType);
+          let version =  preview ? semver.valid(`${pkg.pkg.version}`) : semver.inc(pkg.pkg.devDependencies[dep], bumpType);
           if (version) pkg.pkg.devDependencies[dep] = version;
         }
       }


### PR DESCRIPTION
## Motivation

I noticed a bug in covector on how it's supposed to bump inter-dependent packages. It wasn't showing up in tests but in the covector setup _within_ the covector monorepo workspace so this PR is meant to locate why that was happening.

## Approach

- Before I get into how I fixed the bug, I found another bug from one of my refactors in #187. I had forgotten to rename one of the argument variables and that's been addressed.
- I also accidentally deleted a fixture file so that was reintroduced in this PR
- The bug bug came from the covector config file. The packages listed in the config file must match the package names listed in the packages' package.json files. Fixing this allowed covector to properly bump all the packages and dependencies. See data below in comments.