### PR TITLE
fix: throw error on empty change file

### DIFF
--- a/.changes/throw-on-empty-change-file.md
+++ b/.changes/throw-on-empty-change-file.md
@@ -1,0 +1,5 @@
+---
+"@covector/assemble": patch
+---
+
+Throw an error if we receive a malformed change file or one that is otherwise missing any changes. Closes #201.

--- a/packages/assemble/index.test.ts
+++ b/packages/assemble/index.test.ts
@@ -215,6 +215,32 @@ describe("assemble changes", () => {
   });
 });
 
+describe("errors on bad change files", () => {
+  const emptyChangefile = {
+    path: "",
+    extname: "",
+    data: { filename: ".changes/empty-file.md" },
+    contents: `---
+---
+  
+This doesn't bump much.
+`,
+  };
+
+  it("throws on no changes", function* (): Generator<any> {
+    expect.assertions(1);
+    try {
+      yield assemble({
+        vfiles: [emptyChangefile],
+      });
+    } catch (e) {
+      expect(e.message).toMatch(
+        ".changes/empty-file.md didn't have any packages bumped. Please add a package bump."
+      );
+    }
+  });
+});
+
 describe("special bump types", () => {
   it("valid additional bump types", function* (): Generator<any> {
     const assembled = yield assemble({

--- a/packages/assemble/index.ts
+++ b/packages/assemble/index.ts
@@ -30,6 +30,10 @@ const parseChange = function* ({ cwd, vfile }: { cwd?: string; vfile: VFile }) {
   const parsedYaml = yaml.load(parsedChanges.value);
   changeset.releases =
     typeof parsedYaml === "object" && parsedYaml !== null ? parsedYaml : {};
+  if (Object.keys(changeset.releases).length === 0)
+    throw new Error(
+      `${vfile.data.filename} didn't have any packages bumped. Please add a package bump.`
+    );
   changeset.summary = processor
     .stringify({
       type: "root",


### PR DESCRIPTION
## Motivation

Throw an error if the change file is malformed or otherwise missing a package bump. This deals with #201.

