### PR TITLE
feat: normalize version number pulling and setting

### DIFF
--- a/.changes/abstract-ext-log.md
+++ b/.changes/abstract-ext-log.md
@@ -1,0 +1,6 @@
+---
+"@covector/apply": patch
+"@covector/files": minor
+---
+
+Abstract out the file switches so `@covector/files` is the only package that considers file extensions.


### PR DESCRIPTION
## Motivation

This shifts all considerations and logic that are dependent on the shape of the package file (and consequently the file extension) into the `files` package. When getting and setting the version number in `assemble`, be it the main version or a dep/devDep, we can now just use the function which abstracts over all of these considerations.

## Approach

Pulled all functionality out into a separate function, and then copied it into the `files` packages. Confirmed that the tests passed and no snapshots changed. 
