### PR TITLE
remove ternary and explicitly consider changelog commit bullet points

### DIFF
--- a/.changes/changelog-commits-ternary.md
+++ b/.changes/changelog-commits-ternary.md
@@ -1,0 +1,5 @@
+---
+"@covector/changelog": patch
+---
+
+The bullet point commit messages were occasionally returning undefined. Remove the ternary and more cleanly checking the logic.

--- a/packages/changelog/src/index.ts
+++ b/packages/changelog/src/index.ts
@@ -177,31 +177,32 @@ const applyChanges = ({
       } else {
         addition = assembledChanges.releases[
           change.changes.name
-        ].changes.reduce(
-          (finalString, release) =>
-            !release.meta || (!!release.meta && !release.meta.commits)
-              ? `${finalString}\n- ${release.summary}`
-              : `${finalString}\n- ${release.summary}\n${
-                  !release.meta.dependencies
-                    ? ""
-                    : `  - ${release.meta.dependencies}\n`
-                }${release.meta
-                  .commits!.map(
-                    (commit) =>
-                      `  - [${commit.hashShort}](${gitSiteUrl}commit/${
-                        commit.hashLong
-                      }) ${commit.commitSubject.replace(
-                        /(#[0-9]+)/g,
-                        (match) =>
-                          `[${match}](${gitSiteUrl}pull/${match.substr(
-                            1,
-                            999999
-                          )})`
-                      )} on ${commit.date}`
-                  )
-                  .join("\n")}`,
-          `## [${change.changes.version}]`
-        );
+        ].changes.reduce((finalString, release) => {
+          if (!release.meta || (!!release.meta && !release.meta.commits)) {
+            return `${finalString}\n- ${release.summary}`;
+          } else {
+            if (release.meta.commits) {
+              return `${finalString}\n- ${release.summary}\n${
+                !release.meta.dependencies
+                  ? ""
+                  : `  - ${release.meta.dependencies}\n`
+              }${release.meta.commits
+                .map(
+                  (commit) =>
+                    `  - [${commit.hashShort}](${gitSiteUrl}commit/${
+                      commit.hashLong
+                    }) ${commit.commitSubject.replace(
+                      /(#[0-9]+)/g,
+                      (match) =>
+                        `[${match}](${gitSiteUrl}pull/${match.slice(1)})`
+                    )} on ${commit.date}`
+                )
+                .join("\n")}`;
+            } else {
+              return finalString;
+            }
+          }
+        }, `## [${change.changes.version}]`);
       }
       const parsedAddition = processor.parse(addition);
       const changelogFirstElement = changelog.children.shift();


### PR DESCRIPTION
## Motivation

We were occasionally getting an `undefined` on the bullet points representing commits in the changelog. Addressing the logic to make it more clear.
