### PR TITLE
Preveiw versioning for packages in prerelease mode

### DIFF
--- a/.changes/trim-prerelease-for-preview.md
+++ b/.changes/trim-prerelease-for-preview.md
@@ -1,0 +1,5 @@
+---
+"apply": minor
+---
+
+Preview version template overwrites the prerelease identifier

--- a/.changes/trim-prerelease-for-preview.md
+++ b/.changes/trim-prerelease-for-preview.md
@@ -1,5 +1,5 @@
 ---
-"apply": minor
+"@covector/apply": minor
 ---
 
 Preview version template overwrites the prerelease identifier

--- a/__fixtures__/pkg.js-single-prerelease-json/package.json
+++ b/__fixtures__/pkg.js-single-prerelease-json/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "name": "js-single-prerelease-json-fixture",
+  "description": "A single package at the root. No monorepo setup.",
+  "version": "0.5.9-abc.2"
+}

--- a/__fixtures__/pkg.js-yarn-prerelease-workspace/package.json
+++ b/__fixtures__/pkg.js-yarn-prerelease-workspace/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "name": "js-yarn-workspace",
+  "description": "workspace",
+  "version": "1.0.0",
+  "workspaces": [
+    "packages/*"
+  ]
+}

--- a/__fixtures__/pkg.js-yarn-prerelease-workspace/packages/pkg-a/package.json
+++ b/__fixtures__/pkg.js-yarn-prerelease-workspace/packages/pkg-a/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "yarn-workspace-base-pkg-a",
+  "version": "1.0.0-abc.2",
+  "dependencies": {
+    "yarn-workspace-base-pkg-b": "1.0.0"
+  }
+}

--- a/__fixtures__/pkg.js-yarn-prerelease-workspace/packages/pkg-b/package.json
+++ b/__fixtures__/pkg.js-yarn-prerelease-workspace/packages/pkg-b/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "yarn-workspace-base-pkg-b",
+  "version": "1.0.0-abc.3"
+}

