### PR TITLE
feat(changelog): enhance format for multi-line and reduce commit noise

### DIFF
--- a/.changes/changelog-multi-line-format.md
+++ b/.changes/changelog-multi-line-format.md
@@ -1,0 +1,7 @@
+---
+"@covector/changelog": minor
+"@covector/apply": minor
+"@covector/types": minor
+---
+
+Update the changelog format to fix multi-line change files and reduce commit noise. 

--- a/.changes/format.md
+++ b/.changes/format.md
@@ -1,0 +1,5 @@
+---
+"@covector/changelog": minor
+---
+
+Update the changelog format to fix multi-line change files and reduce commit noise. 

--- a/.changes/format.md
+++ b/.changes/format.md
@@ -1,5 +1,0 @@
----
-"@covector/changelog": minor
----
-
-Update the changelog format to fix multi-line change files and reduce commit noise. 

--- a/packages/action/test/__snapshots__/e2e.test.ts.snap
+++ b/packages/action/test/__snapshots__/e2e.test.ts.snap
@@ -2283,7 +2283,9 @@ Summary about the changes in tauri-updater
 
 Summary about the changes in tauri
 ",
-                    "dependencies": "Bumped due to a bump in tauri.",
+                    "dependencies": Array [
+                      "tauri",
+                    ],
                     "extname": ".md",
                     "filename": "first-change",
                     "path": ".changes/first-change.md",
@@ -2313,7 +2315,7 @@ Merging this PR will release new versions of the following packages based on you
 # tauri.js
 
 ## [0.6.3]
