### PR TITLE
silent errors on npm view as it breaks the check

### DIFF
--- a/.changes/config.json
+++ b/.changes/config.json
@@ -4,7 +4,7 @@
   "pkgManagers": {
     "javascript": {
       "version": true,
-      "getPublishedVersion": "npm view ${ pkg.pkg } version",
+      "getPublishedVersion": "npm view ${ pkg.pkg } version --silent",
       "prepublish": [{ "command": "npm pack", "dryRunCommand": true }],
       "publish": [
         {


### PR DESCRIPTION
## Motivation

In updating `npm`, it started throwing errors when running commands in the package folder. This broke the publish check as it expects to only have the version number returned.
