### PR TITLE
fix: include dist directory in npm bundle

### DIFF
--- a/packages/action/src/index.ts
+++ b/packages/action/src/index.ts
@@ -32,7 +32,7 @@ export function* run(): Generator<any, any, any> {
 
     if (inputCommand === "version-or-publish") {
       const status = yield covector({ command: "status", cwd });
-      if (status.response === "No changes.") {
+      if (status === "No changes.") {
         console.log("As there are no changes, let's try publishing.");
         command = "publish";
       } else {

--- a/packages/covector/package.json
+++ b/packages/covector/package.json
@@ -14,7 +14,8 @@
     "covector": "./bin/covector.js"
   },
   "files": [
-    "bin/*"
+    "bin/*",
+    "dist/*"
   ],
   "scripts": {
     "build": "tsc -b",


### PR DESCRIPTION
## Motivation

When install covector@0.6.0 and try to run any commands you will notice that it's requiring files that are not existent. This PR fixes that by including all files in the `dist` folder.

## Approach

<!-- REQUIRED
  How does this change fulfill the purpose? Keep it high level. Avoid code-splaining.
-->

### Alternate Designs

 <!-- OPTIONAL
   Explain what other alternatives you considered and why you chose this option.
 -->
One could consider excluding the generated .map files.

### Possible Drawbacks or Risks

 <!-- OPTIONAL
   What are the possible side-effects or negative impacts of this change?
 -->

### TODOs and Open Questions

<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the conclusion.
-->

## Learning

<!-- OPTIONAL
  Share any blog posts, patterns, libraries, or documentation that helped you.
-->

## Screenshots

<!-- OPTIONAL
  If relevant, include "before" and "after" to demonstrate this change. Add a caption describing what each screenshot shows.
-->