-- Summary about the changes in tauri
+- Bumped due to a bump in \`tauri\`
 
 
 

--- a/packages/apply/src/parents.ts
+++ b/packages/apply/src/parents.ts
@@ -112,12 +112,12 @@ const parentBump = ({
               // this ends up overwriting in cases multiple bumps,
               //   we should adjust this to accept multiple
               if (
-                parentChange.meta.dependencies === "" ||
-                !parentChange.meta.dependencies
+                !parentChange.meta.dependencies ||
+                parentChange.meta.dependencies.length === 0
               ) {
-                parentChange.meta.dependencies = `Bumped due to a bump in ${main}.`;
+                parentChange.meta.dependencies = [main];
               } else {
-                parentChange.meta.dependencies = `${parentChange.meta.dependencies}\n    - Bumped due to a bump in ${main}.`;
+                parentChange.meta.dependencies.push(main);
               }
             });
           }

--- a/packages/apply/test/__snapshots__/changes-considering.test.ts.snap
+++ b/packages/apply/test/__snapshots__/changes-considering.test.ts.snap
@@ -91,7 +91,9 @@ Object {
         "changes": Array [
           Object {
             "meta": Object {
-              "dependencies": "Bumped due to a bump in pkg-c.",
+              "dependencies": Array [
+                "pkg-c",
+              ],
             },
             "releases": Object {
               "pkg-c": "patch",
@@ -204,7 +206,9 @@ Object {
         "changes": Array [
           Object {
             "meta": Object {
-              "dependencies": "Bumped due to a bump in pkg-d.",
+              "dependencies": Array [
+                "pkg-d",
+              ],
             },
             "releases": Object {
               "pkg-c": "patch",
@@ -229,10 +233,12 @@ Object {
         "changes": Array [
           Object {
             "meta": Object {
-              "dependencies": "Bumped due to a bump in pkg-d.
-    - Bumped due to a bump in pkg-four.
-    - Bumped due to a bump in pkg-three.
-    - Bumped due to a bump in pkg-two.",
+              "dependencies": Array [
+                "pkg-d",
+                "pkg-four",
+                "pkg-three",
+                "pkg-two",
+              ],
             },
             "releases": Object {
               "pkg-c": "patch",
@@ -248,7 +254,9 @@ Object {
         "changes": Array [
           Object {
             "meta": Object {
-              "dependencies": "Bumped due to a bump in pkg-b.",
+              "dependencies": Array [
+                "pkg-b",
+              ],
             },
             "releases": Object {
               "pkg-b": "minor",
@@ -263,8 +271,10 @@ Object {
         "changes": Array [
           Object {
             "meta": Object {
-              "dependencies": "Bumped due to a bump in pkg-d.
-    - Bumped due to a bump in pkg-four.",
+              "dependencies": Array [
+                "pkg-d",
+                "pkg-four",
+              ],
             },
             "releases": Object {
               "pkg-c": "patch",
@@ -289,9 +299,11 @@ Object {
         "changes": Array [
           Object {
             "meta": Object {
-              "dependencies": "Bumped due to a bump in pkg-d.
-    - Bumped due to a bump in pkg-four.
-    - Bumped due to a bump in pkg-three.",
+              "dependencies": Array [
+                "pkg-d",
+                "pkg-four",
+                "pkg-three",
+              ],
             },
             "releases": Object {
               "pkg-c": "patch",

--- a/packages/changelog/test/fill-changelog.test.ts
+++ b/packages/changelog/test/fill-changelog.test.ts
@@ -178,12 +178,9 @@ describe("fills changelog", () => {
     expect(changelog.content).toBe(
       "# Changelog\n\n" +
         "## \\[0.5.6]\n\n" +
-        "- This is a test.\n" +
-        "  - [3ca0504](/commit/3ca05042c51821d229209e18391535c266b6b200) feat: advanced commands, closes [#43](/pull/43) ([#719999](/pull/719999)) on 2020-07-06\n" +
-        "- This is another test.\n" +
-        "  - [3ca0504](/commit/3ca05042c51821d229209e18391535c266b6b200) feat: advanced commands, closes [#23](/pull/23) ([#123](/pull/123)) on 2020-07-06\n" +
-        "- This is the last test.\n" +
-        "  - [3ca0504](/commit/3ca05042c51821d229209e18391535c266b6b200) feat: advanced commands, closes [#9](/pull/9) ([#8873](/pull/8873)) on 2020-07-06\n"
+        "- [`3ca0504`](/commit/3ca05042c51821d229209e18391535c266b6b200)([#43](/pull/43)) This is a test.\n" +
+        "- [`3ca0504`](/commit/3ca05042c51821d229209e18391535c266b6b200)([#23](/pull/23)) This is another test.\n"+
+        "- [`3ca0504`](/commit/3ca05042c51821d229209e18391535c266b6b200)([#9](/pull/9)) This is the last test.\n"
     );
   });
 

--- a/packages/changelog/test/read-changelog.test.ts
+++ b/packages/changelog/test/read-changelog.test.ts
@@ -130,12 +130,9 @@ describe("reads changelog", () => {
     });
     expect(pkgCommandsRan[pkgName].command).toBe(
       "## \\[0.5.6]\n\n" +
-        "- This is a test.\n" +
-        "  - [3ca0504](/commit/3ca05042c51821d229209e18391535c266b6b200) feat: advanced commands, closes [#43](/pull/43) ([#719999](/pull/719999)) on 2020-07-06\n" +
-        "- This is another test.\n" +
-        "  - [3ca0504](/commit/3ca05042c51821d229209e18391535c266b6b200) feat: advanced commands, closes [#23](/pull/23) ([#123](/pull/123)) on 2020-07-06\n" +
-        "- This is the last test.\n" +
-        "  - [3ca0504](/commit/3ca05042c51821d229209e18391535c266b6b200) feat: advanced commands, closes [#9](/pull/9) ([#8873](/pull/8873)) on 2020-07-06\n"
+        "- [`3ca0504`](/commit/3ca05042c51821d229209e18391535c266b6b200)([#43](/pull/43)) This is a test.\n" +
+        "- [`3ca0504`](/commit/3ca05042c51821d229209e18391535c266b6b200)([#23](/pull/23)) This is another test.\n" +
+        "- [`3ca0504`](/commit/3ca05042c51821d229209e18391535c266b6b200)([#9](/pull/9)) This is the last test.\n"
     );
   });
 

--- a/packages/command/test/sh.test.ts
+++ b/packages/command/test/sh.test.ts
@@ -33,7 +33,7 @@ Usage:
     it("shell opted in", function* () {
       const { out } = yield sh("echo this thing", { shell: true }, false);
       expect(out).toBe("this thing");
-    });
+    }, 6000); // increase timeout to 60s, windows seems to take forever
 
     it("defines bash as shell", function* () {
       const { out } = yield sh("echo this thing", { shell: "bash" }, false);
@@ -144,7 +144,7 @@ Usage:
         expect(result.message).toBe(
           "spawn echo this thing | echo but actually this ENOENT"
         );
-      });
+      }, 6000); // increase timeout to 60s, windows seems to take forever
     });
   }
 });

--- a/packages/covector/test/__snapshots__/dry-run.test.ts.snap
+++ b/packages/covector/test/__snapshots__/dry-run.test.ts.snap
@@ -536,7 +536,9 @@ Summary about the changes in tauri-updater
 
 Summary about the changes in tauri
 ",
-                  "dependencies": "Bumped due to a bump in tauri.",
+                  "dependencies": Array [
+                    "tauri",
+                  ],
                   "extname": ".md",
                   "filename": "first-change",
                   "path": ".changes/first-change.md",
@@ -14388,7 +14390,9 @@ Summary about the changes in tauri-updater
 
 Summary about the changes in tauri
 ",
-                  "dependencies": "Bumped due to a bump in tauri.",
+                  "dependencies": Array [
+                    "tauri",
+                  ],
                   "extname": ".md",
                   "filename": "first-change",
                   "path": ".changes/first-change.md",
@@ -15486,7 +15490,7 @@ thiserror = \\"1.0.19\\"
             "versionPrerelease": null,
           },
           "command": "## [0.6.3]
-- Summary about the changes in tauri",
+- Bumped due to a bump in \`tauri\`",
           "postcommand": false,
           "precommand": false,
         },
@@ -17019,7 +17023,7 @@ thiserror = \\"1.0.19\\"
           "versionPrerelease": null,
         },
         "command": "## [0.6.3]
-- Summary about the changes in tauri",
+- Bumped due to a bump in \`tauri\`",
         "postcommand": false,
         "precommand": false,
       },
@@ -17497,7 +17501,9 @@ Summary about the changes in tauri-updater
 
 Summary about the changes in tauri
 ",
-                  "dependencies": "Bumped due to a bump in tauri.",
+                  "dependencies": Array [
+                    "tauri",
+                  ],
                   "extname": ".md",
                   "filename": "first-change",
                   "path": ".changes/first-change.md",

--- a/packages/covector/test/__snapshots__/main.test.ts.snap
+++ b/packages/covector/test/__snapshots__/main.test.ts.snap
@@ -63,7 +63,8 @@ Array [
     "tauri-bundler [publish run from the cwd]: ls",
   ],
   Array [
-    "cli
+    ".changes
+cli
 tauri
 tauri-api
 tauri-updater
@@ -94,7 +95,8 @@ tauri-utils",
     "tauri-api [publish run from the cwd]: ls",
   ],
   Array [
-    "cli
+    ".changes
+cli
 tauri
 tauri-api
 tauri-updater
@@ -125,7 +127,8 @@ tauri-utils",
     "tauri-utils [publish run from the cwd]: ls",
   ],
   Array [
-    "cli
+    ".changes
+cli
 tauri
 tauri-api
 tauri-updater
@@ -2829,7 +2832,8 @@ Object {
       "tauri-bundler [publish run from the cwd]: ls",
     ],
     Array [
-      "cli
+      ".changes
+cli
 tauri
 tauri-api
 tauri-updater
@@ -2857,7 +2861,8 @@ tauri-utils",
       "tauri-api [publish run from the cwd]: ls",
     ],
     Array [
-      "cli
+      ".changes
+cli
 tauri
 tauri-api
 tauri-updater
@@ -2885,7 +2890,8 @@ tauri-utils",
       "tauri-utils [publish run from the cwd]: ls",
     ],
     Array [
-      "cli
+      ".changes
+cli
 tauri
 tauri-api
 tauri-updater
@@ -6125,7 +6131,7 @@ flutter:
           "versionPrerelease": null,
         },
         "command": "## [0.3.2]
-- Summary about the changes in test_app_two",
+- Bumped due to a bump in \`test_app_two\`",
         "postcommand": false,
         "precommand": false,
       },
@@ -6325,7 +6331,9 @@ flutter:
 
 Summary about the changes in test_app_two
 ",
-                  "dependencies": "Bumped due to a bump in test_app_two.",
+                  "dependencies": Array [
+                    "test_app_two",
+                  ],
                   "extname": ".md",
                   "filename": "first-change",
                   "path": ".changes/first-change.md",
@@ -7880,7 +7888,7 @@ thiserror = \\"1.0.19\\"
           "versionPrerelease": null,
         },
         "command": "## [0.6.3]
-- Summary about the changes in tauri",
+- Bumped due to a bump in \`tauri\`",
         "postcommand": false,
         "precommand": false,
       },
@@ -8358,7 +8366,9 @@ Summary about the changes in tauri-updater
 
 Summary about the changes in tauri
 ",
-                  "dependencies": "Bumped due to a bump in tauri.",
+                  "dependencies": Array [
+                    "tauri",
+                  ],
                   "extname": ".md",
                   "filename": "first-change",
                   "path": ".changes/first-change.md",
@@ -8454,7 +8464,8 @@ Array [
     "tauri-bundler [publish run from the cwd]: ls",
   ],
   Array [
-    "cli
+    ".changes
+cli
 tauri
 tauri-api
 tauri-updater
@@ -8488,7 +8499,8 @@ tauri-utils",
     "tauri-api [publish run from the cwd]: ls",
   ],
   Array [
-    "cli
+    ".changes
+cli
 tauri
 tauri-api
 tauri-updater
@@ -8522,7 +8534,8 @@ tauri-utils",
     "tauri-utils [publish run from the cwd]: ls",
   ],
   Array [
-    "cli
+    ".changes
+cli
 tauri
 tauri-api
 tauri-updater

--- a/packages/covector/test/__snapshots__/main.test.ts.snap
+++ b/packages/covector/test/__snapshots__/main.test.ts.snap
@@ -63,8 +63,7 @@ Array [
     "tauri-bundler [publish run from the cwd]: ls",
   ],
   Array [
-    ".changes
-cli
+    "cli
 tauri
 tauri-api
 tauri-updater
@@ -95,8 +94,7 @@ tauri-utils",
     "tauri-api [publish run from the cwd]: ls",
   ],
   Array [
-    ".changes
-cli
+    "cli
 tauri
 tauri-api
 tauri-updater
@@ -127,8 +125,7 @@ tauri-utils",
     "tauri-utils [publish run from the cwd]: ls",
   ],
   Array [
-    ".changes
-cli
+    "cli
 tauri
 tauri-api
 tauri-updater
@@ -2832,8 +2829,7 @@ Object {
       "tauri-bundler [publish run from the cwd]: ls",
     ],
     Array [
-      ".changes
-cli
+      "cli
 tauri
 tauri-api
 tauri-updater
@@ -2861,8 +2857,7 @@ tauri-utils",
       "tauri-api [publish run from the cwd]: ls",
     ],
     Array [
-      ".changes
-cli
+      "cli
 tauri
 tauri-api
 tauri-updater
@@ -2890,8 +2885,7 @@ tauri-utils",
       "tauri-utils [publish run from the cwd]: ls",
     ],
     Array [
-      ".changes
-cli
+      "cli
 tauri
 tauri-api
 tauri-updater
@@ -8464,8 +8458,7 @@ Array [
     "tauri-bundler [publish run from the cwd]: ls",
   ],
   Array [
-    ".changes
-cli
+    "cli
 tauri
 tauri-api
 tauri-updater
@@ -8499,8 +8492,7 @@ tauri-utils",
     "tauri-api [publish run from the cwd]: ls",
   ],
   Array [
-    ".changes
-cli
+    "cli
 tauri
 tauri-api
 tauri-updater
@@ -8534,8 +8526,7 @@ tauri-utils",
     "tauri-utils [publish run from the cwd]: ls",
   ],
   Array [
-    ".changes
-cli
+    "cli
 tauri
 tauri-api
 tauri-updater

--- a/packages/covector/test/__snapshots__/preMode.test.ts.snap
+++ b/packages/covector/test/__snapshots__/preMode.test.ts.snap
@@ -488,7 +488,9 @@ Summary about the changes in tauri-updater
 
 Summary about the changes in tauri
 ",
-                  "dependencies": "Bumped due to a bump in tauri.",
+                  "dependencies": Array [
+                    "tauri",
+                  ],
                   "extname": ".md",
                   "filename": "first-change",
                   "path": ".changes/first-change.md",
@@ -1595,7 +1597,7 @@ thiserror = \\"1.0.19\\"
             ],
           },
           "command": "## [0.6.3-beta.0]
-- Summary about the changes in tauri",
+- Bumped due to a bump in \`tauri\`",
           "postcommand": false,
           "precommand": false,
         },
@@ -3137,7 +3139,7 @@ thiserror = \\"1.0.19\\"
           ],
         },
         "command": "## [0.6.3-beta.0]
-- Summary about the changes in tauri",
+- Bumped due to a bump in \`tauri\`",
         "postcommand": false,
         "precommand": false,
       },
@@ -3615,7 +3617,9 @@ Summary about the changes in tauri-updater
 
 Summary about the changes in tauri
 ",
-                  "dependencies": "Bumped due to a bump in tauri.",
+                  "dependencies": Array [
+                    "tauri",
+                  ],
                   "extname": ".md",
                   "filename": "first-change",
                   "path": ".changes/first-change.md",
@@ -4742,7 +4746,7 @@ thiserror = \\"1.0.19\\"
           ],
         },
         "command": "## [0.6.3-beta.0]
-- Summary about the changes in tauri",
+- Bumped due to a bump in \`tauri\`",
         "postcommand": false,
         "precommand": false,
       },
@@ -5220,7 +5224,9 @@ Summary about the changes in tauri-updater
 
 Summary about the changes in tauri
 ",
-                  "dependencies": "Bumped due to a bump in tauri.",
+                  "dependencies": Array [
+                    "tauri",
+                  ],
                   "extname": ".md",
                   "filename": "first-change",
                   "path": ".changes/first-change.md",
@@ -6359,7 +6365,7 @@ thiserror = \\"1.0.19\\"
           ],
         },
         "command": "## [0.6.3-beta.0]
-- Summary about the changes in tauri",
+- Bumped due to a bump in \`tauri\`",
         "postcommand": false,
         "precommand": false,
       },
@@ -6837,7 +6843,9 @@ Summary about the changes in tauri-updater
 
 Summary about the changes in tauri
 ",
-                  "dependencies": "Bumped due to a bump in tauri.",
+                  "dependencies": Array [
+                    "tauri",
+                  ],
                   "extname": ".md",
                   "filename": "first-change",
                   "path": ".changes/first-change.md",
@@ -7171,7 +7179,7 @@ path = \\"examples/communication/src-tauri/src/main.rs\\"
           ],
         },
         "command": "## [0.6.0-beta.1]
-- Boop again.",
+- Bumped due to a bump in \`tauri-api\`",
         "postcommand": false,
         "precommand": false,
       },
@@ -8046,7 +8054,8 @@ totems = \\"0.2.7\\"",
           ],
         },
         "command": "## [0.6.3-beta.1]
-- Boop again.",
+- Bumped due to a bump in \`tauri-api\`
+- Bumped due to a bump in \`tauri\`",
         "postcommand": false,
         "precommand": false,
       },
@@ -8077,7 +8086,9 @@ totems = \\"0.2.7\\"",
 
 Boop again.
 ",
-                  "dependencies": "Bumped due to a bump in tauri-api.",
+                  "dependencies": Array [
+                    "tauri-api",
+                  ],
                   "extname": ".md",
                   "filename": "third-change",
                   "path": ".changes/third-change.md",
@@ -8641,8 +8652,10 @@ Boop again.
 
 Boop again.
 ",
-                  "dependencies": "Bumped due to a bump in tauri-api.
-    - Bumped due to a bump in tauri.",
+                  "dependencies": Array [
+                    "tauri-api",
+                    "tauri",
+                  ],
                   "extname": ".md",
                   "filename": "third-change",
                   "path": ".changes/third-change.md",

--- a/packages/covector/test/main.test.ts
+++ b/packages/covector/test/main.test.ts
@@ -77,7 +77,7 @@ describe("integration test in production mode", () => {
     expect(changelogTaurijs.content).toBe(
       "# Changelog\n\n" +
         "## \\[0.6.3]\n\n" +
-        "- Summary about the changes in tauri\n"
+        "- Bumped due to a bump in `tauri`\n"
     );
   });
 
@@ -130,7 +130,7 @@ describe("integration test in production mode", () => {
     expect(changelog.content).toBe(
       "# Changelog\n\n" +
         "## \\[0.3.2]\n\n" +
-        "- Summary about the changes in test_app_two\n"
+        "- Bumped due to a bump in `test_app_two`\n"
     );
 
     const versionFile = yield loadFile(

--- a/packages/covector/test/main.test.ts
+++ b/packages/covector/test/main.test.ts
@@ -179,7 +179,7 @@ describe("integration test in production mode", () => {
       consoleInfo: (console.info as any).mock.calls,
       covectorReturn: covectored,
     }).toMatchSnapshot();
-  });
+  }, 6000); // increase timeout to 60s, windows seems to take forever
 
   it("runs publish for dart / flutter", function* () {
     const fullIntegration = f.copy("integration.dart-flutter-single");
@@ -327,7 +327,7 @@ describe("integration test in production mode", () => {
       modifyConfig,
     });
     expect((console.log as any).mock.calls).toMatchSnapshot();
-  });
+  }, 6000); // increase timeout to 60s, windows seems to take forever
 
   it("uses the action config modification", function* () {
     const fullIntegration = f.copy("integration.js-and-rust-with-changes");

--- a/packages/covector/test/preMode.test.ts
+++ b/packages/covector/test/preMode.test.ts
@@ -64,7 +64,7 @@ describe("integration test with preMode `on`", () => {
     expect(changelogTaurijs.content).toBe(
       "# Changelog\n\n" +
         "## \\[0.6.3-beta.0]\n\n" +
-        "- Summary about the changes in tauri\n"
+        "- Bumped due to a bump in `tauri`\n"
     );
   });
 
@@ -96,7 +96,7 @@ describe("integration test with preMode `on`", () => {
     expect(changelogTaurijsOne.content).toBe(
       "# Changelog\n\n" +
         "## \\[0.6.3-beta.0]\n\n" +
-        "- Summary about the changes in tauri\n"
+        "- Bumped due to a bump in `tauri`\n"
     );
 
     const preOne = yield loadFile(
@@ -139,7 +139,7 @@ Boop again.
     expect(changelogTauriCoreTwo.content).toBe(
       "# Changelog\n\n" +
         "## \\[0.6.0-beta.1]\n\n" +
-        "- Boop again.\n" +
+        "- Bumped due to a bump in `tauri-api`\n" +
         "\n" +
         "## \\[0.6.0-beta.0]\n\n" +
         "- Summary about the changes in tauri\n"
@@ -154,10 +154,11 @@ Boop again.
     expect(changelogTaurijsTwo.content).toBe(
       "# Changelog\n\n" +
         "## \\[0.6.3-beta.1]\n\n" +
-        "- Boop again.\n" +
+        "- Bumped due to a bump in `tauri-api`\n" +
+        "- Bumped due to a bump in `tauri`\n" +
         "\n" +
         "## \\[0.6.3-beta.0]\n\n" +
-        "- Summary about the changes in tauri\n"
+        "- Bumped due to a bump in `tauri`\n"
     );
 
     const preTwo = yield loadFile(

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -112,7 +112,7 @@ export type PkgCommandResponse = {
 };
 
 export type Meta = {
-  dependencies: { [k: string]: string }[];
+  dependencies: string[];
   commits?: {
     filename: string;
     hashShort: string;
@@ -209,7 +209,7 @@ export type PipePublishTemplate = {
 export type ChangeParsed = {
   releases: { [k: string]: string };
   summary: string;
-  meta: { dependencies: string };
+  meta: { dependencies: string[] };
 };
 
 export type Changed = Record<


### PR DESCRIPTION
## Motivation

<!-- REQUIRED
  Why are you introducing this change? Why is this change necessary? What
  are you trying to achieve with this change?
  If you have a relevant issue, add a link directly to the URL here.
 -->

Current changelogs are cluttered with commits noise, and restricted to single-line changelogs

## Approach

<!-- REQUIRED
  How does this change fulfill the purpose? Keep it high level. Avoid code-splaining.
-->

1. Indent multi-line changelogs so it renders correctly under its bullet point (done)
2. Reduce the commit noise to only the short commit hash and the PR it was introduce in (done)
3. Group changelogs of dependencies under one bullet-point for each dependency (having a bit trouble with, explained below)

## Screenshots

Ultimately a changelog could look like the following:

- Fix a bug in this package
- Add a feature to this package but needs to be explained in
  multiple paragraphs
  
  This could also include 
  ```
  code blocks
  ```
  
  and also lists:
  - a1
    ```
    run this cmd
    ```
  - a2
  - a3
- Fix another bug in this package
- <details>
  <summary>Bumped due to a bump in `package-utils` </summary>
  
  - A fix in package-utils
  - A feature in package-utils
  - A multi-line feature
    in package-utils
    
    because why not?
  - Performance gains
  </details>
- <details>
  <summary>Bumped due to a bump in `package-macros` </summary>
  
  - A fix in package-macros
  - A feature in package-macros
  - A multi-line feature
    in package-macros
    
    because why not?
  - Performance gains
  </details>
