### PR TITLE
fix failing git test due to missing change file

### DIFF
--- a/.github/workflows/run-on-pr.yml
+++ b/.github/workflows/run-on-pr.yml
@@ -24,7 +24,6 @@ jobs:
         run: echo "$COVECTOR_CONTEXT"
       - name: version dry run directly
         run: node ./packages/covector/bin/covector.js version --dry-run
-      - run: git log --reverse --format="%h %H %as %s" .changes/upgrade-to-effection-v2.md
 
   preview:
     runs-on: ubuntu-latest

--- a/packages/assemble/test/git.test.ts
+++ b/packages/assemble/test/git.test.ts
@@ -9,7 +9,8 @@ describe("git parsing", () => {
     //   to check the git command as that should still be in the history
     const file: File = {
       content: "---\nboop: patch\n---\n",
-      path: `./.changes/upgrade-to-effection-v2.md`,
+      // the `--` forces a path and won't throw an error on missing files
+      path: `-- ./.changes/upgrade-to-effection-v2.md`,
       filename: "upgrade-to-effection-v2.md",
       extname: "md",
     };
@@ -29,6 +30,12 @@ describe("git parsing", () => {
         date: "2022-10-26",
         hashLong: "a346221102075e647693851fd1019d66641f8014",
         hashShort: "a346221",
+      },
+      {
+        commitSubject: "publish new versions (#231)",
+        date: "2023-01-17",
+        hashLong: "b5375deed67cb47f75e29b5628c5c15ff4b99b78",
+        hashShort: "b5375de",
       },
     ]);
   });


### PR DESCRIPTION
## Motivation

In merging in the Version Packages PR, we deleted a file which one of the git log tests relied upon. Fix this test.

## Approach

We can add a `--` for inform git that it is specifically a file reference and not throw an error. This should enable to it to work even after the file is deleted.
