### PR TITLE
feat: Add dist-tag for preview publishing... and fix the published boolean bug

### DIFF
--- a/.changes/pipe-tag-template.md
+++ b/.changes/pipe-tag-template.md
@@ -1,0 +1,10 @@
+---
+"action": minor
+"@covector/assemble": minor
+"@covector/command": minor
+"covector": minor
+---
+
+Pass head branch name into covector for running preview in action
+Tag gets piped into template in assemble
+Fix published boolean bug in command

--- a/__fixtures__/integration.js-and-rust-for-preview/.changes/config.json
+++ b/__fixtures__/integration.js-and-rust-for-preview/.changes/config.json
@@ -2,11 +2,15 @@
   "pkgManagers": {
     "javascript": {
       "version": true,
-      "publish": "echo publishing ${ pkg.pkg } would happen here"
+      "publish": "echo publishing ${ pkg.pkg } would happen here",
+      "prepublish": "echo prepublishing ${ pkg.pkg } would happen here",
+      "postpublish": "echo postpublishing ${ pkg.pkg } would happen here"
     },
     "rust": {
       "version": true,
-      "publish": "echo publishing ${ pkg.pkg } would happen here"
+      "publish": "echo publishing ${ pkg.pkg } would happen here",
+      "prepublish": "echo prepublishing ${ pkg.pkg } would happen here",
+      "postpublish": "echo postpublishing ${ pkg.pkg } would happen here"
     }
   },
   "packages": {

--- a/__fixtures__/integration.js-and-rust-for-preview/.changes/config.json
+++ b/__fixtures__/integration.js-and-rust-for-preview/.changes/config.json
@@ -2,13 +2,13 @@
   "pkgManagers": {
     "javascript": {
       "version": true,
-      "publish": "echo publishing ${ pkg.pkg } would happen here",
+      "publish": "echo publishing ${ pkg.tag ? '--tag pkg.tag' : '' } would happen here",
       "prepublish": "echo prepublishing ${ pkg.pkg } would happen here",
       "postpublish": "echo postpublishing ${ pkg.pkg } would happen here"
     },
     "rust": {
       "version": true,
-      "publish": "echo publishing ${ pkg.pkg } would happen here",
+      "publish": "echo publishing ${ pkg.tag ? '--tag pkg.tag' : '' } would happen here",
       "prepublish": "echo prepublishing ${ pkg.pkg } would happen here",
       "postpublish": "echo postpublishing ${ pkg.pkg } would happen here"
     }

--- a/__fixtures__/integration.js-and-rust-for-preview/.changes/config.json
+++ b/__fixtures__/integration.js-and-rust-for-preview/.changes/config.json
@@ -2,13 +2,13 @@
   "pkgManagers": {
     "javascript": {
       "version": true,
-      "publish": "echo publishing ${ pkg.tag ? '--tag pkg.tag' : '' } would happen here",
+      "publish": "echo publishing${ !pkg.tag ? ' --tag ' + pkg.tag : null } would happen here",
       "prepublish": "echo prepublishing ${ pkg.pkg } would happen here",
       "postpublish": "echo postpublishing ${ pkg.pkg } would happen here"
     },
     "rust": {
       "version": true,
-      "publish": "echo publishing ${ pkg.tag ? '--tag pkg.tag' : '' } would happen here",
+      "publish": "echo publishing${ pkg.tag ? ' --tag ' + pkg.tag : null } would happen here",
       "prepublish": "echo prepublishing ${ pkg.pkg } would happen here",
       "postpublish": "echo postpublishing ${ pkg.pkg } would happen here"
     }

--- a/packages/action/__snapshots__/index.test.ts.snap
+++ b/packages/action/__snapshots__/index.test.ts.snap
@@ -93,7 +93,8 @@ publish
         null
       ],
       \\"postcommand\\": null
-    }
+    },
+    \\"published\\": true
   },
   \\"package-two\\": {
     \\"precommand\\": false,
@@ -128,7 +129,8 @@ publish
         null
       ],
       \\"postcommand\\": null
-    }
+    },
+    \\"published\\": true
   }
 }",
     ],
@@ -175,6 +177,7 @@ publish
       },
       "postcommand": false,
       "precommand": false,
+      "published": true,
     },
     "package-two": Object {
       "command": "## \\\\[1.9.0]
@@ -217,6 +220,7 @@ publish
       },
       "postcommand": false,
       "precommand": false,
+      "published": true,
     },
   },
 }

