### PR TITLE
fix(apply): try to use actual package name when bumping deps

### DIFF
--- a/.changes/fix-bump-deps.md
+++ b/.changes/fix-bump-deps.md
@@ -1,0 +1,5 @@
+---
+"@covector/apply": patch
+---
+
+Try to determine actual package name when bumping dependencies to support nicknames in the packages configuration.

--- a/packages/apply/src/apply.ts
+++ b/packages/apply/src/apply.ts
@@ -284,7 +284,6 @@ const bumpDeps = ({
                 dep: depName,
               });
             }
-            console.log('doneeey')
           }
         });
       }

--- a/packages/apply/src/apply.ts
+++ b/packages/apply/src/apply.ts
@@ -252,6 +252,8 @@ const bumpDeps = ({
       "devDependencies",
       "dev-dependencies",
     ];
+    const depPkg = packageFiles[dep];
+    const depName = depPkg.pkg.package?.name || depPkg.pkg.name || dep;
     depTypes.forEach((property: DepTypes) => {
       if (property && property in currentPkg) {
         const pkgProperties = Object.keys(
@@ -259,8 +261,8 @@ const bumpDeps = ({
         ) as Array<keyof Pkg>;
         pkgProperties.forEach((existingDep) => {
           // if pkg is in dep list
-          if (existingDep === dep) {
-            const prevVersion = getPackageFileVersion({ pkg, property, dep });
+          if (existingDep === depName) {
+            const prevVersion = getPackageFileVersion({ pkg, property, dep: depName });
 
             const versionRequirementMatch = /[\^=~]/.exec(prevVersion);
             const versionRequirement = versionRequirementMatch
@@ -279,9 +281,10 @@ const bumpDeps = ({
                 pkg,
                 version,
                 property,
-                dep,
+                dep: depName,
               });
             }
+            console.log('doneeey')
           }
         });
       }


### PR DESCRIPTION
## Motivation

The current bumpDeps function expects the configuration object to use the actual package name as key, which might not be desired if the package name is large or has namespaces. This PR changes the mechanism to try to pull the package version from the file.

## Approach

Try to pull the package version from the file object.

### Alternate Designs

Add a name field on the package definition or keep expecting the package name to match.

### Possible Drawbacks or Risks

Currently only supports Rust and JavaScript packages.