--- a/packages/apply/src/index.ts
+++ b/packages/apply/src/index.ts
@@ -269,7 +269,7 @@ const bumpAll = ({
     if (previewVersion)
       // change log (assume that the prerelease will be removed)
       console.log(
-        `bumping ${pkg} with ${previewVersion} template to publish a preview`
+        `bumping ${pkg} with ${previewVersion} identifier to publish a preview`
       );
     packageFiles[pkg] = bumpMain({
       packageFile: packageFiles[pkg],

--- a/packages/apply/src/index.ts
+++ b/packages/apply/src/index.ts
@@ -267,8 +267,9 @@ const bumpAll = ({
     if (logs && !previewVersion)
       console.log(`bumping ${pkg} with ${changes[pkg].type}`);
     if (previewVersion)
+      // change log (assume that the prerelease will be removed)
       console.log(
-        `bumping ${pkg} to ${packageFiles[pkg].version}-${previewVersion} to publish a preview`
+        `bumping ${pkg} with ${previewVersion} template to publish a preview`
       );
     packageFiles[pkg] = bumpMain({
       packageFile: packageFiles[pkg],
@@ -322,9 +323,10 @@ const bumpMain = ({
     pkg.versionPrerelease = semver.prerelease(next);
   }
   const prevVersion = getPackageFileVersion({ pkg });
+  const preVersionCleaned = semver.prerelease(prevVersion) ? semver.inc(prevVersion, 'patch') : prevVersion;
   let version =
     previewVersion && previewVersion !== ""
-      ? semver.valid(`${prevVersion}-${previewVersion}`)
+      ? semver.valid(`${preVersionCleaned}-${previewVersion}`)
       : // @ts-ignore TODO bumpType should be narrowed to meet ReleaseType
         semver.inc(prevVersion, bumpType, prereleaseIdentifier);
   if (version) {
@@ -364,9 +366,10 @@ const bumpDeps = ({
           Object.keys(pkg.pkg[property]).forEach((existingDep) => {
             if (existingDep === dep) {
               const prevVersion = getPackageFileVersion({ pkg, property, dep });
+              const preVersionCleaned = semver.prerelease(prevVersion) ? semver.inc(prevVersion, 'patch') : prevVersion;
               let version =
                 previewVersion && previewVersion !== ""
-                  ? semver.valid(`${prevVersion}-${previewVersion}`)
+                  ? semver.valid(`${preVersionCleaned}-${previewVersion}`)
                   : incConsideringPartials(
                       dep,
                       prevVersion,

--- a/packages/apply/test/__snapshots__/index.test.ts.snap
+++ b/packages/apply/test/__snapshots__/index.test.ts.snap
@@ -387,10 +387,10 @@ Object {
   "consoleDir": Array [],
   "consoleLog": Array [
     Array [
-      "bumping yarn-workspace-base-pkg-a to 1.0.0-branch-name.12345 to publish a preview",
+      "bumping yarn-workspace-base-pkg-a with branch-name.12345 template to publish a preview",
     ],
     Array [
-      "bumping yarn-workspace-base-pkg-b to 1.0.0-branch-name.12345 to publish a preview",
+      "bumping yarn-workspace-base-pkg-b with branch-name.12345 template to publish a preview",
     ],
   ],
 }
@@ -401,7 +401,32 @@ Object {
   "consoleDir": Array [],
   "consoleLog": Array [
     Array [
-      "bumping js-single-json-fixture to 0.5.9-branch-name.12345 to publish a preview",
+      "bumping js-single-json-fixture with branch-name.12345 template to publish a preview",
+    ],
+  ],
+}
+`;
+
+exports[`packge file applies preview bump to pre-release bumps multi js json without pre-release 1`] = `
+Object {
+  "consoleDir": Array [],
+  "consoleLog": Array [
+    Array [
+      "bumping yarn-workspace-base-pkg-a with branch-name.12345 template to publish a preview",
+    ],
+    Array [
+      "bumping yarn-workspace-base-pkg-b with branch-name.12345 template to publish a preview",
+    ],
+  ],
+}
+`;
+
+exports[`packge file applies preview bump to pre-release bumps single js json without pre-release 1`] = `
+Object {
+  "consoleDir": Array [],
+  "consoleLog": Array [
+    Array [
+      "bumping js-single-prerelease-json-fixture with branch-name.12345 template to publish a preview",
     ],
   ],
 }

--- a/packages/apply/test/__snapshots__/index.test.ts.snap
+++ b/packages/apply/test/__snapshots__/index.test.ts.snap
@@ -387,10 +387,10 @@ Object {
   "consoleDir": Array [],
   "consoleLog": Array [
     Array [
-      "bumping yarn-workspace-base-pkg-a with branch-name.12345 template to publish a preview",
+      "bumping yarn-workspace-base-pkg-a with branch-name.12345 identifier to publish a preview",
     ],
     Array [
-      "bumping yarn-workspace-base-pkg-b with branch-name.12345 template to publish a preview",
+      "bumping yarn-workspace-base-pkg-b with branch-name.12345 identifier to publish a preview",
     ],
   ],
 }
@@ -401,7 +401,7 @@ Object {
   "consoleDir": Array [],
   "consoleLog": Array [
     Array [
-      "bumping js-single-json-fixture with branch-name.12345 template to publish a preview",
+      "bumping js-single-json-fixture with branch-name.12345 identifier to publish a preview",
     ],
   ],
 }
@@ -412,10 +412,10 @@ Object {
   "consoleDir": Array [],
   "consoleLog": Array [
     Array [
-      "bumping yarn-workspace-base-pkg-a with branch-name.12345 template to publish a preview",
+      "bumping yarn-workspace-base-pkg-a with branch-name.12345 identifier to publish a preview",
     ],
     Array [
-      "bumping yarn-workspace-base-pkg-b with branch-name.12345 template to publish a preview",
+      "bumping yarn-workspace-base-pkg-b with branch-name.12345 identifier to publish a preview",
     ],
   ],
 }
@@ -426,7 +426,7 @@ Object {
   "consoleDir": Array [],
   "consoleLog": Array [
     Array [
-      "bumping js-single-prerelease-json-fixture with branch-name.12345 template to publish a preview",
+      "bumping js-single-prerelease-json-fixture with branch-name.12345 identifier to publish a preview",
     ],
   ],
 }

--- a/packages/apply/test/index.test.ts
+++ b/packages/apply/test/index.test.ts
@@ -1355,3 +1355,154 @@ describe("packge file applies preview bump", () => {
     }).toMatchSnapshot();
   });
 });
+
+describe("packge file applies preview bump to pre-release", () => {
+  let restoreConsole: RestoreConsole;
+  beforeEach(() => {
+    restoreConsole = mockConsole(["log", "dir"]);
+  });
+  afterEach(() => {
+    restoreConsole();
+  });
+
+  it("bumps single js json without pre-release", function* () {
+    const jsonFolder = f.copy("pkg.js-single-prerelease-json"); // 0.5.9-abc.2
+
+    const commands = [
+      {
+        dependencies: undefined,
+        manager: "javascript",
+        path: "./",
+        pkg: "js-single-prerelease-json-fixture",
+        type: "minor",
+        parents: [],
+      },
+    ];
+
+    const config = {
+      packages: {
+        "js-single-prerelease-json-fixture": {
+          path: "./",
+          manager: "javascript",
+        },
+      },
+    };
+
+    yield apply({
+      //@ts-ignore
+      commands,
+      config,
+      cwd: jsonFolder,
+      previewVersion: "branch-name.12345",
+    });
+    //@ts-ignore
+    const modifiedVFile = yield toVFile.read(
+      jsonFolder + "/package.json",
+      "utf-8"
+    );
+    expect(modifiedVFile.contents).toBe(
+      "{\n" +
+        '  "private": true,\n' +
+        '  "name": "js-single-prerelease-json-fixture",\n' +
+        '  "description": "A single package at the root. No monorepo setup.",\n' +
+        '  "version": "0.5.9-branch-name.12345"\n' +
+        "}\n"
+    );
+
+    expect({
+      //@ts-ignore
+      consoleLog: console.log.mock.calls,
+      //@ts-ignore
+      consoleDir: console.dir.mock.calls,
+    }).toMatchSnapshot();
+  });
+
+  it("bumps multi js json without pre-release", function* () {
+    const jsonFolder = f.copy("pkg.js-yarn-prerelease-workspace");
+
+    const commands = [
+      {
+        dependencies: ["yarn-workspace-base-pkg-b", "all"],
+        manager: "javascript",
+        path: "./",
+        pkg: "yarn-workspace-base-pkg-a",
+        type: "minor",
+        parents: [],
+      },
+      {
+        dependencies: undefined,
+        manager: "javascript",
+        path: undefined,
+        pkg: "yarn-workspace-base-pkg-b",
+        type: "minor",
+        parents: ["yarn-workspace-base-pkg-a"],
+      },
+      {
+        dependencies: undefined,
+        manager: "javascript",
+        path: undefined,
+        pkg: "all",
+        type: "minor",
+        parents: ["yarn-workspace-base-pkg-a", "yarn-workspace-base-pkg-b"],
+      },
+    ];
+
+    const config = {
+      packages: {
+        "yarn-workspace-base-pkg-a": {
+          path: "./packages/pkg-a/", // 1.0.0-abc.2
+          manager: "javascript",
+          dependencies: ["yarn-workspace-base-pkg-b", "all"],
+        },
+        "yarn-workspace-base-pkg-b": {
+          path: "./packages/pkg-b/", // 1.0.0-abc.3
+          manager: "javascript",
+          dependencies: ["all"],
+        },
+        all: { version: true },
+      },
+    };
+
+    yield apply({
+      //@ts-ignore
+      commands,
+      //@ts-ignore
+      config,
+      cwd: jsonFolder,
+      previewVersion: "branch-name.12345",
+    });
+    //@ts-ignore
+    const modifiedPkgAVFile = yield toVFile.read(
+      jsonFolder + "/packages/pkg-a/package.json",
+      "utf-8"
+    );
+    expect(modifiedPkgAVFile.contents).toBe(
+      "{\n" +
+        '  "name": "yarn-workspace-base-pkg-a",\n' +
+        '  "version": "1.0.0-branch-name.12345",\n' +
+        '  "dependencies": {\n' +
+        '    "yarn-workspace-base-pkg-b": "1.0.0-branch-name.12345"\n' +
+        "  }\n" +
+        "}\n"
+    );
+
+    //@ts-ignore
+    const modifiedPkgBVFile = yield toVFile.read(
+      jsonFolder + "/packages/pkg-b/package.json",
+      "utf-8"
+    );
+    expect(modifiedPkgBVFile.contents).toBe(
+      "{\n" +
+        '  "name": "yarn-workspace-base-pkg-b",\n' +
+        '  "version": "1.0.0-branch-name.12345"\n' +
+        "}\n"
+    );
+
+    expect({
+      //@ts-ignore
+      consoleLog: console.log.mock.calls,
+      //@ts-ignore
+      consoleDir: console.dir.mock.calls,
+    }).toMatchSnapshot();
+  });
+});

--- a/packages/covector/test/__snapshots__/index.test.ts.snap
+++ b/packages/covector/test/__snapshots__/index.test.ts.snap
@@ -1639,13 +1639,13 @@ Object {
   "consoleInfo": Array [],
   "consoleLog": Array [
     Array [
-      "bumping package-b with branch-name.12345 template to publish a preview",
+      "bumping package-b with branch-name.12345 identifier to publish a preview",
     ],
     Array [
-      "bumping package-a with branch-name.12345 template to publish a preview",
+      "bumping package-a with branch-name.12345 identifier to publish a preview",
     ],
     Array [
-      "bumping package-c with branch-name.12345 template to publish a preview",
+      "bumping package-c with branch-name.12345 identifier to publish a preview",
     ],
     Array [
       "package-a [prepublish]: echo prepublishing package-a would happen here",
@@ -1821,13 +1821,13 @@ Object {
   "consoleInfo": Array [],
   "consoleLog": Array [
     Array [
-      "bumping package-b with branch-name.12345 template to publish a preview",
+      "bumping package-b with branch-name.12345 identifier to publish a preview",
     ],
     Array [
-      "bumping package-a with branch-name.12345 template to publish a preview",
+      "bumping package-a with branch-name.12345 identifier to publish a preview",
     ],
     Array [
-      "bumping package-c with branch-name.12345 template to publish a preview",
+      "bumping package-c with branch-name.12345 identifier to publish a preview",
     ],
     Array [
       "package-a [prepublish]: echo prepublishing package-a would happen here",

--- a/packages/covector/test/__snapshots__/index.test.ts.snap
+++ b/packages/covector/test/__snapshots__/index.test.ts.snap
@@ -1639,13 +1639,13 @@ Object {
   "consoleInfo": Array [],
   "consoleLog": Array [
     Array [
-      "bumping package-b to 0.0.1-branch-name.12345 to publish a preview",
+      "bumping package-b with branch-name.12345 template to publish a preview",
     ],
     Array [
-      "bumping package-a to 0.0.1-branch-name.12345 to publish a preview",
+      "bumping package-a with branch-name.12345 template to publish a preview",
     ],
     Array [
-      "bumping package-c to 0.0.1-branch-name.12345 to publish a preview",
+      "bumping package-c with branch-name.12345 template to publish a preview",
     ],
     Array [
       "package-a [prepublish]: echo prepublishing package-a would happen here",
@@ -1821,13 +1821,13 @@ Object {
   "consoleInfo": Array [],
   "consoleLog": Array [
     Array [
-      "bumping package-b to 0.0.1-branch-name.12345 to publish a preview",
+      "bumping package-b with branch-name.12345 template to publish a preview",
     ],
     Array [
-      "bumping package-a to 0.0.1-branch-name.12345 to publish a preview",
+      "bumping package-a with branch-name.12345 template to publish a preview",
     ],
     Array [
-      "bumping package-c to 0.0.1-branch-name.12345 to publish a preview",
+      "bumping package-c with branch-name.12345 template to publish a preview",
     ],
     Array [
       "package-a [prepublish]: echo prepublishing package-a would happen here",


### PR DESCRIPTION
## Motivation

[This](https://github.com/thefrontside/material-ui-interactors/pull/36#issuecomment-866980082) discussion. The preview version will stack on top of a prerelease version so `1.0.0-beta.1` will turn into `1.0.0-beta.1-my-preview.12345`.

## Approach
```
publish preview ?
  in prerelease ?
    apply patch to revert prerelease (without actually bumping patch) and then apply preview version
  not prerelease ?
    just apply preview version
```