### PR TITLE
feat: github action output template pipe

### DIFF
--- a/.changes/action-pipe-as-output.md
+++ b/.changes/action-pipe-as-output.md
@@ -1,0 +1,7 @@
+---
+"covector": minor
+"action": minor
+"@covector/assemble": minor
+---
+
+Adjust output from assemble and covector to expose the template that is piped into each command. This allows us to set it as an output in the github action.

--- a/packages/action/__snapshots__/index.test.ts.snap
+++ b/packages/action/__snapshots__/index.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`full e2e test tests publish 1`] = `
+exports[`full e2e test tests publish input 1`] = `
 Object {
   "consoleDir": Array [],
   "consoleLog": Array [
@@ -139,97 +139,368 @@ publish
 }",
     ],
   ],
-  "covectoredAction": Object {
-    "package-one": Object {
-      "command": "## \\\\[2.3.1]
+}
+`;
+
+exports[`full e2e test tests publish input 2`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "commandRan",
+      "publish",
+    ],
+    Array [
+      "status",
+      "No changes.",
+    ],
+    Array [
+      "package-one-published",
+      "true",
+    ],
+    Array [
+      "package-two-published",
+      "true",
+    ],
+    Array [
+      "packagesPublished",
+      "package-one,package-two",
+    ],
+    Array [
+      "templatePipe",
+      "{\\"package-one\\":{\\"name\\":\\"package-one\\",\\"pipe\\":{\\"pkg\\":{\\"pkg\\":\\"package-one\\",\\"path\\":\\"./packages/package-one\\",\\"changelog\\":\\"## \\\\\\\\[2.3.1]\\\\n\\\\n- Added some cool things.\\\\n\\",\\"precommand\\":null,\\"command\\":[{\\"command\\":\\"echo publish\\",\\"pipe\\":true},null],\\"postcommand\\":null,\\"manager\\":\\"javascript\\",\\"errorOnVersionRange\\":null,\\"tag\\":\\"\\"},\\"pkgFile\\":{\\"name\\":\\"package-one\\",\\"version\\":\\"2.3.1\\",\\"versionMajor\\":2,\\"versionMinor\\":3,\\"versionPatch\\":1,\\"pkg\\":{\\"name\\":\\"package-one\\",\\"version\\":\\"2.3.1\\",\\"license\\":\\"MIT\\",\\"scripts\\":{\\"build\\":\\"npm info tauri@0.8.0 description\\",\\"test\\":\\"npm info covector@0.1.0 license\\"}}}}},\\"package-two\\":{\\"name\\":\\"package-two\\",\\"pipe\\":{\\"pkg\\":{\\"pkg\\":\\"package-two\\",\\"path\\":\\"./packages/package-two\\",\\"changelog\\":\\"## \\\\\\\\[1.9.0]\\\\n\\\\n- Added some even cooler things.\\\\n\\",\\"precommand\\":null,\\"command\\":[{\\"command\\":\\"echo publish\\",\\"pipe\\":true},null],\\"postcommand\\":null,\\"manager\\":\\"javascript\\",\\"errorOnVersionRange\\":null,\\"tag\\":\\"\\"},\\"pkgFile\\":{\\"name\\":\\"package-two\\",\\"version\\":\\"1.9.0\\",\\"versionMajor\\":1,\\"versionMinor\\":9,\\"versionPatch\\":0,\\"pkg\\":{\\"name\\":\\"package-two\\",\\"version\\":\\"1.9.0\\",\\"license\\":\\"MIT\\",\\"scripts\\":{\\"build\\":\\"echo this command is not piped, it is run from scripts for pk2\\",\\"test\\":\\"echo this command is not piped, it is run from the test script\\"}}}}}}",
+    ],
+    Array [
+      "successfulPublish",
+      true,
+    ],
+    Array [
+      "change",
+      Object {
+        "package-one": Object {
+          "command": "## \\\\[2.3.1]
 
 - Added some cool things.
 
 publish
 ",
-      "pkg": Object {
-        "command": Array [
-          Object {
-            "command": "echo publish",
-            "dryRunCommand": undefined,
-            "pipe": true,
-          },
-          [Function],
-        ],
-        "dependencies": undefined,
-        "errorOnVersionRange": null,
-        "manager": "javascript",
-        "path": "./packages/package-one",
-        "pkg": "package-one",
-        "pkgFile": Object {
-          "name": "package-one",
           "pkg": Object {
-            "license": "MIT",
-            "name": "package-one",
-            "scripts": Object {
-              "build": "npm info tauri@0.8.0 description",
-              "test": "npm info covector@0.1.0 license",
+            "command": Array [
+              Object {
+                "command": "echo publish",
+                "dryRunCommand": undefined,
+                "pipe": true,
+              },
+              [Function],
+            ],
+            "dependencies": undefined,
+            "errorOnVersionRange": null,
+            "manager": "javascript",
+            "path": "./packages/package-one",
+            "pkg": "package-one",
+            "pkgFile": Object {
+              "name": "package-one",
+              "pkg": Object {
+                "license": "MIT",
+                "name": "package-one",
+                "scripts": Object {
+                  "build": "npm info tauri@0.8.0 description",
+                  "test": "npm info covector@0.1.0 license",
+                },
+                "version": "2.3.1",
+              },
+              "version": "2.3.1",
+              "versionMajor": 2,
+              "versionMinor": 3,
+              "versionPatch": 1,
+              "versionPrerelease": null,
             },
-            "version": "2.3.1",
+            "postcommand": null,
+            "precommand": null,
           },
-          "version": "2.3.1",
-          "versionMajor": 2,
-          "versionMinor": 3,
-          "versionPatch": 1,
-          "versionPrerelease": null,
+          "postcommand": false,
+          "precommand": false,
+          "published": true,
         },
-        "postcommand": null,
-        "precommand": null,
-      },
-      "postcommand": false,
-      "precommand": false,
-      "published": true,
-    },
-    "package-two": Object {
-      "command": "## \\\\[1.9.0]
+        "package-two": Object {
+          "command": "## \\\\[1.9.0]
 
 - Added some even cooler things.
 
 publish
 ",
-      "pkg": Object {
-        "command": Array [
-          Object {
-            "command": "echo publish",
-            "dryRunCommand": undefined,
-            "pipe": true,
-          },
-          [Function],
-        ],
-        "dependencies": undefined,
-        "errorOnVersionRange": null,
-        "manager": "javascript",
-        "path": "./packages/package-two",
-        "pkg": "package-two",
-        "pkgFile": Object {
-          "name": "package-two",
           "pkg": Object {
-            "license": "MIT",
-            "name": "package-two",
-            "scripts": Object {
-              "build": "echo this command is not piped, it is run from scripts for pk2",
-              "test": "echo this command is not piped, it is run from the test script",
+            "command": Array [
+              Object {
+                "command": "echo publish",
+                "dryRunCommand": undefined,
+                "pipe": true,
+              },
+              [Function],
+            ],
+            "dependencies": undefined,
+            "errorOnVersionRange": null,
+            "manager": "javascript",
+            "path": "./packages/package-two",
+            "pkg": "package-two",
+            "pkgFile": Object {
+              "name": "package-two",
+              "pkg": Object {
+                "license": "MIT",
+                "name": "package-two",
+                "scripts": Object {
+                  "build": "echo this command is not piped, it is run from scripts for pk2",
+                  "test": "echo this command is not piped, it is run from the test script",
+                },
+                "version": "1.9.0",
+              },
+              "version": "1.9.0",
+              "versionMajor": 1,
+              "versionMinor": 9,
+              "versionPatch": 0,
+              "versionPrerelease": null,
             },
-            "version": "1.9.0",
+            "postcommand": null,
+            "precommand": null,
           },
-          "version": "1.9.0",
-          "versionMajor": 1,
-          "versionMinor": 9,
-          "versionPatch": 0,
-          "versionPrerelease": null,
+          "postcommand": false,
+          "precommand": false,
+          "published": true,
         },
-        "postcommand": null,
-        "precommand": null,
       },
-      "postcommand": false,
-      "precommand": false,
-      "published": true,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
     },
-  },
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
+exports[`full e2e test tests publish output 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "commandRan",
+      "publish",
+    ],
+    Array [
+      "status",
+      "No changes.",
+    ],
+    Array [
+      "packagesPublished",
+      "package-one,package-two",
+    ],
+    Array [
+      "templatePipe",
+      "{\\"package-one\\":{\\"name\\":\\"package-one\\",\\"pipe\\":{\\"pkg\\":{\\"pkg\\":\\"package-one\\",\\"path\\":\\"./packages/package-one\\",\\"changelog\\":\\"## \\\\\\\\[2.3.1]\\\\n\\\\n- Added some cool things.\\\\n\\",\\"precommand\\":null,\\"command\\":{\\"command\\":\\"echo publish\\",\\"pipe\\":true},\\"postcommand\\":null,\\"manager\\":\\"javascript\\",\\"errorOnVersionRange\\":null,\\"tag\\":\\"\\"},\\"pkgFile\\":{\\"name\\":\\"package-one\\",\\"version\\":\\"2.3.1\\",\\"versionMajor\\":2,\\"versionMinor\\":3,\\"versionPatch\\":1,\\"pkg\\":{\\"name\\":\\"package-one\\",\\"version\\":\\"2.3.1\\",\\"license\\":\\"MIT\\",\\"scripts\\":{\\"build\\":\\"npm info tauri@0.8.0 description\\",\\"test\\":\\"npm info covector@0.1.0 license\\"}}}}},\\"package-two\\":{\\"name\\":\\"package-two\\",\\"pipe\\":{\\"pkg\\":{\\"pkg\\":\\"package-two\\",\\"path\\":\\"./packages/package-two\\",\\"changelog\\":\\"## \\\\\\\\[1.9.0]\\\\n\\\\n- Added some even cooler things.\\\\n\\",\\"precommand\\":null,\\"command\\":{\\"command\\":\\"echo publish\\",\\"pipe\\":true},\\"postcommand\\":null,\\"manager\\":\\"javascript\\",\\"errorOnVersionRange\\":null,\\"tag\\":\\"\\"},\\"pkgFile\\":{\\"name\\":\\"package-two\\",\\"version\\":\\"1.9.0\\",\\"versionMajor\\":1,\\"versionMinor\\":9,\\"versionPatch\\":0,\\"pkg\\":{\\"name\\":\\"package-two\\",\\"version\\":\\"1.9.0\\",\\"license\\":\\"MIT\\",\\"scripts\\":{\\"build\\":\\"echo this command is not piped, it is run from scripts for pk2\\",\\"test\\":\\"echo this command is not piped, it is run from the test script\\"}}}}}}",
+    ],
+    Array [
+      "successfulPublish",
+      true,
+    ],
+    Array [
+      "change",
+      Object {
+        "package-one": Object {
+          "command": "## \\\\[2.3.1]
+
+- Added some cool things.
+
+publish
+",
+          "pkg": Object {
+            "command": Array [
+              Object {
+                "command": "echo publish",
+                "dryRunCommand": undefined,
+                "pipe": true,
+              },
+            ],
+            "dependencies": undefined,
+            "errorOnVersionRange": null,
+            "manager": "javascript",
+            "path": "./packages/package-one",
+            "pkg": "package-one",
+            "pkgFile": Object {
+              "name": "package-one",
+              "pkg": Object {
+                "license": "MIT",
+                "name": "package-one",
+                "scripts": Object {
+                  "build": "npm info tauri@0.8.0 description",
+                  "test": "npm info covector@0.1.0 license",
+                },
+                "version": "2.3.1",
+              },
+              "version": "2.3.1",
+              "versionMajor": 2,
+              "versionMinor": 3,
+              "versionPatch": 1,
+              "versionPrerelease": null,
+            },
+            "postcommand": null,
+            "precommand": null,
+          },
+          "postcommand": false,
+          "precommand": false,
+          "published": true,
+        },
+        "package-two": Object {
+          "command": "## \\\\[1.9.0]
+
+- Added some even cooler things.
+
+publish
+",
+          "pkg": Object {
+            "command": Array [
+              Object {
+                "command": "echo publish",
+                "dryRunCommand": undefined,
+                "pipe": true,
+              },
+            ],
+            "dependencies": undefined,
+            "errorOnVersionRange": null,
+            "manager": "javascript",
+            "path": "./packages/package-two",
+            "pkg": "package-two",
+            "pkgFile": Object {
+              "name": "package-two",
+              "pkg": Object {
+                "license": "MIT",
+                "name": "package-two",
+                "scripts": Object {
+                  "build": "echo this command is not piped, it is run from scripts for pk2",
+                  "test": "echo this command is not piped, it is run from the test script",
+                },
+                "version": "1.9.0",
+              },
+              "version": "1.9.0",
+              "versionMajor": 1,
+              "versionMinor": 9,
+              "versionPatch": 0,
+              "versionPrerelease": null,
+            },
+            "postcommand": null,
+            "precommand": null,
+          },
+          "postcommand": false,
+          "precommand": false,
+          "published": true,
+        },
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
+exports[`full e2e test tests version output 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "commandRan",
+      "version",
+    ],
+    Array [
+      "status",
+      "No changes.",
+    ],
+    Array [
+      "successfulPublish",
+      false,
+    ],
+    Array [
+      "templatePipe",
+      Object {},
+    ],
+    Array [
+      "change",
+      "# Version Updates
+
+Merging this PR will bump all of the applicable packages based on your change files.
+
+",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
 }
 `;

--- a/packages/action/action.yml
+++ b/packages/action/action.yml
@@ -47,6 +47,8 @@ outputs:
     description: Boolean as a string if we published anything. Useful to skip follow-on steps with nothing published.
   packagesPublished:
     description: Comma separated list of all of the packages that published. Most useful for chaining runs together to act on the filtered list.
+  templatePipe:
+    description: A stringified key/value pair object of the `pipe` that is passed to each command.
 runs:
   using: "node12"
   main: "dist/index.js"

--- a/packages/assemble/__snapshots__/index.test.ts.snap
+++ b/packages/assemble/__snapshots__/index.test.ts.snap
@@ -396,52 +396,139 @@ Object {
 `;
 
 exports[`merge config test merges nested bumps 1`] = `
-Array [
-  Object {
-    "command": Array [
-      "true",
-    ],
-    "dependencies": Array [
-      "assemble1",
-      "all",
-    ],
-    "errorOnVersionRange": null,
-    "manager": undefined,
-    "path": "./packages/assemble1",
-    "pkg": "assemble1",
-    "postcommand": null,
-    "precommand": null,
-    "type": "minor",
+Object {
+  "commands": Array [
+    Object {
+      "command": Array [
+        "true",
+      ],
+      "dependencies": Array [
+        "assemble1",
+        "all",
+      ],
+      "errorOnVersionRange": null,
+      "manager": undefined,
+      "path": "./packages/assemble1",
+      "pkg": "assemble1",
+      "postcommand": null,
+      "precommand": null,
+      "type": "minor",
+    },
+    Object {
+      "command": Array [
+        "true",
+      ],
+      "dependencies": Array [
+        "all",
+      ],
+      "errorOnVersionRange": null,
+      "manager": undefined,
+      "path": "./packages/assemble2",
+      "pkg": "assemble2",
+      "postcommand": null,
+      "precommand": null,
+      "type": "minor",
+    },
+    Object {
+      "command": Array [
+        "true",
+      ],
+      "dependencies": undefined,
+      "errorOnVersionRange": null,
+      "manager": undefined,
+      "path": undefined,
+      "pkg": "all",
+      "postcommand": null,
+      "precommand": null,
+      "type": "minor",
+    },
+  ],
+  "pipeTemplate": Object {
+    "all": Object {
+      "name": "all",
+      "pipe": Object {
+        "pkg": Object {
+          "command": true,
+          "dependencies": undefined,
+          "errorOnVersionRange": null,
+          "manager": undefined,
+          "path": undefined,
+          "pkg": "all",
+          "postcommand": null,
+          "precommand": null,
+        },
+        "release": Object {
+          "changes": Array [
+            Object {
+              "releases": Object {
+                "all": "minor",
+              },
+              "summary": "This is a test.",
+            },
+          ],
+          "type": "minor",
+        },
+      },
+    },
+    "assemble1": Object {
+      "name": "assemble1",
+      "pipe": Object {
+        "pkg": Object {
+          "command": true,
+          "dependencies": Array [
+            "assemble1",
+            "all",
+          ],
+          "errorOnVersionRange": null,
+          "manager": undefined,
+          "path": "./packages/assemble1",
+          "pkg": "assemble1",
+          "postcommand": null,
+          "precommand": null,
+        },
+        "release": Object {
+          "changes": Array [
+            Object {
+              "releases": Object {
+                "assemble1": "patch",
+              },
+              "summary": "This is a test.",
+            },
+          ],
+          "type": "minor",
+        },
+      },
+    },
+    "assemble2": Object {
+      "name": "assemble2",
+      "pipe": Object {
+        "pkg": Object {
+          "command": true,
+          "dependencies": Array [
+            "all",
+          ],
+          "errorOnVersionRange": null,
+          "manager": undefined,
+          "path": "./packages/assemble2",
+          "pkg": "assemble2",
+          "postcommand": null,
+          "precommand": null,
+        },
+        "release": Object {
+          "changes": Array [
+            Object {
+              "releases": Object {
+                "all": "minor",
+              },
+              "summary": "This is a test.",
+            },
+          ],
+          "type": "minor",
+        },
+      },
+    },
   },
-  Object {
-    "command": Array [
-      "true",
-    ],
-    "dependencies": Array [
-      "all",
-    ],
-    "errorOnVersionRange": null,
-    "manager": undefined,
-    "path": "./packages/assemble2",
-    "pkg": "assemble2",
-    "postcommand": null,
-    "precommand": null,
-    "type": "minor",
-  },
-  Object {
-    "command": Array [
-      "true",
-    ],
-    "dependencies": undefined,
-    "errorOnVersionRange": null,
-    "manager": undefined,
-    "path": undefined,
-    "pkg": "all",
-    "postcommand": null,
-    "precommand": null,
-    "type": "minor",
-  },
-]
+}
 `;
 
 exports[`merge config test merges publish 1`] = `
@@ -530,57 +617,189 @@ Array [
 `;
 
 exports[`merge config test merges version 1`] = `
-Array [
-  Object {
-    "command": Array [
-      "cargo version patch",
-    ],
-    "dependencies": Array [
-      "assemble2",
-      "all",
-    ],
-    "errorOnVersionRange": null,
-    "manager": "cargo",
-    "path": "./packages/namespaced-assemble2",
-    "pkg": "@namespaced/assemble2",
-    "postcommand": null,
-    "precommand": null,
-    "type": "patch",
+Object {
+  "commands": Array [
+    Object {
+      "command": Array [
+        "cargo version patch",
+      ],
+      "dependencies": Array [
+        "assemble2",
+        "all",
+      ],
+      "errorOnVersionRange": null,
+      "manager": "cargo",
+      "path": "./packages/namespaced-assemble2",
+      "pkg": "@namespaced/assemble2",
+      "postcommand": null,
+      "precommand": null,
+      "type": "patch",
+    },
+    Object {
+      "command": Array [
+        "lerna version minor --no-git-tag-version --no-push",
+      ],
+      "dependencies": Array [
+        "all",
+      ],
+      "errorOnVersionRange": null,
+      "manager": "javascript",
+      "path": "./packages/assemble1",
+      "pkg": "assemble1",
+      "postcommand": null,
+      "precommand": null,
+      "type": "minor",
+    },
+    Object {
+      "command": Array [
+        "lerna version major",
+      ],
+      "dependencies": Array [
+        "all",
+      ],
+      "errorOnVersionRange": null,
+      "manager": undefined,
+      "path": "./packages/assemble2",
+      "pkg": "assemble2",
+      "postcommand": null,
+      "precommand": null,
+      "type": "major",
+    },
+  ],
+  "pipeTemplate": Object {
+    "@namespaced/assemble2": Object {
+      "name": "@namespaced/assemble2",
+      "pipe": Object {
+        "pkg": Object {
+          "command": "cargo version \${ release.type }",
+          "dependencies": Array [
+            "assemble2",
+            "all",
+          ],
+          "errorOnVersionRange": null,
+          "manager": "cargo",
+          "path": "./packages/namespaced-assemble2",
+          "pkg": "@namespaced/assemble2",
+          "postcommand": null,
+          "precommand": null,
+        },
+        "release": Object {
+          "changes": Array [
+            Object {
+              "releases": Object {
+                "@namespaced/assemble2": "patch",
+                "assemble1": "patch",
+              },
+              "summary": "This is a test.",
+            },
+          ],
+          "type": "patch",
+        },
+      },
+    },
+    "assemble1": Object {
+      "name": "assemble1",
+      "pipe": Object {
+        "pkg": Object {
+          "command": "lerna version \${ release.type } --no-git-tag-version --no-push",
+          "dependencies": Array [
+            "all",
+          ],
+          "errorOnVersionRange": null,
+          "manager": "javascript",
+          "path": "./packages/assemble1",
+          "pkg": "assemble1",
+          "postcommand": null,
+          "precommand": null,
+        },
+        "release": Object {
+          "changes": Array [
+            Object {
+              "releases": Object {
+                "assemble1": "patch",
+                "assemble2": "patch",
+              },
+              "summary": "This is a test.",
+            },
+            Object {
+              "releases": Object {
+                "assemble1": "minor",
+                "assemble2": "patch",
+              },
+              "summary": "This is a test.",
+            },
+            Object {
+              "releases": Object {
+                "assemble1": "patch",
+                "assemble2": "major",
+              },
+              "summary": "This is a test.",
+            },
+            Object {
+              "releases": Object {
+                "@namespaced/assemble2": "patch",
+                "assemble1": "patch",
+              },
+              "summary": "This is a test.",
+            },
+          ],
+          "type": "minor",
+        },
+      },
+    },
+    "assemble2": Object {
+      "name": "assemble2",
+      "pipe": Object {
+        "pkg": Object {
+          "command": "lerna version \${ release.type }",
+          "dependencies": Array [
+            "all",
+          ],
+          "errorOnVersionRange": null,
+          "manager": undefined,
+          "path": "./packages/assemble2",
+          "pkg": "assemble2",
+          "postcommand": null,
+          "precommand": null,
+        },
+        "release": Object {
+          "changes": Array [
+            Object {
+              "releases": Object {
+                "assemble1": "patch",
+                "assemble2": "patch",
+              },
+              "summary": "This is a test.",
+            },
+            Object {
+              "releases": Object {
+                "assemble1": "minor",
+                "assemble2": "patch",
+              },
+              "summary": "This is a test.",
+            },
+            Object {
+              "releases": Object {
+                "assemble1": "patch",
+                "assemble2": "major",
+              },
+              "summary": "This is a test.",
+            },
+          ],
+          "type": "major",
+        },
+      },
+    },
   },
-  Object {
-    "command": Array [
-      "lerna version minor --no-git-tag-version --no-push",
-    ],
-    "dependencies": Array [
-      "all",
-    ],
-    "errorOnVersionRange": null,
-    "manager": "javascript",
-    "path": "./packages/assemble1",
-    "pkg": "assemble1",
-    "postcommand": null,
-    "precommand": null,
-    "type": "minor",
-  },
-  Object {
-    "command": Array [
-      "lerna version major",
-    ],
-    "dependencies": Array [
-      "all",
-    ],
-    "errorOnVersionRange": null,
-    "manager": undefined,
-    "path": "./packages/assemble2",
-    "pkg": "assemble2",
-    "postcommand": null,
-    "precommand": null,
-    "type": "major",
-  },
-]
+}
 `;
 
-exports[`merge config test merges version without command 1`] = `Array []`;
+exports[`merge config test merges version without command 1`] = `
+Object {
+  "commands": Array [],
+  "pipeTemplate": Object {},
+}
+`;
 
 exports[`merge filtered config test merges publish 1`] = `
 Array [
@@ -640,7 +859,12 @@ Array [
 ]
 `;
 
-exports[`merge filtered config test merges version 1`] = `Array []`;
+exports[`merge filtered config test merges version 1`] = `
+Object {
+  "commands": Array [],
+  "pipeTemplate": Object {},
+}
+`;
 
 exports[`special bump types handles an only noop 1`] = `
 Object {

--- a/packages/assemble/index.test.ts
+++ b/packages/assemble/index.test.ts
@@ -476,8 +476,8 @@ describe("merge filtered config test", () => {
 
 // vfile returns fs information that is flaky between machines, scrub it
 const scrubVfile = (mergedPublishConfig: any) => {
-  return mergedPublishConfig.map((pkg: any) => {
+  return mergedPublishConfig.commands.map((pkg: any) => {
     delete pkg.pkgFile.vfile;
     return pkg;
-  }, mergedPublishConfig);
+  }, mergedPublishConfig.commands);
 };

--- a/packages/covector/index.test.ts
+++ b/packages/covector/index.test.ts
@@ -71,17 +71,22 @@ describe("integration test in production mode", () => {
         cwd: fullIntegration,
       })
     );
+    if (typeof covectored !== "object")
+      throw new Error("We are expecting an object here.");
     expect({
       consoleLog: consoleMock.log.mock.calls,
       consoleInfo: consoleMock.info.mock.calls,
       //@ts-ignore
-      covectorReturn: Object.keys(covectored).reduce((pkgs, pkg) => {
-        // remove these as they are dependent on the OS
-        // and user running them so would always fail
-        //@ts-ignore
-        delete pkgs[pkg].applied.vfile;
-        return pkgs;
-      }, covectored),
+      covectorReturn: Object.keys(covectored.commandsRan).reduce(
+        (pkgs, pkg) => {
+          // remove these as they are dependent on the OS
+          // and user running them so would always fail
+          //@ts-ignore
+          delete pkgs[pkg].applied.vfile;
+          return pkgs;
+        },
+        covectored.commandsRan
+      ),
     }).toMatchSnapshot();
 
     const changelogTauriCore = await toVFile.read(
@@ -113,17 +118,22 @@ describe("integration test in production mode", () => {
         cwd: fullIntegration,
       })
     );
+    if (typeof covectored !== "object")
+      throw new Error("We are expecting an object here.");
     expect({
       consoleLog: consoleMock.log.mock.calls,
       consoleInfo: consoleMock.info.mock.calls,
       //@ts-ignore
-      covectorReturn: Object.keys(covectored).reduce((pkgs, pkg) => {
-        // remove these as they are dependent on the OS
-        // and user running them so would always fail
-        //@ts-ignore
-        delete pkgs[pkg].applied.vfile;
-        return pkgs;
-      }, covectored),
+      covectorReturn: Object.keys(covectored.commandsRan).reduce(
+        (pkgs, pkg) => {
+          // remove these as they are dependent on the OS
+          // and user running them so would always fail
+          //@ts-ignore
+          delete pkgs[pkg].applied.vfile;
+          return pkgs;
+        },
+        covectored.commandsRan
+      ),
     }).toMatchSnapshot();
 
     const changelog = await toVFile.read(
@@ -154,17 +164,22 @@ describe("integration test in production mode", () => {
         cwd: fullIntegration,
       })
     );
+    if (typeof covectored !== "object")
+      throw new Error("We are expecting an object here.");
     expect({
       consoleLog: consoleMock.log.mock.calls,
       consoleInfo: consoleMock.info.mock.calls,
       //@ts-ignore
-      covectorReturn: Object.keys(covectored).reduce((pkgs, pkg) => {
-        // remove these as they are dependent on the OS
-        // and user running them so would always fail
-        //@ts-ignore
-        delete pkgs[pkg].applied.vfile;
-        return pkgs;
-      }, covectored),
+      covectorReturn: Object.keys(covectored.commandsRan).reduce(
+        (pkgs, pkg) => {
+          // remove these as they are dependent on the OS
+          // and user running them so would always fail
+          //@ts-ignore
+          delete pkgs[pkg].applied.vfile;
+          return pkgs;
+        },
+        covectored.commandsRan
+      ),
     }).toMatchSnapshot();
 
     const changelog = await toVFile.read(
@@ -194,17 +209,22 @@ describe("integration test in production mode", () => {
         cwd: fullIntegration,
       })
     );
+    if (typeof covectored !== "object")
+      throw new Error("We are expecting an object here.");
     expect({
       consoleLog: consoleMock.log.mock.calls,
       consoleInfo: consoleMock.info.mock.calls,
       //@ts-ignore
-      covectorReturn: Object.keys(covectored).reduce((pkgs, pkg) => {
-        // remove these as they are dependent on the OS
-        // and user running them so would always fail
-        //@ts-ignore
-        delete pkgs[pkg].applied.vfile;
-        return pkgs;
-      }, covectored),
+      covectorReturn: Object.keys(covectored.commandsRan).reduce(
+        (pkgs, pkg) => {
+          // remove these as they are dependent on the OS
+          // and user running them so would always fail
+          //@ts-ignore
+          delete pkgs[pkg].applied.vfile;
+          return pkgs;
+        },
+        covectored.commandsRan
+      ),
     }).toMatchSnapshot();
 
     const changelog = await toVFile.read(
@@ -453,17 +473,22 @@ describe("integration test in --dry-run mode", () => {
         dryRun: true,
       })
     );
+    if (typeof covectored !== "object")
+      throw new Error("We are expecting an object here.");
     expect({
       consoleLog: consoleMock.log.mock.calls,
       consoleInfo: consoleMock.info.mock.calls,
       //@ts-ignore
-      covectorReturn: Object.keys(covectored).reduce((pkgs, pkg) => {
-        // remove these as they are dependent on the OS
-        // and user running them so would always fail
-        //@ts-ignore
-        delete pkgs[pkg].applied.vfile;
-        return pkgs;
-      }, covectored),
+      covectorReturn: Object.keys(covectored.commandsRan).reduce(
+        (pkgs, pkg) => {
+          // remove these as they are dependent on the OS
+          // and user running them so would always fail
+          //@ts-ignore
+          delete pkgs[pkg].applied.vfile;
+          return pkgs;
+        },
+        covectored.commandsRan
+      ),
     }).toMatchSnapshot();
 
     const changelogTauriCore = toVFile.read(
@@ -567,17 +592,22 @@ describe("integration test with preMode `on`", () => {
         cwd: fullIntegration,
       })
     );
+    if (typeof covectored !== "object")
+      throw new Error("We are expecting an object here.");
     expect({
       consoleLog: consoleMock.log.mock.calls,
       consoleInfo: consoleMock.info.mock.calls,
       //@ts-ignore
-      covectorReturn: Object.keys(covectored).reduce((pkgs, pkg) => {
-        // remove these as they are dependent on the OS
-        // and user running them so would always fail
-        //@ts-ignore
-        delete pkgs[pkg].applied.vfile;
-        return pkgs;
-      }, covectored),
+      covectorReturn: Object.keys(covectored.commandsRan).reduce(
+        (pkgs, pkg) => {
+          // remove these as they are dependent on the OS
+          // and user running them so would always fail
+          //@ts-ignore
+          delete pkgs[pkg].applied.vfile;
+          return pkgs;
+        },
+        covectored.commandsRan
+      ),
     }).toMatchSnapshot();
 
     const changelogTauriCore = await toVFile.read(
@@ -707,25 +737,35 @@ Boop again.
       '{\n  "tag": "beta",\n  "changes": [\n    ".changes/first-change.md",\n    ".changes/second-change.md",\n    ".changes/third-change.md"\n  ]\n}\n'
     );
 
+    if (typeof covectoredOne !== "object")
+      throw new Error("We are expecting an object here.");
+    if (typeof covectoredTwo !== "object")
+      throw new Error("We are expecting an object here.");
     expect({
       consoleLog: consoleMock.log.mock.calls,
       consoleInfo: consoleMock.info.mock.calls,
       //@ts-ignore
-      covectorReturnOne: Object.keys(covectoredOne).reduce((pkgs, pkg) => {
-        // remove these as they are dependent on the OS
-        // and user running them so would always fail
-        //@ts-ignore
-        delete pkgs[pkg].applied.vfile;
-        return pkgs;
-      }, covectoredOne),
+      covectorReturnOne: Object.keys(covectoredOne.commandsRan).reduce(
+        (pkgs, pkg) => {
+          // remove these as they are dependent on the OS
+          // and user running them so would always fail
+          //@ts-ignore
+          delete pkgs[pkg].applied.vfile;
+          return pkgs;
+        },
+        covectoredOne.commandsRan
+      ),
       //@ts-ignore
-      covectorReturnTwo: Object.keys(covectoredTwo).reduce((pkgs, pkg) => {
-        // remove these as they are dependent on the OS
-        // and user running them so would always fail
-        //@ts-ignore
-        delete pkgs[pkg].applied.vfile;
-        return pkgs;
-      }, covectoredTwo),
+      covectorReturnTwo: Object.keys(covectoredTwo.commandsRan).reduce(
+        (pkgs, pkg) => {
+          // remove these as they are dependent on the OS
+          // and user running them so would always fail
+          //@ts-ignore
+          delete pkgs[pkg].applied.vfile;
+          return pkgs;
+        },
+        covectoredTwo.commandsRan
+      ),
     }).toMatchSnapshot();
   });
 
@@ -741,17 +781,22 @@ Boop again.
         dryRun: true,
       })
     );
+    if (typeof covectored !== "object")
+      throw new Error("We are expecting an object here.");
     expect({
       consoleLog: consoleMock.log.mock.calls,
       consoleInfo: consoleMock.info.mock.calls,
       //@ts-ignore
-      covectorReturn: Object.keys(covectored).reduce((pkgs, pkg) => {
-        // remove these as they are dependent on the OS
-        // and user running them so would always fail
-        //@ts-ignore
-        delete pkgs[pkg].applied.vfile;
-        return pkgs;
-      }, covectored),
+      covectorReturn: Object.keys(covectored.commandsRan).reduce(
+        (pkgs, pkg) => {
+          // remove these as they are dependent on the OS
+          // and user running them so would always fail
+          //@ts-ignore
+          delete pkgs[pkg].applied.vfile;
+          return pkgs;
+        },
+        covectored.commandsRan
+      ),
     }).toMatchSnapshot();
 
     const changelogTauriCore = toVFile.read(
@@ -780,17 +825,22 @@ describe("integration test for complex commands", () => {
         cwd: fullIntegration,
       })
     );
+    if (typeof covectored !== "object")
+      throw new Error("We are expecting an object here.");
     expect({
       consoleLog: consoleMock.log.mock.calls,
       consoleInfo: consoleMock.info.mock.calls,
       //@ts-ignore
-      covectorReturn: Object.keys(covectored).reduce((pkgs, pkg) => {
-        // remove these as they are dependent on the OS
-        // and user running them so would always fail
-        //@ts-ignore
-        delete pkgs[pkg].applied.vfile;
-        return pkgs;
-      }, covectored),
+      covectorReturn: Object.keys(covectored.commandsRan).reduce(
+        (pkgs, pkg) => {
+          // remove these as they are dependent on the OS
+          // and user running them so would always fail
+          //@ts-ignore
+          delete pkgs[pkg].applied.vfile;
+          return pkgs;
+        },
+        covectored.commandsRan
+      ),
     }).toMatchSnapshot();
 
     const changelogTauriCore = toVFile.read(
@@ -869,17 +919,22 @@ describe("integration test for complex commands", () => {
         dryRun: true,
       })
     );
+    if (typeof covectored !== "object")
+      throw new Error("We are expecting an object here.");
     expect({
       consoleLog: consoleMock.log.mock.calls,
       consoleInfo: consoleMock.info.mock.calls,
       //@ts-ignore
-      covectorReturn: Object.keys(covectored).reduce((pkgs, pkg) => {
-        // remove these as they are dependent on the OS
-        // and user running them so would always fail
-        //@ts-ignore
-        delete pkgs[pkg].applied.vfile;
-        return pkgs;
-      }, covectored),
+      covectorReturn: Object.keys(covectored.commandsRan).reduce(
+        (pkgs, pkg) => {
+          // remove these as they are dependent on the OS
+          // and user running them so would always fail
+          //@ts-ignore
+          delete pkgs[pkg].applied.vfile;
+          return pkgs;
+        },
+        covectored.commandsRan
+      ),
     }).toMatchSnapshot();
 
     const changelogTauriCore = toVFile.read(
@@ -954,10 +1009,10 @@ describe("integration test for complex commands", () => {
 
 // vfile returns fs information that is flaky between machines, scrub it
 const scrubVfile = (covectored: any) => {
-  return Object.keys(covectored).reduce((c, pkg) => {
+  return Object.keys(covectored.commandsRan).reduce((c, pkg) => {
     delete c[pkg].pkg.pkgFile.vfile;
     return c;
-  }, covectored);
+  }, covectored.commandsRan);
 };
 
 describe("integration test to invoke sub commands", () => {

--- a/packages/covector/src/run.ts
+++ b/packages/covector/src/run.ts
@@ -348,7 +348,9 @@ export function* covector({
       dryRun,
     });
 
-    const publishCommands: PkgPublish[] = yield mergeIntoConfig({
+    const {
+      commands: publishCommands,
+    }: { commands: PkgPublish[] } = yield mergeIntoConfig({
       assembledChanges,
       config,
       command: "publish",


### PR DESCRIPTION
## Motivation

This adds some additional tests around the Github action output. We also adjusted the output from `assemble` and `covector` to expose the information being piped into the commands. This is then exposed as an output from the Github action. Potentially useful when composing actions. 

## Approach

<!-- REQUIRED
  How does this change fulfill the purpose? Keep it high level. Avoid code-splaining.
-->