--- a/packages/action/src/index.ts
+++ b/packages/action/src/index.ts
@@ -128,14 +128,15 @@ export function* run(): Generator<any, any, any> {
         const branchName = github?.context?.payload?.pull_request?.head?.ref;
         let identifier;
         let versionTemplate;
+        const branchTag = branchName.replace(/(?!.\_)\_/g, '__').replace(/\//g, '_');
         
         switch(versionIdentifier){
           case "branch":
             identifier = branchName.replace(/\_/g, '-').replace(/\//g, '-');
             break;
           default:
-            throw new Error(`Version identifier you specified, "${versionIdentifier}", is invalid.`)
-        }
+            throw new Error(`Version identifier you specified, "${versionIdentifier}", is invalid.`);
+        };
 
         switch(previewVersion){
           case "date":
@@ -145,14 +146,15 @@ export function* run(): Generator<any, any, any> {
             versionTemplate = `${identifier}.${github.context.payload.after.substring(0, 7)}`;
             break;
           default:
-            throw new Error(`Preview version template you specified, "${previewVersion}", is invalid. Please use 'date' or 'sha'.`)
+            throw new Error(`Preview version template you specified, "${previewVersion}", is invalid. Please use 'date' or 'sha'.`);
         };
 
         covectored = yield covector({
           command,
           filterPackages,
           cwd,
-          previewVersion: versionTemplate
+          previewVersion: versionTemplate,
+          branchTag
         });
 
         if (covectored) {

--- a/packages/action/src/index.ts
+++ b/packages/action/src/index.ts
@@ -129,6 +129,10 @@ export function* run(): Generator<any, any, any> {
         let identifier;
         let versionTemplate;
         const branchTag = branchName.replace(/(?!.\_)\_/g, '__').replace(/\//g, '_');
+
+        if (branchName === "latest") {
+          throw new Error(`Using the branch name, 'latest', will conflict with restricted tags when publishing packages. Please create another pull request with a different branch name.`);
+        }
         
         switch(versionIdentifier){
           case "branch":

--- a/packages/apply/index.test.ts
+++ b/packages/apply/index.test.ts
@@ -134,9 +134,9 @@ describe("package file apply bump (snapshot)", () => {
       "utf-8"
     );
     expect(modifiedVFile.contents).toBe(
-      "name: test_app\ndescription: a great one\nhomepage: https://github.com/\nversion: 0.4.0\n" +
+      "name: test_app\ndescription: a great one\nhomepage: 'https://github.com/'\nversion: 0.4.0\n" +
         "environment:\n  sdk: '>=2.10.0 <3.0.0'\n" +
-        "dependencies:\n  flutter:\n    sdk: flutter\n  meta: any\n  provider: ^4.3.2\n  related_package:\n    git:\n      url: git@github.com:jbolda/covector.git\n      ref: main\n      path: __fixtures__/haha/\n" +
+        "dependencies:\n  flutter:\n    sdk: flutter\n  meta: any\n  provider: ^4.3.2\n  related_package:\n    git:\n      url: 'git@github.com:jbolda/covector.git'\n      ref: main\n      path: __fixtures__/haha/\n" +
         "dev_dependencies:\n  flutter_test:\n    sdk: flutter\n  build_runner: any\n  json_serializable: any\n  mobx_codegen: any\n" +
         "flutter:\n  assets:\n    - assets/schema/\n    - assets/localization/\n"
     );

--- a/packages/apply/index.test.ts
+++ b/packages/apply/index.test.ts
@@ -134,9 +134,9 @@ describe("package file apply bump (snapshot)", () => {
       "utf-8"
     );
     expect(modifiedVFile.contents).toBe(
-      "name: test_app\ndescription: a great one\nhomepage: 'https://github.com/'\nversion: 0.4.0\n" +
+      "name: test_app\ndescription: a great one\nhomepage: https://github.com/\nversion: 0.4.0\n" +
         "environment:\n  sdk: '>=2.10.0 <3.0.0'\n" +
-        "dependencies:\n  flutter:\n    sdk: flutter\n  meta: any\n  provider: ^4.3.2\n  related_package:\n    git:\n      url: 'git@github.com:jbolda/covector.git'\n      ref: main\n      path: __fixtures__/haha/\n" +
+        "dependencies:\n  flutter:\n    sdk: flutter\n  meta: any\n  provider: ^4.3.2\n  related_package:\n    git:\n      url: git@github.com:jbolda/covector.git\n      ref: main\n      path: __fixtures__/haha/\n" +
         "dev_dependencies:\n  flutter_test:\n    sdk: flutter\n  build_runner: any\n  json_serializable: any\n  mobx_codegen: any\n" +
         "flutter:\n  assets:\n    - assets/schema/\n    - assets/localization/\n"
     );

--- a/packages/assemble/index.ts
+++ b/packages/assemble/index.ts
@@ -340,6 +340,7 @@ export type PkgPublish = {
   getPublishedVersion?: string;
   assets?: { name: string; path: string }[];
   pkgFile?: PackageFile;
+  tag?: string;
 };
 
 type PipePublishTemplate = {
@@ -355,6 +356,7 @@ export const mergeIntoConfig = function* ({
   dryRun = false,
   filterPackages = [],
   changelogs,
+  tag = '',
 }: {
   config: ConfigFile;
   assembledChanges: { releases: {} };
@@ -363,9 +365,11 @@ export const mergeIntoConfig = function* ({
   dryRun: boolean;
   filterPackages: string[];
   changelogs?: { [k: string]: { name: string; changelog: string } };
+  tag?: string;
 }): Generator<any, PkgPublish[], any> {
   // build in assembledChanges to only issue commands with ones with changes
   // and pipe in data to template function
+
   const pkgCommands = Object.keys(config.packages).reduce(
     (pkged: { [k: string]: PkgPublish }, pkg) => {
       const pkgManager = config.packages[pkg].manager;
@@ -438,7 +442,7 @@ export const mergeIntoConfig = function* ({
     if (!pkgCommands[pkg]) continue;
 
     const pipeToTemplate: PipePublishTemplate = {
-      pkg: pkgCommands[pkg],
+      pkg: {...pkgCommands[pkg], tag},
     };
 
     let extraPublishParams = {

--- a/packages/command/index.ts
+++ b/packages/command/index.ts
@@ -132,6 +132,9 @@ export const attemptCommands = function* ({
     if (!!pkgCommandsRan)
       _pkgCommandsRan[pkg.pkg][`${commandPrefix}command`] =
         stdout !== "" ? stdout : true;
+
+    if (!!pkgCommandsRan && command === 'publish' && !commandPrefix)
+      _pkgCommandsRan[pkg.pkg]['published'] = true
   }
   return _pkgCommandsRan;
 };

--- a/packages/covector/__snapshots__/index.test.ts.snap
+++ b/packages/covector/__snapshots__/index.test.ts.snap
@@ -1669,6 +1669,131 @@ Object {
 }
 `;
 
+exports[`integration test for preview command with dist tags runs version and publish for js and rust 1`] = `
+Object {
+  "consoleInfo": Array [],
+  "consoleLog": Array [
+    Array [
+      "bumping package-b to 0.0.1-branch-name.12345 to publish a preview",
+    ],
+    Array [
+      "bumping package-a to 0.0.1-branch-name.12345 to publish a preview",
+    ],
+    Array [
+      "bumping package-c to 0.0.1-branch-name.12345 to publish a preview",
+    ],
+    Array [
+      "package-a [publish]: echo publishing package-a would happen here --tag branch_name",
+    ],
+    Array [
+      "publishing package-a would happen here --tag branch_name",
+    ],
+    Array [
+      "package-b [publish]: echo publishing package-b would happen here --tag branch_name",
+    ],
+    Array [
+      "publishing package-b would happen here --tag branch_name",
+    ],
+    Array [
+      "package-c [publish]: echo publishing package-c would happen here --tag branch_name",
+    ],
+    Array [
+      "publishing package-c would happen here --tag branch_name",
+    ],
+  ],
+  "covectorReturn": Object {
+    "package-a": Object {
+      "command": true,
+      "pkg": Object {
+        "command": "echo publishing package-a would happen here --tag branch_name",
+        "dependencies": Array [
+          "package-b",
+        ],
+        "manager": "javascript",
+        "path": "./package-a",
+        "pkg": "package-a",
+        "pkgFile": Object {
+          "name": "package-a",
+          "pkg": Object {
+            "dependencies": Object {
+              "package-b": "0.0.1-branch-name.12345",
+            },
+            "name": "package-a",
+            "version": "0.0.1-branch-name.12345",
+          },
+          "version": "0.0.1-branch-name.12345",
+          "versionMajor": 0,
+          "versionMinor": 0,
+          "versionPatch": 1,
+        },
+        "postcommand": null,
+        "precommand": null,
+      },
+      "postcommand": false,
+      "precommand": false,
+    },
+    "package-b": Object {
+      "command": true,
+      "pkg": Object {
+        "command": "echo publishing package-b would happen here --tag branch_name",
+        "dependencies": undefined,
+        "manager": "javascript",
+        "path": "./package-b",
+        "pkg": "package-b",
+        "pkgFile": Object {
+          "name": "package-b",
+          "pkg": Object {
+            "dependencies": Object {},
+            "name": "package-b",
+            "version": "0.0.1-branch-name.12345",
+          },
+          "version": "0.0.1-branch-name.12345",
+          "versionMajor": 0,
+          "versionMinor": 0,
+          "versionPatch": 1,
+        },
+        "postcommand": null,
+        "precommand": null,
+      },
+      "postcommand": false,
+      "precommand": false,
+    },
+    "package-c": Object {
+      "command": true,
+      "pkg": Object {
+        "command": "echo publishing package-c would happen here --tag branch_name",
+        "dependencies": Array [
+          "package-b",
+        ],
+        "manager": "rust",
+        "path": "./package-c",
+        "pkg": "package-c",
+        "pkgFile": Object {
+          "name": "package-c",
+          "pkg": Object {
+            "dependencies": Object {
+              "package-b": "0.0.1-branch-name.12345",
+            },
+            "package": Object {
+              "name": "package-c",
+              "version": "0.0.1-branch-name.12345",
+            },
+          },
+          "version": "0.0.1-branch-name.12345",
+          "versionMajor": 0,
+          "versionMinor": 0,
+          "versionPatch": 1,
+        },
+        "postcommand": null,
+        "precommand": null,
+      },
+      "postcommand": false,
+      "precommand": false,
+    },
+  },
+}
+`;
+
 exports[`integration test in --dry-run mode passes correct config for js and rust 1`] = `
 Object {
   "consoleDir": Array [

--- a/packages/covector/__snapshots__/index.test.ts.snap
+++ b/packages/covector/__snapshots__/index.test.ts.snap
@@ -144,6 +144,7 @@ Object {
           "pkg": "package-one",
           "postcommand": null,
           "precommand": null,
+          "tag": "",
         },
         "pkgFile": Object {
           "name": "package-one",
@@ -182,6 +183,7 @@ Object {
           "pkg": "package-two",
           "postcommand": null,
           "precommand": null,
+          "tag": "",
         },
         "pkgFile": Object {
           "name": "package-two",
@@ -581,6 +583,7 @@ Object {
           "pkg": "package-one",
           "postcommand": null,
           "precommand": null,
+          "tag": "",
         },
         "pkgFile": Object {
           "name": "package-one",
@@ -619,6 +622,7 @@ Object {
           "pkg": "package-two",
           "postcommand": null,
           "precommand": null,
+          "tag": "",
         },
         "pkgFile": Object {
           "name": "package-two",
@@ -1092,6 +1096,7 @@ Object {
           "pkg": "package-one",
           "postcommand": null,
           "precommand": null,
+          "tag": "",
         },
         "pkgFile": Object {
           "name": "package-one",
@@ -1140,6 +1145,7 @@ Object {
           "pkg": "package-two",
           "postcommand": null,
           "precommand": null,
+          "tag": "",
         },
         "pkgFile": Object {
           "name": "package-two",
@@ -1576,29 +1582,31 @@ Object {
       "prepublishing package-c would happen here",
     ],
     Array [
-      "package-a [publish]: echo publishing package-a would happen here --tag ",
+      "package-a [publish]: echo publishing  would happen here",
     ],
     Array [
-      "publishing package-a would happen here --tag",
+      "publishing would happen here",
     ],
     Array [
-      "package-b [publish]: echo publishing package-b would happen here --tag ",
+      "package-b [publish]: echo publishing  would happen here",
     ],
     Array [
-      "publishing package-b would happen here --tag",
+      "publishing would happen here",
     ],
     Array [
-      "package-c [publish]: echo publishing package-c would happen here --tag ",
+      "package-c [publish]: echo publishing  would happen here",
     ],
     Array [
-      "publishing package-c would happen here --tag",
+      "publishing would happen here",
     ],
   ],
   "covectorReturn": Object {
     "package-a": Object {
       "command": true,
       "pkg": Object {
-        "command": "echo publishing package-a would happen here --tag ",
+        "command": Array [
+          "echo publishing  would happen here",
+        ],
         "dependencies": Array [
           "package-b",
         ],
@@ -1633,7 +1641,9 @@ Object {
     "package-b": Object {
       "command": true,
       "pkg": Object {
-        "command": "echo publishing package-b would happen here --tag ",
+        "command": Array [
+          "echo publishing  would happen here",
+        ],
         "dependencies": undefined,
         "manager": "javascript",
         "path": "./package-b",
@@ -1664,7 +1674,9 @@ Object {
     "package-c": Object {
       "command": true,
       "pkg": Object {
-        "command": "echo publishing package-c would happen here --tag ",
+        "command": Array [
+          "echo publishing  would happen here",
+        ],
         "dependencies": Array [
           "package-b",
         ],
@@ -1937,6 +1949,7 @@ Object {
           "pkg": "tauri-bundler",
           "postcommand": null,
           "precommand": null,
+          "tag": "",
         },
         "pkgFile": Object {
           "name": "tauri-bundler",
@@ -2067,6 +2080,7 @@ Object {
           "pkg": "tauri",
           "postcommand": null,
           "precommand": null,
+          "tag": "",
         },
         "pkgFile": Object {
           "name": "tauri",
@@ -2211,6 +2225,7 @@ Object {
           "pkg": "tauri-api",
           "postcommand": null,
           "precommand": null,
+          "tag": "",
         },
         "pkgFile": Object {
           "name": "tauri-api",
@@ -2295,6 +2310,7 @@ Object {
           "pkg": "tauri-utils",
           "postcommand": null,
           "precommand": null,
+          "tag": "",
         },
         "pkgFile": Object {
           "name": "tauri-utils",
@@ -2338,6 +2354,7 @@ Object {
           "pkg": "tauri-updater",
           "postcommand": null,
           "precommand": null,
+          "tag": "",
         },
         "pkgFile": Object {
           "name": "tauri-updater",
@@ -3810,6 +3827,7 @@ Object {
           "pkg": "tauri.js",
           "postcommand": null,
           "precommand": null,
+          "tag": "",
         },
         "pkgFile": Object {
           "name": "tauri.js",
@@ -3950,6 +3968,7 @@ Object {
           "pkg": "tauri-bundler",
           "postcommand": "echo postmode for \${ pkg.pkg }",
           "precommand": "echo premode for \${ pkg.pkg }",
+          "tag": "",
         },
         "pkgFile": Object {
           "name": "tauri-bundler",
@@ -4086,6 +4105,7 @@ Object {
           "pkg": "tauri",
           "postcommand": "echo postmode for \${ pkg.pkg }",
           "precommand": "echo premode for \${ pkg.pkg }",
+          "tag": "",
         },
         "pkgFile": Object {
           "name": "tauri",
@@ -4236,6 +4256,7 @@ Object {
           "pkg": "tauri-api",
           "postcommand": "echo postmode for \${ pkg.pkg }",
           "precommand": "echo premode for \${ pkg.pkg }",
+          "tag": "",
         },
         "pkgFile": Object {
           "name": "tauri-api",
@@ -4326,6 +4347,7 @@ Object {
           "pkg": "tauri-utils",
           "postcommand": "echo postmode for \${ pkg.pkg }",
           "precommand": "echo premode for \${ pkg.pkg }",
+          "tag": "",
         },
         "pkgFile": Object {
           "name": "tauri-utils",
@@ -7842,6 +7864,7 @@ Object {
       },
       "postcommand": false,
       "precommand": false,
+      "published": true,
     },
   },
 }
@@ -7885,6 +7908,7 @@ Object {
       },
       "postcommand": false,
       "precommand": false,
+      "published": true,
     },
   },
 }

--- a/packages/covector/__snapshots__/index.test.ts.snap
+++ b/packages/covector/__snapshots__/index.test.ts.snap
@@ -1734,29 +1734,31 @@ Object {
       "prepublishing package-c would happen here",
     ],
     Array [
-      "package-a [publish]: echo publishing package-a would happen here --tag branch_name",
+      "package-a [publish]: echo publishing --tag pkg.tag would happen here",
     ],
     Array [
-      "publishing package-a would happen here --tag branch_name",
+      "publishing --tag pkg.tag would happen here",
     ],
     Array [
-      "package-b [publish]: echo publishing package-b would happen here --tag branch_name",
+      "package-b [publish]: echo publishing --tag pkg.tag would happen here",
     ],
     Array [
-      "publishing package-b would happen here --tag branch_name",
+      "publishing --tag pkg.tag would happen here",
     ],
     Array [
-      "package-c [publish]: echo publishing package-c would happen here --tag branch_name",
+      "package-c [publish]: echo publishing --tag pkg.tag would happen here",
     ],
     Array [
-      "publishing package-c would happen here --tag branch_name",
+      "publishing --tag pkg.tag would happen here",
     ],
   ],
   "covectorReturn": Object {
     "package-a": Object {
       "command": true,
       "pkg": Object {
-        "command": "echo publishing package-a would happen here --tag branch_name",
+        "command": Array [
+          "echo publishing --tag pkg.tag would happen here",
+        ],
         "dependencies": Array [
           "package-b",
         ],
@@ -1791,7 +1793,9 @@ Object {
     "package-b": Object {
       "command": true,
       "pkg": Object {
-        "command": "echo publishing package-b would happen here --tag branch_name",
+        "command": Array [
+          "echo publishing --tag pkg.tag would happen here",
+        ],
         "dependencies": undefined,
         "manager": "javascript",
         "path": "./package-b",
@@ -1822,7 +1826,9 @@ Object {
     "package-c": Object {
       "command": true,
       "pkg": Object {
-        "command": "echo publishing package-c would happen here --tag branch_name",
+        "command": Array [
+          "echo publishing --tag pkg.tag would happen here",
+        ],
         "dependencies": Array [
           "package-b",
         ],

--- a/packages/covector/__snapshots__/index.test.ts.snap
+++ b/packages/covector/__snapshots__/index.test.ts.snap
@@ -1582,19 +1582,19 @@ Object {
       "prepublishing package-c would happen here",
     ],
     Array [
-      "package-a [publish]: echo publishing  would happen here",
+      "package-a [publish]: echo publishing --tag  would happen here",
     ],
     Array [
-      "publishing would happen here",
+      "publishing --tag would happen here",
     ],
     Array [
-      "package-b [publish]: echo publishing  would happen here",
+      "package-b [publish]: echo publishing --tag  would happen here",
     ],
     Array [
-      "publishing would happen here",
+      "publishing --tag would happen here",
     ],
     Array [
-      "package-c [publish]: echo publishing  would happen here",
+      "package-c [publish]: echo publishing would happen here",
     ],
     Array [
       "publishing would happen here",
@@ -1605,7 +1605,7 @@ Object {
       "command": true,
       "pkg": Object {
         "command": Array [
-          "echo publishing  would happen here",
+          "echo publishing --tag  would happen here",
         ],
         "dependencies": Array [
           "package-b",
@@ -1642,7 +1642,7 @@ Object {
       "command": true,
       "pkg": Object {
         "command": Array [
-          "echo publishing  would happen here",
+          "echo publishing --tag  would happen here",
         ],
         "dependencies": undefined,
         "manager": "javascript",
@@ -1675,7 +1675,7 @@ Object {
       "command": true,
       "pkg": Object {
         "command": Array [
-          "echo publishing  would happen here",
+          "echo publishing would happen here",
         ],
         "dependencies": Array [
           "package-b",
@@ -1746,22 +1746,22 @@ Object {
       "prepublishing package-c would happen here",
     ],
     Array [
-      "package-a [publish]: echo publishing --tag pkg.tag would happen here",
+      "package-a [publish]: echo publishing would happen here",
     ],
     Array [
-      "publishing --tag pkg.tag would happen here",
+      "publishing would happen here",
     ],
     Array [
-      "package-b [publish]: echo publishing --tag pkg.tag would happen here",
+      "package-b [publish]: echo publishing would happen here",
     ],
     Array [
-      "publishing --tag pkg.tag would happen here",
+      "publishing would happen here",
     ],
     Array [
-      "package-c [publish]: echo publishing --tag pkg.tag would happen here",
+      "package-c [publish]: echo publishing --tag branch_name would happen here",
     ],
     Array [
-      "publishing --tag pkg.tag would happen here",
+      "publishing --tag branch_name would happen here",
     ],
   ],
   "covectorReturn": Object {
@@ -1769,7 +1769,7 @@ Object {
       "command": true,
       "pkg": Object {
         "command": Array [
-          "echo publishing --tag pkg.tag would happen here",
+          "echo publishing would happen here",
         ],
         "dependencies": Array [
           "package-b",
@@ -1806,7 +1806,7 @@ Object {
       "command": true,
       "pkg": Object {
         "command": Array [
-          "echo publishing --tag pkg.tag would happen here",
+          "echo publishing would happen here",
         ],
         "dependencies": undefined,
         "manager": "javascript",
@@ -1839,7 +1839,7 @@ Object {
       "command": true,
       "pkg": Object {
         "command": Array [
-          "echo publishing --tag pkg.tag would happen here",
+          "echo publishing --tag branch_name would happen here",
         ],
         "dependencies": Array [
           "package-b",

--- a/packages/covector/__snapshots__/index.test.ts.snap
+++ b/packages/covector/__snapshots__/index.test.ts.snap
@@ -507,6 +507,7 @@ publish
       },
       "postcommand": false,
       "precommand": false,
+      "published": true,
     },
     "package-two": Object {
       "command": "## \\\\[1.9.0]
@@ -548,6 +549,7 @@ publish
       },
       "postcommand": false,
       "precommand": false,
+      "published": true,
     },
   },
 }
@@ -755,6 +757,7 @@ Object {
           },
           "postcommand": false,
           "precommand": false,
+          "published": true,
         },
         "package-two": Object {
           "command": "## \\\\[1.9.0]
@@ -795,6 +798,7 @@ Object {
           },
           "postcommand": false,
           "precommand": false,
+          "published": true,
         },
       },
     ],
@@ -839,6 +843,7 @@ Object {
       },
       "postcommand": false,
       "precommand": false,
+      "published": true,
     },
     "package-two": Object {
       "command": "## \\\\[1.9.0]
@@ -879,6 +884,7 @@ Object {
       },
       "postcommand": false,
       "precommand": false,
+      "published": true,
     },
   },
 }
@@ -1552,31 +1558,47 @@ Object {
       "bumping package-c to 0.0.1-branch-name.12345 to publish a preview",
     ],
     Array [
-      "package-a [publish]: echo publishing package-a would happen here",
+      "package-a [prepublish]: echo prepublishing package-a would happen here",
     ],
     Array [
-      "publishing package-a would happen here",
+      "prepublishing package-a would happen here",
     ],
     Array [
-      "package-b [publish]: echo publishing package-b would happen here",
+      "package-b [prepublish]: echo prepublishing package-b would happen here",
     ],
     Array [
-      "publishing package-b would happen here",
+      "prepublishing package-b would happen here",
     ],
     Array [
-      "package-c [publish]: echo publishing package-c would happen here",
+      "package-c [prepublish]: echo prepublishing package-c would happen here",
     ],
     Array [
-      "publishing package-c would happen here",
+      "prepublishing package-c would happen here",
+    ],
+    Array [
+      "package-a [publish]: echo publishing package-a would happen here --tag ",
+    ],
+    Array [
+      "publishing package-a would happen here --tag",
+    ],
+    Array [
+      "package-b [publish]: echo publishing package-b would happen here --tag ",
+    ],
+    Array [
+      "publishing package-b would happen here --tag",
+    ],
+    Array [
+      "package-c [publish]: echo publishing package-c would happen here --tag ",
+    ],
+    Array [
+      "publishing package-c would happen here --tag",
     ],
   ],
   "covectorReturn": Object {
     "package-a": Object {
       "command": true,
       "pkg": Object {
-        "command": Array [
-          "echo publishing package-a would happen here",
-        ],
+        "command": "echo publishing package-a would happen here --tag ",
         "dependencies": Array [
           "package-b",
         ],
@@ -1597,18 +1619,21 @@ Object {
           "versionMinor": 0,
           "versionPatch": 1,
         },
-        "postcommand": null,
-        "precommand": null,
+        "postcommand": Array [
+          "echo postpublishing package-a would happen here",
+        ],
+        "precommand": Array [
+          "echo prepublishing package-a would happen here",
+        ],
       },
       "postcommand": false,
-      "precommand": false,
+      "precommand": true,
+      "published": true,
     },
     "package-b": Object {
       "command": true,
       "pkg": Object {
-        "command": Array [
-          "echo publishing package-b would happen here",
-        ],
+        "command": "echo publishing package-b would happen here --tag ",
         "dependencies": undefined,
         "manager": "javascript",
         "path": "./package-b",
@@ -1625,18 +1650,21 @@ Object {
           "versionMinor": 0,
           "versionPatch": 1,
         },
-        "postcommand": null,
-        "precommand": null,
+        "postcommand": Array [
+          "echo postpublishing package-b would happen here",
+        ],
+        "precommand": Array [
+          "echo prepublishing package-b would happen here",
+        ],
       },
       "postcommand": false,
-      "precommand": false,
+      "precommand": true,
+      "published": true,
     },
     "package-c": Object {
       "command": true,
       "pkg": Object {
-        "command": Array [
-          "echo publishing package-c would happen here",
-        ],
+        "command": "echo publishing package-c would happen here --tag ",
         "dependencies": Array [
           "package-b",
         ],
@@ -1659,11 +1687,16 @@ Object {
           "versionMinor": 0,
           "versionPatch": 1,
         },
-        "postcommand": null,
-        "precommand": null,
+        "postcommand": Array [
+          "echo postpublishing package-c would happen here",
+        ],
+        "precommand": Array [
+          "echo prepublishing package-c would happen here",
+        ],
       },
       "postcommand": false,
-      "precommand": false,
+      "precommand": true,
+      "published": true,
     },
   },
 }
@@ -1681,6 +1714,24 @@ Object {
     ],
     Array [
       "bumping package-c to 0.0.1-branch-name.12345 to publish a preview",
+    ],
+    Array [
+      "package-a [prepublish]: echo prepublishing package-a would happen here",
+    ],
+    Array [
+      "prepublishing package-a would happen here",
+    ],
+    Array [
+      "package-b [prepublish]: echo prepublishing package-b would happen here",
+    ],
+    Array [
+      "prepublishing package-b would happen here",
+    ],
+    Array [
+      "package-c [prepublish]: echo prepublishing package-c would happen here",
+    ],
+    Array [
+      "prepublishing package-c would happen here",
     ],
     Array [
       "package-a [publish]: echo publishing package-a would happen here --tag branch_name",
@@ -1726,11 +1777,16 @@ Object {
           "versionMinor": 0,
           "versionPatch": 1,
         },
-        "postcommand": null,
-        "precommand": null,
+        "postcommand": Array [
+          "echo postpublishing package-a would happen here",
+        ],
+        "precommand": Array [
+          "echo prepublishing package-a would happen here",
+        ],
       },
       "postcommand": false,
-      "precommand": false,
+      "precommand": true,
+      "published": true,
     },
     "package-b": Object {
       "command": true,
@@ -1752,11 +1808,16 @@ Object {
           "versionMinor": 0,
           "versionPatch": 1,
         },
-        "postcommand": null,
-        "precommand": null,
+        "postcommand": Array [
+          "echo postpublishing package-b would happen here",
+        ],
+        "precommand": Array [
+          "echo prepublishing package-b would happen here",
+        ],
       },
       "postcommand": false,
-      "precommand": false,
+      "precommand": true,
+      "published": true,
     },
     "package-c": Object {
       "command": true,
@@ -1784,11 +1845,16 @@ Object {
           "versionMinor": 0,
           "versionPatch": 1,
         },
-        "postcommand": null,
-        "precommand": null,
+        "postcommand": Array [
+          "echo postpublishing package-c would happen here",
+        ],
+        "precommand": Array [
+          "echo prepublishing package-c would happen here",
+        ],
       },
       "postcommand": false,
-      "precommand": false,
+      "precommand": true,
+      "published": true,
     },
   },
 }
@@ -5169,6 +5235,7 @@ Object {
           },
           "postcommand": true,
           "precommand": true,
+          "published": true,
         },
         "tauri-bundler": Object {
           "command": true,
@@ -5306,6 +5373,7 @@ Object {
           },
           "postcommand": true,
           "precommand": true,
+          "published": true,
         },
         "tauri-utils": Object {
           "command": true,
@@ -5358,6 +5426,7 @@ Object {
           },
           "postcommand": true,
           "precommand": true,
+          "published": true,
         },
         "tauri.js": Object {
           "command": true,
@@ -5491,6 +5560,7 @@ Object {
           },
           "postcommand": false,
           "precommand": false,
+          "published": true,
         },
       },
     ],
@@ -5743,6 +5813,7 @@ Object {
       },
       "postcommand": true,
       "precommand": true,
+      "published": true,
     },
     "tauri-bundler": Object {
       "command": true,
@@ -5880,6 +5951,7 @@ Object {
       },
       "postcommand": true,
       "precommand": true,
+      "published": true,
     },
     "tauri-utils": Object {
       "command": true,
@@ -5932,6 +6004,7 @@ Object {
       },
       "postcommand": true,
       "precommand": true,
+      "published": true,
     },
     "tauri.js": Object {
       "command": true,
@@ -6065,6 +6138,7 @@ Object {
       },
       "postcommand": false,
       "precommand": false,
+      "published": true,
     },
   },
 }
@@ -8216,6 +8290,7 @@ tauri-utils",
       },
       "postcommand": true,
       "precommand": true,
+      "published": true,
     },
     "tauri-bundler": Object {
       "command": true,
@@ -8353,6 +8428,7 @@ tauri-utils",
       },
       "postcommand": true,
       "precommand": true,
+      "published": true,
     },
     "tauri-utils": Object {
       "command": true,
@@ -8405,6 +8481,7 @@ tauri-utils",
       },
       "postcommand": true,
       "precommand": true,
+      "published": true,
     },
     "tauri.js": Object {
       "command": true,
@@ -8538,6 +8615,7 @@ tauri-utils",
       },
       "postcommand": false,
       "precommand": false,
+      "published": true,
     },
   },
 }

--- a/packages/covector/index.test.ts
+++ b/packages/covector/index.test.ts
@@ -740,4 +740,32 @@ describe("integration test for preview command", () => {
       covectorReturn: scrubVfile(covectored),
     }).toMatchSnapshot();
   });
-})
+});
+
+describe.only("integration test for preview command with dist tags", () => {
+  let restoreConsole: Function;
+  beforeEach(() => {
+    restoreConsole = mockConsole(["log", "dir", "info", "error"]);
+  });
+  afterEach(() => {
+    restoreConsole();
+  });
+
+  it("runs version and publish for js and rust", async () => {
+    const fullIntegration = f.copy("integration.js-and-rust-for-preview");
+    const covectored = await run(
+      covector({
+        command: "preview",
+        cwd: fullIntegration,
+        previewVersion: 'branch-name.12345',
+        branchTag: 'branch_name'
+      })
+    );
+
+    expect({
+      consoleLog: consoleMock.log.mock.calls,
+      consoleInfo: consoleMock.info.mock.calls,
+      covectorReturn: scrubVfile(covectored),
+    }).toMatchSnapshot();
+  });
+});

--- a/packages/covector/index.test.ts
+++ b/packages/covector/index.test.ts
@@ -742,7 +742,7 @@ describe("integration test for preview command", () => {
   });
 });
 
-describe.only("integration test for preview command with dist tags", () => {
+describe("integration test for preview command with dist tags", () => {
   let restoreConsole: Function;
   beforeEach(() => {
     restoreConsole = mockConsole(["log", "dir", "info", "error"]);

--- a/packages/covector/src/run.ts
+++ b/packages/covector/src/run.ts
@@ -53,6 +53,7 @@ export function* covector({
   filterPackages = [],
   modifyConfig = async (c) => c,
   previewVersion = '',
+  branchTag = '',
 }: {
   command: string;
   dryRun?: boolean;
@@ -60,6 +61,7 @@ export function* covector({
   filterPackages?: string[];
   modifyConfig?: (c: any) => Promise<any>;
   previewVersion?: string;
+  branchTag?: string;
 }): Generator<any, Covector | string, any> {
   const config = yield modifyConfig(yield configFile({ cwd }));
   const changesPaths = yield changeFiles({
@@ -318,6 +320,15 @@ export function* covector({
       filterPackages,
     });
 
+    const publishCommandsWithTags: PkgPublish[] = publishCommands.map(pkg => {
+      //@ts-ignore
+      if(pkg.command.length === 1){
+        //@ts-ignore
+        pkg.command = pkg.command[0] + ` --tag ${branchTag}`
+      };
+      return pkg;
+    });
+
     if (publishCommands.length === 0) {
       console.log(`No commands configured to run on publish.`);
       return `No commands configured to run on publish.`;
@@ -325,7 +336,7 @@ export function* covector({
 
     const commandsToRun: PkgPublish[] = yield confirmCommandsToRun({
       cwd,
-      commands: publishCommands,
+      commands: publishCommandsWithTags,
       command: 'publish',
     });
 

--- a/packages/covector/src/run.ts
+++ b/packages/covector/src/run.ts
@@ -318,15 +318,7 @@ export function* covector({
       cwd,
       dryRun,
       filterPackages,
-    });
-
-    const publishCommandsWithTags: PkgPublish[] = publishCommands.map(pkg => {
-      //@ts-ignore
-      if(pkg.command.length === 1){
-        //@ts-ignore
-        pkg.command = pkg.command[0] + ` --tag ${branchTag}`
-      };
-      return pkg;
+      tag: branchTag,
     });
 
     if (publishCommands.length === 0) {
@@ -336,7 +328,7 @@ export function* covector({
 
     const commandsToRun: PkgPublish[] = yield confirmCommandsToRun({
       cwd,
-      commands: publishCommandsWithTags,
+      commands: publishCommands,
       command: 'publish',
     });
 


### PR DESCRIPTION
## Motivation
To add tags to the preview packages. It's fine as is at the moment because the pre-release semver syntax _without_ bumping means the latest tag will not be compromised but it's still nice to tag the preview packages for NPM.

## Approach
- `action.command.preview` will now pass in `covector({ ..., branchTag })`
  - the branchTag takes the branch name from the context of the workflow
    - the branch is then converted in the same manner our current preview action treats its tags:
      ```js
      const branchTag = branchName.replace(/(?!.\_)\_/g, '__').replace(/\//g, '_');
      ```
- ~the `branchTag` argument gets utilized _within_ `covector`'s preview command by mutating the publish commands~
  - ~alternatively I could've passed in the branchTag into `mergeIntoConfig` but there's a lot going on in there and mutating the object after `mergeIntoConfig` seemed to provide more clarity~
  - ~see TODO below but the tagging only works if the publish command is a single command and therefore shouldn't be an array~
- the `branchTag` variable is exposed through piping into the template so users can configure their command like this:
```js
{
  "publish": "npm publish ${ pkg.tag ? '--tag pkg.tag' : '' }"
}
```
- fixed the published boolean bug. resolves #197

## TODOs
- [x] Prevent `latest`
  - [x] ⚠️ I configured the action to throw an error if the branch name of a pull request is `latest` but this only applies to the `preview` command in action. Should this be brought up higher to include pre-release publishing?
- [x] ⚠️ ~The publish command can be an array in which case it is difficult to auto-detect which command we should be slapping on the tag argument. But since we have pre-publish and post-publish, would it be possible to restrict the publish command to be a single string property?~
- [x] ⚠️ ~The `--tag TagName` works for NPM but I'm not sure about other registries~
- [x] ⚠️ ~Write tests for action package~ On second thought, maybe we don't need to write tests for the action because all it does is receive arguments and pass it into covector. So I think we can cover the test cases from covector's end?
- [x] ~~Oops, forgot to take out an `only` flag in one of the test suites from a previous PR~~ Fixed
- [x] I have the `published` boolean toggled at the end of `attemptCommands` for when `_pkgCommandsRan` exists, command is `publish` and there are no `commandPrefixes`.
- [x] Add change files once the other TODOs are sorted