### PR TITLE
chore(action): Update actions/core and actions/github dependencies

### DIFF
--- a/.changes/deprecation-github-output.md
+++ b/.changes/deprecation-github-output.md
@@ -1,0 +1,5 @@
+---
+"action": patch
+---
+
+Update `@actions/core` and `@actions/github` to remove deprecation warnings.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5641,8 +5641,8 @@
       "version": "0.7.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@actions/core": "^1.6.0",
-        "@actions/github": "^5.0.1",
+        "@actions/core": "^1.10.0",
+        "@actions/github": "^5.1.1",
         "effection": "^2.0.6"
       },
       "devDependencies": {
@@ -7139,8 +7139,8 @@
     "action": {
       "version": "file:packages/action",
       "requires": {
-        "@actions/core": "^1.6.0",
-        "@actions/github": "^5.0.1",
+        "@actions/core": "^1.10.0",
+        "@actions/github": "^5.1.1",
         "@covector/types": "^0.0.0",
         "@vercel/ncc": "^0.36.0",
         "effection": "^2.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,30 +23,31 @@
       }
     },
     "node_modules/@actions/core": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.6.0.tgz",
-      "integrity": "sha512-NB1UAZomZlCV/LmJqkLhNTqtKfFXJZAUPcfl/zqG7EfsQdeUJtaWO98SGbuQ3pydJ3fHl2CvI/51OKYlCYYcaw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
       "dependencies": {
-        "@actions/http-client": "^1.0.11"
+        "@actions/http-client": "^2.0.1",
+        "uuid": "^8.3.2"
       }
     },
     "node_modules/@actions/github": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@actions/github/-/github-5.0.1.tgz",
-      "integrity": "sha512-JZGyPM9ektb8NVTTI/2gfJ9DL7Rk98tQ7OVyTlgTuaQroariRBsOnzjy0I2EarX4xUZpK88YyO503fhmjFdyAg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/github/-/github-5.1.1.tgz",
+      "integrity": "sha512-Nk59rMDoJaV+mHCOJPXuvB1zIbomlKS0dmSIqPGxd0enAXBnOfn4VWF+CGtRCwXZG9Epa54tZA7VIRlJDS8A6g==",
       "dependencies": {
-        "@actions/http-client": "^1.0.11",
+        "@actions/http-client": "^2.0.1",
         "@octokit/core": "^3.6.0",
         "@octokit/plugin-paginate-rest": "^2.17.0",
         "@octokit/plugin-rest-endpoint-methods": "^5.13.0"
       }
     },
     "node_modules/@actions/http-client": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.11.tgz",
-      "integrity": "sha512-VRYHGQV1rqnROJqdMvGUbY/Kn8vriQe/F9HR2AlYHzmKuM/p3kjNuXhmdBfcVgsvRWTz5C5XW5xvndZrVBuAYg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.0.1.tgz",
+      "integrity": "sha512-PIXiMVtz6VvyaRsGY268qvj57hXQEpsYogYOu2nrQhlf+XCGmZstmuZBbAybUl1nQGnvS1k1eEsQ69ZoD7xlSw==",
       "dependencies": {
-        "tunnel": "0.0.6"
+        "tunnel": "^0.0.6"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -5423,6 +5424,14 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/v8-to-istanbul": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-8.1.1.tgz",
@@ -6413,30 +6422,31 @@
   },
   "dependencies": {
     "@actions/core": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.6.0.tgz",
-      "integrity": "sha512-NB1UAZomZlCV/LmJqkLhNTqtKfFXJZAUPcfl/zqG7EfsQdeUJtaWO98SGbuQ3pydJ3fHl2CvI/51OKYlCYYcaw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
       "requires": {
-        "@actions/http-client": "^1.0.11"
+        "@actions/http-client": "^2.0.1",
+        "uuid": "^8.3.2"
       }
     },
     "@actions/github": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@actions/github/-/github-5.0.1.tgz",
-      "integrity": "sha512-JZGyPM9ektb8NVTTI/2gfJ9DL7Rk98tQ7OVyTlgTuaQroariRBsOnzjy0I2EarX4xUZpK88YyO503fhmjFdyAg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/github/-/github-5.1.1.tgz",
+      "integrity": "sha512-Nk59rMDoJaV+mHCOJPXuvB1zIbomlKS0dmSIqPGxd0enAXBnOfn4VWF+CGtRCwXZG9Epa54tZA7VIRlJDS8A6g==",
       "requires": {
-        "@actions/http-client": "^1.0.11",
+        "@actions/http-client": "^2.0.1",
         "@octokit/core": "^3.6.0",
         "@octokit/plugin-paginate-rest": "^2.17.0",
         "@octokit/plugin-rest-endpoint-methods": "^5.13.0"
       }
     },
     "@actions/http-client": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.11.tgz",
-      "integrity": "sha512-VRYHGQV1rqnROJqdMvGUbY/Kn8vriQe/F9HR2AlYHzmKuM/p3kjNuXhmdBfcVgsvRWTz5C5XW5xvndZrVBuAYg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.0.1.tgz",
+      "integrity": "sha512-PIXiMVtz6VvyaRsGY268qvj57hXQEpsYogYOu2nrQhlf+XCGmZstmuZBbAybUl1nQGnvS1k1eEsQ69ZoD7xlSw==",
       "requires": {
-        "tunnel": "0.0.6"
+        "tunnel": "^0.0.6"
       }
     },
     "@ampproject/remapping": {
@@ -11149,6 +11159,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-to-istanbul": {
       "version": "8.1.1",

--- a/packages/action/package.json
+++ b/packages/action/package.json
@@ -12,8 +12,8 @@
     "clean": "echo noop"
   },
   "dependencies": {
-    "@actions/core": "^1.6.0",
-    "@actions/github": "^5.0.1",
+    "@actions/core": "^1.10.0",
+    "@actions/github": "^5.1.1",
     "effection": "^2.0.6"
   },
   "devDependencies": {


### PR DESCRIPTION
## Motivation

Updates [`@actions/core`](https://github.com/actions/toolkit/tree/main/packages/core) to 1.10.0 and [`@actions/github`](https://github.com/actions/toolkit/tree/main/packages/github) to 5.1.1. The `@actions/core` update resolves [deprecation warnings](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) coming from calls to `core.setOutput()`, which will be removed in June 2023.

## Approach

Updates dependencies

### Possible Drawbacks or Risks

N/A

### TODOs and Open Questions

- [ ] Rebuild the action dist (I can do this if you prefer)
