### PR TITLE
dep bumps use main version directly vs presuming increment is correct

### DIFF
--- a/.changes/dep-bump-from-main.md
+++ b/.changes/dep-bump-from-main.md
@@ -1,0 +1,5 @@
+---
+"@covector/apply": minor
+---
+
+The dependency bumps will now use the version of the next version of the package as derived from the existing change files. Previously it presumed that a dependency bump was sufficient.

--- a/.changes/dep-bump-from-main.md
+++ b/.changes/dep-bump-from-main.md
@@ -2,4 +2,4 @@
 "@covector/apply": minor
 ---
 
-The dependency bumps will now use the version of the next version of the package as derived from the existing change files. Previously it presumed that a dependency bump was sufficient.
+The dependency bumps will now use the next version of the package as derived from the existing change files. Previously, it presumed that a applying a dependency bump was sufficient which worked most of the time, but ignored some edge cases.

--- a/packages/apply/src/index.ts
+++ b/packages/apply/src/index.ts
@@ -1,4 +1,4 @@
-import { all } from "effection";
+import { all, Operation } from "effection";
 import {
   readPkgFile,
   writePkgFile,
@@ -24,15 +24,15 @@ export function* apply({
   cwd = process.cwd(),
   bump = true,
   previewVersion = "",
-  prereleaseIdentifier = null,
+  prereleaseIdentifier,
 }: {
   commands: PackageCommand[];
   config: ConfigFile;
   cwd: string;
   bump: boolean;
   previewVersion: string;
-  prereleaseIdentifier: string | null;
-}): Generator<any, PackageFile[], any> {
+  prereleaseIdentifier?: string;
+}): Operation<PackageFile[]> {
   const changes = commands.reduce(
     (finalChanges: { [k: string]: PackageCommand }, command) => {
       finalChanges[command.pkg] = command;
@@ -41,7 +41,6 @@ export function* apply({
     {}
   );
 
-  // @ts-ignore since TS doesn't like yielding on a Promise
   let allPackages = yield readAll({ changes, config, cwd });
   const bumps = bumpAll({
     changes,
@@ -71,13 +70,13 @@ export function* validateApply({
   commands,
   config,
   cwd = process.cwd(),
-  prereleaseIdentifier = null,
+  prereleaseIdentifier,
 }: {
   commands: PackageCommand[];
   config: ConfigFile;
   cwd: string;
-  prereleaseIdentifier: string | null;
-}): Generator<any, true | Error, any> {
+  prereleaseIdentifier?: string;
+}): Operation<true | Error> {
   const changes = commands.reduce(
     (finalChanges: { [k: string]: PackageCommand }, command) => {
       finalChanges[command.pkg] = command;
@@ -117,7 +116,7 @@ function* readAll({
   changes: { [k: string]: { parents: string[] } };
   config: ConfigFile;
   cwd: string;
-}): Generator<any, { [k: string]: PackageFile }, any> {
+}): Operation<{ [k: string]: PackageFile }> {
   let templateShell: PackageFile = {
     version: "",
     pkg: { name: "", version: "" },
@@ -139,13 +138,13 @@ function* readAll({
     Object.keys(files).map((pkg) =>
       !config.packages[pkg].path
         ? function* () {
-          return { name: pkg };
-        }
+            return { name: pkg };
+          }
         : readPkgFile({
-          cwd,
-          pkgConfig: config.packages[pkg],
-          nickname: pkg,
-        })
+            cwd,
+            pkgConfig: config.packages[pkg],
+            nickname: pkg,
+          })
     )
   );
 
@@ -194,14 +193,14 @@ type Changed = {
 export const changesConsideringParents = ({
   assembledChanges,
   config,
-  prereleaseIdentifier = null,
+  prereleaseIdentifier,
 }: {
   assembledChanges: {
     releases: Releases;
     changes: ChangeParsed[];
   };
   config: ConfigFile;
-  prereleaseIdentifier: string | null;
+  prereleaseIdentifier?: string;
 }) => {
   const parents = resolveParents({ config });
 
@@ -223,7 +222,7 @@ export const changesConsideringParents = ({
 const parentBump = (
   initialChanges: Changed,
   parents: any,
-  prereleaseIdentifier: string | null
+  prereleaseIdentifier?: string
 ): Changed => {
   let changes = { ...initialChanges };
   let recurse = false;
@@ -263,24 +262,32 @@ const bumpAll = ({
   allPackages,
   logs = true,
   previewVersion = "",
-  prereleaseIdentifier = null,
+  prereleaseIdentifier,
 }: {
   changes: Releases;
-  allPackages: { [k: string]: PackageFile };
+  allPackages: Record<string, PackageFile>;
   logs?: boolean;
   previewVersion?: string;
-  prereleaseIdentifier: string | null;
+  prereleaseIdentifier?: string;
 }) => {
+  // spread so that we can mutate
   let packageFiles = { ...allPackages };
+
+  // loop through all packages and bump the main version for each
+  //
   for (let pkg of Object.keys(changes)) {
     if (!packageFiles[pkg].file || changes[pkg].type === "noop") continue;
-    if (logs && !previewVersion)
+
+    if (logs && !previewVersion) {
       console.log(`bumping ${pkg} with ${changes[pkg].type}`);
-    if (previewVersion)
+    } else if (previewVersion) {
       // change log (assume that the prerelease will be removed)
       console.log(
         `bumping ${pkg} with ${previewVersion} identifier to publish a preview`
       );
+    }
+
+    // bump the package's version number
     packageFiles[pkg] = bumpMain({
       packageFile: packageFiles[pkg],
       bumpType: changes[pkg].type,
@@ -288,16 +295,20 @@ const bumpAll = ({
       prereleaseIdentifier,
       errorOnVersionRange: changes[pkg].errorOnVersionRange,
     });
-    if (changes[pkg] && changes[pkg].dependencies) {
-      let deps = changes[pkg].dependencies!;
+  }
+
+  for (let pkg of Object.keys(changes)) {
+    // bump any deps that are in the monorepo
+    // and have a version bump as well
+    if (changes?.[pkg]?.dependencies) {
+      let deps = changes?.[pkg]?.dependencies || [];
       for (let pkgDep of deps) {
         if (!!changes[pkgDep]) {
           packageFiles[pkg] = bumpDeps({
             packageFile: packageFiles[pkg],
             dep: pkgDep,
-            bumpType: changes[pkgDep].type,
             previewVersion,
-            prereleaseIdentifier,
+            packageFiles,
           });
         }
       }
@@ -311,20 +322,28 @@ const bumpMain = ({
   packageFile,
   bumpType,
   previewVersion,
-  prereleaseIdentifier = null,
+  prereleaseIdentifier,
   errorOnVersionRange,
 }: {
   packageFile: PackageFile;
   bumpType: CommonBumps;
   previewVersion: string;
-  prereleaseIdentifier: string | null;
+  prereleaseIdentifier?: string;
   errorOnVersionRange?: string;
 }) => {
   let pkg = { ...packageFile };
   if (!pkg.version)
     throw new Error(`${pkg.name} does not have a version number.`);
-  // @ts-ignore TODO bumpType should be narrowed to meet ReleaseType
-  let next = semver.inc(pkg.version, bumpType, prereleaseIdentifier);
+
+  if (bumpType === "noop")
+    throw new Error(`${pkg.name} needs a valid bump type, passed ${bumpType}`);
+
+  if (prereleaseIdentifier && typeof prereleaseIdentifier !== "string")
+    throw new Error(
+      `${pkg.name} needs prereleaseIdentifier passed as a string`
+    );
+
+  let next = semver.inc(pkg.version, bumpType, undefined, prereleaseIdentifier);
   if (next) {
     pkg.version = next;
     pkg.versionMajor = semver.major(next);
@@ -340,32 +359,32 @@ const bumpMain = ({
     previewVersion && previewVersion !== ""
       ? semver.valid(`${preVersionCleaned}-${previewVersion}`)
       : // @ts-ignore TODO bumpType should be narrowed to meet ReleaseType
-      semver.inc(prevVersion, bumpType, prereleaseIdentifier);
+        semver.inc(prevVersion, bumpType, prereleaseIdentifier);
+
   if (version) {
     pkg = setPackageFileVersion({ pkg, version });
     if (errorOnVersionRange && semver.satisfies(version, errorOnVersionRange)) {
       throw new Error(
         `${pkg.name} will be bumped to ${version}. ` +
-        `This satisfies the range ${errorOnVersionRange} which the configuration disallows. ` +
-        `Please adjust your bump to accommodate the range or otherwise adjust the allowed range in \`errorOnVersionRange\`.`
+          `This satisfies the range ${errorOnVersionRange} which the configuration disallows. ` +
+          `Please adjust your bump to accommodate the range or otherwise adjust the allowed range in \`errorOnVersionRange\`.`
       );
     }
   }
+
   return pkg;
 };
 
 const bumpDeps = ({
   packageFile,
   dep,
-  bumpType,
   previewVersion,
-  prereleaseIdentifier = null,
+  packageFiles,
 }: {
   packageFile: PackageFile;
   dep: string;
-  bumpType: string;
   previewVersion: string;
-  prereleaseIdentifier: string | null;
+  packageFiles: Record<string, PackageFile>;
 }) => {
   let pkg = { ...packageFile };
 
@@ -376,25 +395,29 @@ const bumpDeps = ({
         if (pkg.pkg[property]) {
           // @ts-ignore
           Object.keys(pkg.pkg[property]).forEach((existingDep) => {
+            // if pkg is in dep list
             if (existingDep === dep) {
               const prevVersion = getPackageFileVersion({ pkg, property, dep });
-              const preVersionCleaned = semver.prerelease(prevVersion)
-                ? semver.inc(prevVersion, "patch")
-                : prevVersion;
-              let version =
-                previewVersion && previewVersion !== ""
-                  ? semver.valid(`${preVersionCleaned}-${previewVersion}`)
-                  : incConsideringPartials(
-                    dep,
-                    prevVersion,
-                    // @ts-ignore TODO deal with ReleaseType
-                    bumpType,
-                    prereleaseIdentifier
-                  );
+
+              const versionRequirementMatch = /[\^=~]/.exec(prevVersion);
+              const versionRequirement = versionRequirementMatch
+                ? versionRequirementMatch[0]
+                : "";
+
+              const version = deriveVersionConsideringPartials({
+                dependency: dep,
+                prevVersion,
+                versionRequirement,
+                previewVersion,
+                packageFiles,
+              });
               if (version) {
-                const versionRequirementMatch = /[\^=~]/.exec(prevVersion)
-                const versionRequirement = versionRequirementMatch ? versionRequirementMatch[0] : ''
-                pkg = setPackageFileVersion({ pkg, version: `${versionRequirement}${version}`, property, dep });
+                pkg = setPackageFileVersion({
+                  pkg,
+                  version,
+                  property,
+                  dep,
+                });
               }
             }
           });
@@ -405,43 +428,37 @@ const bumpDeps = ({
   return pkg;
 };
 
-const incConsideringPartials = (
-  dependency: string,
-  version: string,
-  bumpType: string,
-  prereleaseIdentifier: string | null
-) => {
-  if (semver.valid(version)) {
-    // @ts-ignore TODO deal with ReleaseType
-    return semver.inc(version, bumpType, prereleaseIdentifier);
-  } else {
-    if (prereleaseIdentifier !== null) {
-      console.warn(
-        `bump for ${dependency} skipped as ${version} is a range, and does not specifically include prereleases. ` +
-        `Please pin to a major.minor.patch for a prerelease bump.`
-      );
-      return null;
-    }
-    try {
-      const coerced = semver.coerce(version);
-      if (!coerced)
-        throw new Error(
-          `Cannot bump ${version} with ${bumpType}. Is it a valid version number?`
-        );
-      // @ts-ignore TODO deal with ReleaseType
-      const fullVersion = semver.inc(coerced, bumpType).split(".");
-      if (version.split(".").length === 2) {
-        return [fullVersion[0], fullVersion[1]].join(".");
-      } else if (version.split(".").length === 1) {
-        return fullVersion[0];
-      } else {
-        // failsafe is better than null
-        return fullVersion.join(".");
-      }
-    } catch {
-      // failsafe is better than null
-      // @ts-ignore TODO what should we _really_ do here?
-      return semver.inc(semver.coerce(version), bumpType);
-    }
+const deriveVersionConsideringPartials = ({
+  dependency,
+  prevVersion,
+  versionRequirement,
+  previewVersion,
+  packageFiles,
+}: {
+  dependency: string;
+  prevVersion: string;
+  versionRequirement: string;
+  previewVersion: string;
+  packageFiles: Record<string, PackageFile>;
+}) => {
+  if (previewVersion && previewVersion !== "") {
+    const preVersionCleaned = semver.prerelease(prevVersion)
+      ? semver.inc(prevVersion, "patch")
+      : prevVersion;
+    return semver.valid(`${preVersionCleaned}-${previewVersion}`);
   }
+
+  const pkg = packageFiles[dependency];
+  const { version, versionMajor, versionMinor, versionPatch } = pkg;
+
+  if (!version) throw new Error(`${pkg.name} doesn't have a version?`);
+
+  let depVersion = version;
+  if (prevVersion.split(".").length === 2) {
+    depVersion = `${versionMajor}.${versionMinor}`;
+  } else if (prevVersion.split(".").length === 1) {
+    depVersion = `${versionMajor}`;
+  }
+
+  return `${versionRequirement}${depVersion}`;
 };

--- a/packages/apply/test/__snapshots__/apply.test.ts.snap
+++ b/packages/apply/test/__snapshots__/apply.test.ts.snap
@@ -170,13 +170,21 @@ Object {
 exports[`package file apply bump (snapshot) fails bump single js json that satisfies range 1`] = `
 Object {
   "consoleDir": Array [],
-  "consoleLog": Array [],
+  "consoleLog": Array [
+    Array [
+      "bumping js-single-json-fixture with minor",
+    ],
+  ],
 }
 `;
 
 exports[`package file apply bump (snapshot) fails bumps single rust toml that satisfies range 1`] = `
 Object {
   "consoleDir": Array [],
-  "consoleLog": Array [],
+  "consoleLog": Array [
+    Array [
+      "bumping rust-single-fixture with minor",
+    ],
+  ],
 }
 `;

--- a/packages/apply/test/apply.test.ts
+++ b/packages/apply/test/apply.test.ts
@@ -1,6 +1,6 @@
 import { apply } from "../src";
 import { loadFile } from "@covector/files";
-import { it } from "@effection/jest";
+import { it, captureError } from "@effection/jest";
 import mockConsole, { RestoreConsole } from "jest-mock-console";
 import fixtures from "fixturez";
 const f = fixtures(__dirname);
@@ -166,9 +166,13 @@ describe("package file apply bump (snapshot)", () => {
       },
     };
 
-    //@ts-ignore
-    const applied = apply({ commands, config, cwd: jsonFolder });
-    expect(applied.return).toThrow();
+    const applied = yield captureError(
+      //@ts-ignore
+      apply({ commands, config, cwd: jsonFolder })
+    );
+    expect(applied.message).toBe(
+      "js-single-json-fixture will be bumped to 0.6.0. This satisfies the range >= 0.6.0 which the configuration disallows. Please adjust your bump to accommodate the range or otherwise adjust the allowed range in `errorOnVersionRange`."
+    );
     expect({
       //@ts-ignore
       consoleLog: console.log.mock.calls,
@@ -201,9 +205,13 @@ describe("package file apply bump (snapshot)", () => {
       },
     };
 
-    //@ts-ignore
-    const applied = apply({ commands, config, cwd: rustFolder });
-    expect(applied.return).toThrow();
+    const applied = yield captureError(
+      //@ts-ignore
+      apply({ commands, config, cwd: rustFolder })
+    );
+    expect(applied.message).toBe(
+      "rust-single-fixture will be bumped to 0.6.0. This satisfies the range >= 0.6.0 which the configuration disallows. Please adjust your bump to accommodate the range or otherwise adjust the allowed range in `errorOnVersionRange`."
+    );
     expect({
       //@ts-ignore
       consoleLog: console.log.mock.calls,

--- a/packages/assemble/src/index.ts
+++ b/packages/assemble/src/index.ts
@@ -232,6 +232,7 @@ export const assemble = function* ({
     plan.releases = mergeReleases(changes, config || {});
   }
 
+  // check that plan only includes pkgs that exist
   if (config && Object.keys(config).length > 0) {
     for (let pkg of Object.keys(plan.releases)) {
       if (!config.packages[pkg]) {


### PR DESCRIPTION
## Motivation

The dep bumps presume that we could simply blindly increment the version that was previously set. This works _most_ of the time with automatic bumps, but if any user adds a dep or a bump is missed then it causes issues. The bump could be incremented but still be behind.

This seeks to use to version _just_ set as the version for the dep bumps as well.
