### PR TITLE
Include all file in dist directory

### DIFF
--- a/.changes/fix-covector-dist.md
+++ b/.changes/fix-covector-dist.md
@@ -1,0 +1,5 @@
+---
+"covector": patch
+---
+
+Remove the `files` property of `package.json` to properly publish all of the `dist` files.

--- a/packages/covector/package.json
+++ b/packages/covector/package.json
@@ -13,11 +13,6 @@
   "bin": {
     "covector": "./bin/covector.js"
   },
-  "files": [
-    "bin/*",
-    "dist/*.js",
-    "dist/*.d.ts"
-  ],
   "scripts": {
     "build": "tsc -b",
     "clean": "rimraf dist",

--- a/packages/covector/package.json
+++ b/packages/covector/package.json
@@ -14,7 +14,9 @@
     "covector": "./bin/covector.js"
   },
   "files": [
-    "bin/*"
+    "bin/*",
+    "dist/*.js",
+    "dist/*.d.ts"
   ],
   "scripts": {
     "build": "tsc -b",


### PR DESCRIPTION
## Motivation

Installing covector@0.6.0 from nom and runnning any commands crashes because files `./run` and `./cli` are missing. This PR fixes that. 

## Approach

<!-- REQUIRED
  How does this change fulfill the purpose? Keep it high level. Avoid code-splaining.
-->

### Alternate Designs

 <!-- OPTIONAL
   Explain what other alternatives you considered and why you chose this option.
 -->

### Possible Drawbacks or Risks

 <!-- OPTIONAL
   What are the possible side-effects or negative impacts of this change?
 -->

### TODOs and Open Questions

<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the conclusion.
-->

## Learning

<!-- OPTIONAL
  Share any blog posts, patterns, libraries, or documentation that helped you.
-->

## Screenshots

<!-- OPTIONAL
  If relevant, include "before" and "after" to demonstrate this change. Add a caption describing what each screenshot shows.
-->
