### PR TITLE
skip bump on range and add version number for deps in changelog

### DIFF
--- a/.changes/changelog-deps-version-number.md
+++ b/.changes/changelog-deps-version-number.md
@@ -1,0 +1,6 @@
+---
+"@covector/apply": minor
+"@covector/changelog": minor
+---
+
+Add change for all exact deps rolled up to handle it with the changelog deps section. Add the version number to the changelog deps section.

--- a/.changes/dep-range-bump-without-release.md
+++ b/.changes/dep-range-bump-without-release.md
@@ -1,0 +1,5 @@
+---
+"@covector/apply": patch
+---
+
+Fix `undefined` error when dep with range was bumped.

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,11 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+*.ts text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+
 packages/action/dist/* binary
 **/package-lock.json binary

--- a/__fixtures__/pkg.js-yarn-workspace/packages/pkg-c/package.json
+++ b/__fixtures__/pkg.js-yarn-workspace/packages/pkg-c/package.json
@@ -1,7 +1,0 @@
-{
-  "name": "yarn-workspace-base-pkg-c",
-  "version": "1.0.0",
-  "dependencies": {
-    "yarn-workspace-base-pkg-b": "^1.0.0"
-  }
-}

--- a/__fixtures__/pkg.js-yarn-workspace/packages/pkg-c/package.json
+++ b/__fixtures__/pkg.js-yarn-workspace/packages/pkg-c/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "yarn-workspace-base-pkg-one",
+  "name": "yarn-workspace-base-pkg-c",
   "version": "1.0.0",
   "dependencies": {
     "yarn-workspace-base-pkg-b": "^1.0.0"

--- a/__fixtures__/pkg.js-yarn-workspace/packages/pkg-c/package.json
+++ b/__fixtures__/pkg.js-yarn-workspace/packages/pkg-c/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "yarn-workspace-base-pkg-c",
+  "version": "1.0.0",
+  "dependencies": {
+    "yarn-workspace-base-pkg-b": "^1.0.0"
+  }
+}

--- a/__fixtures__/pkg.js-yarn-workspace/packages/pkg-one/package.json
+++ b/__fixtures__/pkg.js-yarn-workspace/packages/pkg-one/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "yarn-workspace-base-pkg-c",
+  "name": "yarn-workspace-base-pkg-one",
   "version": "1.0.0",
   "dependencies": {
     "yarn-workspace-base-pkg-b": "^1.0.0"

--- a/packages/action/src/index.ts
+++ b/packages/action/src/index.ts
@@ -161,15 +161,7 @@ export function* run(): Generator<any, any, any> {
         core.setOutput("successfulPublish", successfulPublish);
 
         core.setOutput("change", covectored.commandsRan);
-        const payload = JSON.stringify(
-          Object.keys(covectored.commandsRan).reduce((c, pkg) => {
-            //@ts-expect-error
-            delete c[pkg].pkg.pkgFile.vfile;
-            return c;
-          }, covectored.commandsRan),
-          undefined,
-          2
-        );
+        const payload = JSON.stringify(covectored.commandsRan, undefined, 2);
 
         core.startGroup(`covector publish output`);
         console.log(`The covector output: ${payload}`);

--- a/packages/action/test/__snapshots__/e2e.test.ts.snap
+++ b/packages/action/test/__snapshots__/e2e.test.ts.snap
@@ -2279,24 +2279,12 @@ Summary about the changes in tauri-updater
               "changes": Array [
                 Object {
                   "meta": Object {
-                    "content": "---
-\\"tauri\\": minor
----
-
-Summary about the changes in tauri
-",
                     "dependencies": Array [
                       "tauri",
                     ],
-                    "extname": ".md",
-                    "filename": "first-change",
-                    "path": ".changes/first-change.md",
                   },
-                  "releases": Object {
-                    "tauri": "minor",
-                  },
-                  "summary": "Summary about the changes in tauri",
-                  "tag": undefined,
+                  "releases": Object {},
+                  "summary": "",
                 },
               ],
               "parents": Object {},
@@ -2320,7 +2308,7 @@ Merging this PR will release new versions of the following packages based on you
 ## [0.6.3]
 ### Dependencies
 
-- Updated to latest \`tauri\`
+- Upgraded to \`tauri@0.6.0\`
 
 
 

--- a/packages/apply/package.json
+++ b/packages/apply/package.json
@@ -18,12 +18,10 @@
   "dependencies": {
     "@covector/files": "0.6.1",
     "effection": "^2.0.6",
-    "lodash": "^4.17.21",
     "semver": "^7.3.8"
   },
   "devDependencies": {
     "@covector/types": "^0.0.0",
-    "@types/lodash": "^4.14.191",
     "tslib": "^2.5.0",
     "typescript": "^4.9.5"
   },

--- a/packages/apply/src/apply.ts
+++ b/packages/apply/src/apply.ts
@@ -1,4 +1,4 @@
-import { all, Operation } from "effection";
+import { type Operation } from "effection";
 import {
   writePkgFile,
   getPackageFileVersion,
@@ -252,14 +252,14 @@ const bumpDeps = ({
       "devDependencies",
       "dev-dependencies",
       "build-dependencies",
-      "target"
+      "target",
     ];
     const depPkg = packageFiles[dep];
     const depName = depPkg.pkg.package?.name || depPkg.pkg.name || dep;
     depTypes.forEach((property: DepTypes) => {
       if (property && property in currentPkg) {
-        if (property === 'target') {
-          const targets = currentPkg[property] as object
+        if (property === "target") {
+          const targets = currentPkg[property] as object;
           for (const target of Object.values(targets)) {
             depTypes.forEach((property: DepTypes) => {
               if (property && property in target) {
@@ -288,7 +288,8 @@ const bumpDeps = ({
             dep,
             previewVersion,
             packageFiles,
-            getPreviousVersion: () => getPackageFileVersion({ pkg, property, dep: depName }),
+            getPreviousVersion: () =>
+              getPackageFileVersion({ pkg, property, dep: depName }),
           });
           if (version) {
             pkg = setPackageFileVersion({
@@ -325,13 +326,13 @@ const getDepBumpVersion = ({
   packageFiles: Record<string, PackageFile>;
   getPreviousVersion: () => string;
 }) => {
-  const pkgProperties = Object.keys(
-    currentPkg[property] as object
-  ) as Array<keyof Pkg>;
+  const pkgProperties = Object.keys(currentPkg[property] as object) as Array<
+    keyof Pkg
+  >;
   for (const existingDep of pkgProperties) {
     // if pkg is in dep list
     if (existingDep === depName) {
-      const prevVersion = getPreviousVersion()
+      const prevVersion = getPreviousVersion();
       const versionRequirementMatch = /[\^=~]/.exec(prevVersion);
       const versionRequirement = versionRequirementMatch
         ? versionRequirementMatch[0]
@@ -348,7 +349,7 @@ const getDepBumpVersion = ({
     }
   }
   return null;
-}
+};
 
 const deriveVersionConsideringPartials = ({
   dependency,

--- a/packages/apply/src/parents.ts
+++ b/packages/apply/src/parents.ts
@@ -89,37 +89,33 @@ const parentBump = ({
             ?.version || "none";
         const versionRequirementMatch = /[\^=~]/.exec(prevDepVersion);
         // pkg is the parent and main is the child
-        if (
-          !changes[pkg] &&
-          (!versionRequirementMatch || prevDepVersion === "none")
-        ) {
+        if (!versionRequirementMatch || prevDepVersion === "none") {
           // if the parent doesn't have a release
           //   and it doesn't have the dependency as a range
           //   add one to adopt the next version of it's child
           //   but don't use the changes as we will refer to this dep
           //   bump otherwise and pulling up the changelog is not needed
-          changes[pkg] = {
-            changes: [],
-            parents: parents[pkg],
-            // prerelease will do bump the X in `-beta.X` if it is already a prerelease
-            // or it will do a prepatch if it isn't a prerelease
-            type: !prereleaseIdentifier ? "patch" : "prerelease",
-          };
-          // we also need to presume recursion to update the parents' parents
-          if (Object.values(parents[pkg]).length > 0) recurse = true;
-
-          changes[pkg].changes?.forEach((parentChange) => {
-            // this ends up overwriting in cases multiple bumps,
-            //   we should adjust this to accept multiple
-            if (
-              !parentChange.meta.dependencies ||
-              parentChange.meta.dependencies.length === 0
-            ) {
-              parentChange.meta.dependencies = [main];
-            } else {
-              parentChange.meta.dependencies.push(main);
-            }
-          });
+          if (!changes[pkg]) {
+            changes[pkg] = {
+              changes: [
+                { meta: { dependencies: [main] }, summary: "", releases: {} },
+              ],
+              parents: parents[pkg],
+              // prerelease will do bump the X in `-beta.X` if it is already a prerelease
+              // or it will do a prepatch if it isn't a prerelease
+              type: !prereleaseIdentifier ? "patch" : "prerelease",
+            };
+            // we also need to presume recursion to update the parents' parents
+            if (Object.values(parents[pkg]).length > 0) recurse = true;
+          } else {
+            // if we have have a release planned, add a skeleton so it shows
+            //  in the deps bump section
+            changes[pkg].changes?.push({
+              meta: { dependencies: [main] },
+              summary: "",
+              releases: {},
+            });
+          }
         }
       });
     }

--- a/packages/apply/test/__snapshots__/apply-preview.test.ts.snap
+++ b/packages/apply/test/__snapshots__/apply-preview.test.ts.snap
@@ -1,0 +1,57 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`package file applies preview bump bumps multi js json 1`] = `
+Object {
+  "consoleDir": Array [],
+  "consoleLog": Array [
+    Array [
+      "bumping yarn-workspace-base-pkg-a with branch-name.12345 identifier to publish a preview",
+    ],
+    Array [
+      "bumping yarn-workspace-base-pkg-b with branch-name.12345 identifier to publish a preview",
+    ],
+    Array [
+      "bumping all with branch-name.12345 identifier to publish a preview",
+    ],
+  ],
+}
+`;
+
+exports[`package file applies preview bump bumps single js json 1`] = `
+Object {
+  "consoleDir": Array [],
+  "consoleLog": Array [
+    Array [
+      "bumping js-single-json-fixture with branch-name.12345 identifier to publish a preview",
+    ],
+  ],
+}
+`;
+
+exports[`package file applies preview bump to pre-release bumps multi js json without pre-release 1`] = `
+Object {
+  "consoleDir": Array [],
+  "consoleLog": Array [
+    Array [
+      "bumping yarn-workspace-base-pkg-a with branch-name.12345 identifier to publish a preview",
+    ],
+    Array [
+      "bumping yarn-workspace-base-pkg-b with branch-name.12345 identifier to publish a preview",
+    ],
+    Array [
+      "bumping all with branch-name.12345 identifier to publish a preview",
+    ],
+  ],
+}
+`;
+
+exports[`package file applies preview bump to pre-release bumps single js json without pre-release 1`] = `
+Object {
+  "consoleDir": Array [],
+  "consoleLog": Array [
+    Array [
+      "bumping js-single-prerelease-json-fixture with branch-name.12345 identifier to publish a preview",
+    ],
+  ],
+}
+`;

--- a/packages/apply/test/__snapshots__/apply.test.ts.snap
+++ b/packages/apply/test/__snapshots__/apply.test.ts.snap
@@ -1,76 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`package file applies preview bump bumps multi js json 1`] = `
-Object {
-  "consoleDir": Array [],
-  "consoleLog": Array [
-    Array [
-      "bumping yarn-workspace-base-pkg-a with branch-name.12345 identifier to publish a preview",
-    ],
-    Array [
-      "bumping yarn-workspace-base-pkg-b with branch-name.12345 identifier to publish a preview",
-    ],
-    Array [
-      "bumping all with branch-name.12345 identifier to publish a preview",
-    ],
-  ],
-}
-`;
-
-exports[`package file applies preview bump bumps single js json 1`] = `
-Object {
-  "consoleDir": Array [],
-  "consoleLog": Array [
-    Array [
-      "bumping js-single-json-fixture with branch-name.12345 identifier to publish a preview",
-    ],
-  ],
-}
-`;
-
-exports[`package file applies preview bump to pre-release bumps multi js json without pre-release 1`] = `
-Object {
-  "consoleDir": Array [],
-  "consoleLog": Array [
-    Array [
-      "bumping yarn-workspace-base-pkg-a with branch-name.12345 identifier to publish a preview",
-    ],
-    Array [
-      "bumping yarn-workspace-base-pkg-b with branch-name.12345 identifier to publish a preview",
-    ],
-    Array [
-      "bumping all with branch-name.12345 identifier to publish a preview",
-    ],
-  ],
-}
-`;
-
-exports[`package file applies preview bump to pre-release bumps single js json without pre-release 1`] = `
-Object {
-  "consoleDir": Array [],
-  "consoleLog": Array [
-    Array [
-      "bumping js-single-prerelease-json-fixture with branch-name.12345 identifier to publish a preview",
-    ],
-  ],
-}
-`;
-
-exports[`package file apply bump (snapshot) bump multi rust toml as patch with object dep missing patch 1`] = `
-Object {
-  "consoleDir": Array [],
-  "consoleLog": Array [
-    Array [
-      "bumping rust_pkg_a_fixture with patch",
-    ],
-    Array [
-      "bumping rust_pkg_b_fixture with patch",
-    ],
-  ],
-}
-`;
-
-exports[`package file apply bump (snapshot) bumps multi js json 1`] = `
+exports[`package file apply bump (snapshot) on js bumps multi 1`] = `
 Object {
   "consoleDir": Array [],
   "consoleLog": Array [
@@ -87,63 +17,24 @@ Object {
 }
 `;
 
-exports[`package file apply bump (snapshot) bumps multi rust toml 1`] = `
+exports[`package file apply bump (snapshot) on js bumps multi with parent as range 1`] = `
 Object {
   "consoleDir": Array [],
   "consoleLog": Array [
     Array [
-      "bumping rust_pkg_a_fixture with minor",
+      "bumping yarn-workspace-base-pkg-a with minor",
     ],
     Array [
-      "bumping rust_pkg_b_fixture with minor",
+      "bumping yarn-workspace-base-pkg-b with minor",
+    ],
+    Array [
+      "bumping all with minor",
     ],
   ],
 }
 `;
 
-exports[`package file apply bump (snapshot) bumps multi rust toml as minor with object dep missing patch 1`] = `
-Object {
-  "consoleDir": Array [],
-  "consoleLog": Array [
-    Array [
-      "bumping rust_pkg_a_fixture with minor",
-    ],
-    Array [
-      "bumping rust_pkg_b_fixture with minor",
-    ],
-  ],
-}
-`;
-
-exports[`package file apply bump (snapshot) bumps multi rust toml with dep missing patch 1`] = `
-Object {
-  "consoleDir": Array [],
-  "consoleLog": Array [
-    Array [
-      "bumping rust_pkg_a_fixture with minor",
-    ],
-    Array [
-      "bumping rust_pkg_b_fixture with minor",
-    ],
-  ],
-}
-`;
-
-exports[`package file apply bump (snapshot) bumps multi rust toml with object dep 1`] = `
-Object {
-  "consoleDir": Array [],
-  "consoleLog": Array [
-    Array [
-      "bumping rust_pkg_a_fixture with minor",
-    ],
-    Array [
-      "bumping rust_pkg_b_fixture with minor",
-    ],
-  ],
-}
-`;
-
-exports[`package file apply bump (snapshot) bumps single js json 1`] = `
+exports[`package file apply bump (snapshot) on js bumps single 1`] = `
 Object {
   "consoleDir": Array [],
   "consoleLog": Array [
@@ -154,7 +45,88 @@ Object {
 }
 `;
 
-exports[`package file apply bump (snapshot) bumps single rust toml 1`] = `
+exports[`package file apply bump (snapshot) on js fails bump single that satisfies range 1`] = `
+Object {
+  "consoleDir": Array [],
+  "consoleLog": Array [
+    Array [
+      "bumping js-single-json-fixture with minor",
+    ],
+  ],
+}
+`;
+
+exports[`package file apply bump (snapshot) on rust bump multi as patch with object dep missing patch 1`] = `
+Object {
+  "consoleDir": Array [],
+  "consoleLog": Array [
+    Array [
+      "bumping rust_pkg_a_fixture with patch",
+    ],
+    Array [
+      "bumping rust_pkg_b_fixture with patch",
+    ],
+  ],
+}
+`;
+
+exports[`package file apply bump (snapshot) on rust bumps multi 1`] = `
+Object {
+  "consoleDir": Array [],
+  "consoleLog": Array [
+    Array [
+      "bumping rust_pkg_a_fixture with minor",
+    ],
+    Array [
+      "bumping rust_pkg_b_fixture with minor",
+    ],
+  ],
+}
+`;
+
+exports[`package file apply bump (snapshot) on rust bumps multi as minor with object dep missing patch 1`] = `
+Object {
+  "consoleDir": Array [],
+  "consoleLog": Array [
+    Array [
+      "bumping rust_pkg_a_fixture with minor",
+    ],
+    Array [
+      "bumping rust_pkg_b_fixture with minor",
+    ],
+  ],
+}
+`;
+
+exports[`package file apply bump (snapshot) on rust bumps multi with dep missing patch 1`] = `
+Object {
+  "consoleDir": Array [],
+  "consoleLog": Array [
+    Array [
+      "bumping rust_pkg_a_fixture with minor",
+    ],
+    Array [
+      "bumping rust_pkg_b_fixture with minor",
+    ],
+  ],
+}
+`;
+
+exports[`package file apply bump (snapshot) on rust bumps multi with object dep 1`] = `
+Object {
+  "consoleDir": Array [],
+  "consoleLog": Array [
+    Array [
+      "bumping rust_pkg_a_fixture with minor",
+    ],
+    Array [
+      "bumping rust_pkg_b_fixture with minor",
+    ],
+  ],
+}
+`;
+
+exports[`package file apply bump (snapshot) on rust bumps single 1`] = `
 Object {
   "consoleDir": Array [],
   "consoleLog": Array [
@@ -165,34 +137,23 @@ Object {
 }
 `;
 
-exports[`package file apply bump (snapshot) bumps single yaml toml 1`] = `
+exports[`package file apply bump (snapshot) on rust fails bumps single that satisfies range 1`] = `
+Object {
+  "consoleDir": Array [],
+  "consoleLog": Array [
+    Array [
+      "bumping rust-single-fixture with minor",
+    ],
+  ],
+}
+`;
+
+exports[`package file apply bump (snapshot) on yaml bumps single 1`] = `
 Object {
   "consoleDir": Array [],
   "consoleLog": Array [
     Array [
       "bumping test_app with minor",
-    ],
-  ],
-}
-`;
-
-exports[`package file apply bump (snapshot) fails bump single js json that satisfies range 1`] = `
-Object {
-  "consoleDir": Array [],
-  "consoleLog": Array [
-    Array [
-      "bumping js-single-json-fixture with minor",
-    ],
-  ],
-}
-`;
-
-exports[`package file apply bump (snapshot) fails bumps single rust toml that satisfies range 1`] = `
-Object {
-  "consoleDir": Array [],
-  "consoleLog": Array [
-    Array [
-      "bumping rust-single-fixture with minor",
     ],
   ],
 }

--- a/packages/apply/test/__snapshots__/apply.test.ts.snap
+++ b/packages/apply/test/__snapshots__/apply.test.ts.snap
@@ -22,13 +22,10 @@ Object {
   "consoleDir": Array [],
   "consoleLog": Array [
     Array [
-      "bumping yarn-workspace-base-pkg-a with minor",
+      "bumping yarn-workspace-base-pkg-a with patch",
     ],
     Array [
       "bumping yarn-workspace-base-pkg-b with minor",
-    ],
-    Array [
-      "bumping all with minor",
     ],
   ],
 }

--- a/packages/apply/test/__snapshots__/changes-considering.test.ts.snap
+++ b/packages/apply/test/__snapshots__/changes-considering.test.ts.snap
@@ -17,21 +17,15 @@ Object {
         "type": "minor",
       },
       "yarn-workspace-base-pkg-a": Object {
-        "dependencies": undefined,
-        "manager": "javascript",
+        "changes": Array [],
         "parents": Object {},
-        "path": undefined,
-        "pkg": "all",
         "type": "patch",
       },
       "yarn-workspace-base-pkg-b": Object {
-        "dependencies": undefined,
-        "manager": "javascript",
+        "changes": Array [],
         "parents": Object {
           "yarn-workspace-base-pkg-a": Object {},
         },
-        "path": undefined,
-        "pkg": "all",
         "type": "patch",
       },
     },
@@ -66,13 +60,10 @@ Object {
         "type": "patch",
       },
       "yarn-workspace-base-pkg-b": Object {
-        "dependencies": undefined,
-        "manager": "javascript",
+        "changes": Array [],
         "parents": Object {
           "yarn-workspace-base-pkg-a": Object {},
         },
-        "path": undefined,
-        "pkg": "all",
         "type": "patch",
       },
     },
@@ -88,20 +79,7 @@ Object {
     "changes": undefined,
     "releases": Object {
       "pkg-a": Object {
-        "changes": Array [
-          Object {
-            "meta": Object {
-              "dependencies": Array [
-                "pkg-c",
-              ],
-            },
-            "releases": Object {
-              "pkg-c": "patch",
-              "pkg-d": "major",
-            },
-            "summary": "This should patch bump up the pkg-[number] line to where pkg-one also receives a bump. The pkg-c writes to a patch so we patch bump up that line too.",
-          },
-        ],
+        "changes": Array [],
         "parents": Object {
           "pkg-overall": Object {
             "pkg-a": Array [
@@ -203,20 +181,7 @@ Object {
         "type": "major",
       },
       "pkg-four": Object {
-        "changes": Array [
-          Object {
-            "meta": Object {
-              "dependencies": Array [
-                "pkg-d",
-              ],
-            },
-            "releases": Object {
-              "pkg-c": "patch",
-              "pkg-d": "major",
-            },
-            "summary": "This should patch bump up the pkg-[number] line to where pkg-one also receives a bump. The pkg-c writes to a patch so we patch bump up that line too.",
-          },
-        ],
+        "changes": Array [],
         "parents": Object {
           "pkg-three": Object {
             "pkg-four": Array [
@@ -230,59 +195,17 @@ Object {
         "type": "patch",
       },
       "pkg-one": Object {
-        "changes": Array [
-          Object {
-            "meta": Object {
-              "dependencies": Array [
-                "pkg-d",
-                "pkg-four",
-                "pkg-three",
-                "pkg-two",
-              ],
-            },
-            "releases": Object {
-              "pkg-c": "patch",
-              "pkg-d": "major",
-            },
-            "summary": "This should patch bump up the pkg-[number] line to where pkg-one also receives a bump. The pkg-c writes to a patch so we patch bump up that line too.",
-          },
-        ],
+        "changes": Array [],
         "parents": Object {},
         "type": "patch",
       },
       "pkg-overall": Object {
-        "changes": Array [
-          Object {
-            "meta": Object {
-              "dependencies": Array [
-                "pkg-b",
-              ],
-            },
-            "releases": Object {
-              "pkg-b": "minor",
-            },
-            "summary": "The pkg-b doesn't have a dep bump, but can dep bump pkg-a and pkg-overall with a patch.",
-          },
-        ],
+        "changes": Array [],
         "parents": Object {},
         "type": "patch",
       },
       "pkg-three": Object {
-        "changes": Array [
-          Object {
-            "meta": Object {
-              "dependencies": Array [
-                "pkg-d",
-                "pkg-four",
-              ],
-            },
-            "releases": Object {
-              "pkg-c": "patch",
-              "pkg-d": "major",
-            },
-            "summary": "This should patch bump up the pkg-[number] line to where pkg-one also receives a bump. The pkg-c writes to a patch so we patch bump up that line too.",
-          },
-        ],
+        "changes": Array [],
         "parents": Object {
           "pkg-two": Object {
             "pkg-three": Array [
@@ -296,22 +219,7 @@ Object {
         "type": "patch",
       },
       "pkg-two": Object {
-        "changes": Array [
-          Object {
-            "meta": Object {
-              "dependencies": Array [
-                "pkg-d",
-                "pkg-four",
-                "pkg-three",
-              ],
-            },
-            "releases": Object {
-              "pkg-c": "patch",
-              "pkg-d": "major",
-            },
-            "summary": "This should patch bump up the pkg-[number] line to where pkg-one also receives a bump. The pkg-c writes to a patch so we patch bump up that line too.",
-          },
-        ],
+        "changes": Array [],
         "parents": Object {
           "pkg-one": Object {
             "pkg-two": Array [
@@ -327,6 +235,90 @@ Object {
     },
   },
   "consoleDir": Array [],
+  "consoleLog": Array [],
+}
+`;
+
+exports[`list changes considering parents skips roll up if range dep 1`] = `
+Object {
+  "changes": Object {
+    "changes": undefined,
+    "releases": Object {
+      "pkg-a": Object {
+        "changes": Array [
+          Object {
+            "meta": Object {},
+            "releases": Object {
+              "pkg-a": "patch",
+            },
+            "summary": "Roll up just a bit please.",
+          },
+        ],
+        "parents": Object {
+          "pkg-b": Object {
+            "pkg-a": Array [
+              Object {
+                "type": "dependencies",
+                "version": "1.0.0",
+              },
+            ],
+          },
+          "pkg-c": Object {
+            "pkg-a": Array [
+              Object {
+                "type": "dependencies",
+                "version": "^1.0.0",
+              },
+            ],
+          },
+        },
+        "type": "patch",
+      },
+      "pkg-b": Object {
+        "changes": Array [],
+        "parents": Object {},
+        "type": "patch",
+      },
+    },
+  },
+  "consoleDir": Array [
+    Array [
+      Object {
+        "pkg-a": Object {
+          "deps": Object {},
+          "name": "pkg-a",
+          "version": "none",
+        },
+        "pkg-b": Object {
+          "deps": Object {
+            "pkg-a": Array [
+              Object {
+                "type": "dependencies",
+                "version": "1.0.0",
+              },
+            ],
+          },
+          "name": "pkg-b",
+          "version": "none",
+        },
+        "pkg-c": Object {
+          "deps": Object {
+            "pkg-a": Array [
+              Object {
+                "type": "dependencies",
+                "version": "^1.0.0",
+              },
+            ],
+          },
+          "name": "pkg-c",
+          "version": "none",
+        },
+      },
+      Object {
+        "depth": 5,
+      },
+    ],
+  ],
   "consoleLog": Array [],
 }
 `;

--- a/packages/apply/test/__snapshots__/changes-considering.test.ts.snap
+++ b/packages/apply/test/__snapshots__/changes-considering.test.ts.snap
@@ -17,12 +17,59 @@ Object {
         "type": "minor",
       },
       "yarn-workspace-base-pkg-a": Object {
-        "changes": Array [],
+        "changes": Array [
+          Object {
+            "meta": Object {
+              "dependencies": Array [
+                "all",
+              ],
+            },
+            "releases": Object {},
+            "summary": "",
+          },
+          Object {
+            "meta": Object {
+              "dependencies": Array [
+                "all",
+              ],
+            },
+            "releases": Object {},
+            "summary": "",
+          },
+          Object {
+            "meta": Object {
+              "dependencies": Array [
+                "yarn-workspace-base-pkg-b",
+              ],
+            },
+            "releases": Object {},
+            "summary": "",
+          },
+        ],
         "parents": Object {},
         "type": "patch",
       },
       "yarn-workspace-base-pkg-b": Object {
-        "changes": Array [],
+        "changes": Array [
+          Object {
+            "meta": Object {
+              "dependencies": Array [
+                "all",
+              ],
+            },
+            "releases": Object {},
+            "summary": "",
+          },
+          Object {
+            "meta": Object {
+              "dependencies": Array [
+                "all",
+              ],
+            },
+            "releases": Object {},
+            "summary": "",
+          },
+        ],
         "parents": Object {
           "yarn-workspace-base-pkg-a": Object {},
         },
@@ -60,7 +107,26 @@ Object {
         "type": "patch",
       },
       "yarn-workspace-base-pkg-b": Object {
-        "changes": Array [],
+        "changes": Array [
+          Object {
+            "meta": Object {
+              "dependencies": Array [
+                "all",
+              ],
+            },
+            "releases": Object {},
+            "summary": "",
+          },
+          Object {
+            "meta": Object {
+              "dependencies": Array [
+                "all",
+              ],
+            },
+            "releases": Object {},
+            "summary": "",
+          },
+        ],
         "parents": Object {
           "yarn-workspace-base-pkg-a": Object {},
         },
@@ -79,7 +145,44 @@ Object {
     "changes": undefined,
     "releases": Object {
       "pkg-a": Object {
-        "changes": Array [],
+        "changes": Array [
+          Object {
+            "meta": Object {
+              "dependencies": Array [
+                "pkg-c",
+              ],
+            },
+            "releases": Object {},
+            "summary": "",
+          },
+          Object {
+            "meta": Object {
+              "dependencies": Array [
+                "pkg-c",
+              ],
+            },
+            "releases": Object {},
+            "summary": "",
+          },
+          Object {
+            "meta": Object {
+              "dependencies": Array [
+                "pkg-c",
+              ],
+            },
+            "releases": Object {},
+            "summary": "",
+          },
+          Object {
+            "meta": Object {
+              "dependencies": Array [
+                "pkg-c",
+              ],
+            },
+            "releases": Object {},
+            "summary": "",
+          },
+        ],
         "parents": Object {
           "pkg-overall": Object {
             "pkg-a": Array [
@@ -136,6 +239,42 @@ Object {
             },
             "summary": "This should patch bump up the pkg-[number] line to where pkg-one also receives a bump. The pkg-c writes to a patch so we patch bump up that line too.",
           },
+          Object {
+            "meta": Object {
+              "dependencies": Array [
+                "pkg-d",
+              ],
+            },
+            "releases": Object {},
+            "summary": "",
+          },
+          Object {
+            "meta": Object {
+              "dependencies": Array [
+                "pkg-d",
+              ],
+            },
+            "releases": Object {},
+            "summary": "",
+          },
+          Object {
+            "meta": Object {
+              "dependencies": Array [
+                "pkg-d",
+              ],
+            },
+            "releases": Object {},
+            "summary": "",
+          },
+          Object {
+            "meta": Object {
+              "dependencies": Array [
+                "pkg-d",
+              ],
+            },
+            "releases": Object {},
+            "summary": "",
+          },
         ],
         "parents": Object {
           "pkg-a": Object {
@@ -181,7 +320,44 @@ Object {
         "type": "major",
       },
       "pkg-four": Object {
-        "changes": Array [],
+        "changes": Array [
+          Object {
+            "meta": Object {
+              "dependencies": Array [
+                "pkg-d",
+              ],
+            },
+            "releases": Object {},
+            "summary": "",
+          },
+          Object {
+            "meta": Object {
+              "dependencies": Array [
+                "pkg-d",
+              ],
+            },
+            "releases": Object {},
+            "summary": "",
+          },
+          Object {
+            "meta": Object {
+              "dependencies": Array [
+                "pkg-d",
+              ],
+            },
+            "releases": Object {},
+            "summary": "",
+          },
+          Object {
+            "meta": Object {
+              "dependencies": Array [
+                "pkg-d",
+              ],
+            },
+            "releases": Object {},
+            "summary": "",
+          },
+        ],
         "parents": Object {
           "pkg-three": Object {
             "pkg-four": Array [
@@ -195,17 +371,119 @@ Object {
         "type": "patch",
       },
       "pkg-one": Object {
-        "changes": Array [],
+        "changes": Array [
+          Object {
+            "meta": Object {
+              "dependencies": Array [
+                "pkg-two",
+              ],
+            },
+            "releases": Object {},
+            "summary": "",
+          },
+        ],
         "parents": Object {},
         "type": "patch",
       },
       "pkg-overall": Object {
-        "changes": Array [],
+        "changes": Array [
+          Object {
+            "meta": Object {
+              "dependencies": Array [
+                "pkg-b",
+              ],
+            },
+            "releases": Object {},
+            "summary": "",
+          },
+          Object {
+            "meta": Object {
+              "dependencies": Array [
+                "pkg-b",
+              ],
+            },
+            "releases": Object {},
+            "summary": "",
+          },
+          Object {
+            "meta": Object {
+              "dependencies": Array [
+                "pkg-a",
+              ],
+            },
+            "releases": Object {},
+            "summary": "",
+          },
+          Object {
+            "meta": Object {
+              "dependencies": Array [
+                "pkg-b",
+              ],
+            },
+            "releases": Object {},
+            "summary": "",
+          },
+          Object {
+            "meta": Object {
+              "dependencies": Array [
+                "pkg-a",
+              ],
+            },
+            "releases": Object {},
+            "summary": "",
+          },
+          Object {
+            "meta": Object {
+              "dependencies": Array [
+                "pkg-b",
+              ],
+            },
+            "releases": Object {},
+            "summary": "",
+          },
+          Object {
+            "meta": Object {
+              "dependencies": Array [
+                "pkg-a",
+              ],
+            },
+            "releases": Object {},
+            "summary": "",
+          },
+        ],
         "parents": Object {},
         "type": "patch",
       },
       "pkg-three": Object {
-        "changes": Array [],
+        "changes": Array [
+          Object {
+            "meta": Object {
+              "dependencies": Array [
+                "pkg-four",
+              ],
+            },
+            "releases": Object {},
+            "summary": "",
+          },
+          Object {
+            "meta": Object {
+              "dependencies": Array [
+                "pkg-four",
+              ],
+            },
+            "releases": Object {},
+            "summary": "",
+          },
+          Object {
+            "meta": Object {
+              "dependencies": Array [
+                "pkg-four",
+              ],
+            },
+            "releases": Object {},
+            "summary": "",
+          },
+        ],
         "parents": Object {
           "pkg-two": Object {
             "pkg-three": Array [
@@ -219,7 +497,26 @@ Object {
         "type": "patch",
       },
       "pkg-two": Object {
-        "changes": Array [],
+        "changes": Array [
+          Object {
+            "meta": Object {
+              "dependencies": Array [
+                "pkg-three",
+              ],
+            },
+            "releases": Object {},
+            "summary": "",
+          },
+          Object {
+            "meta": Object {
+              "dependencies": Array [
+                "pkg-three",
+              ],
+            },
+            "releases": Object {},
+            "summary": "",
+          },
+        ],
         "parents": Object {
           "pkg-one": Object {
             "pkg-two": Array [
@@ -275,7 +572,17 @@ Object {
         "type": "patch",
       },
       "pkg-b": Object {
-        "changes": Array [],
+        "changes": Array [
+          Object {
+            "meta": Object {
+              "dependencies": Array [
+                "pkg-a",
+              ],
+            },
+            "releases": Object {},
+            "summary": "",
+          },
+        ],
         "parents": Object {},
         "type": "patch",
       },

--- a/packages/apply/test/apply-preview.test.ts
+++ b/packages/apply/test/apply-preview.test.ts
@@ -1,0 +1,322 @@
+import { apply } from "../src";
+import { loadFile, readAllPkgFiles } from "@covector/files";
+import { it } from "@effection/jest";
+import mockConsole, { RestoreConsole } from "jest-mock-console";
+import fixtures from "fixturez";
+const f = fixtures(__dirname);
+
+const configDefaults = {
+  changeFolder: ".changes",
+};
+
+describe("package file applies preview bump", () => {
+  let restoreConsole: RestoreConsole;
+  beforeEach(() => {
+    restoreConsole = mockConsole(["log", "dir"]);
+  });
+  afterEach(() => {
+    restoreConsole();
+  });
+
+  it("bumps single js json", function* () {
+    const jsonFolder = f.copy("pkg.js-single-json"); // 0.5.9
+
+    const commands = [
+      {
+        dependencies: undefined,
+        manager: "javascript",
+        path: "./",
+        pkg: "js-single-json-fixture",
+        type: "minor",
+        parents: {},
+      },
+    ];
+
+    const config = {
+      ...configDefaults,
+      packages: {
+        "js-single-json-fixture": {
+          path: "./",
+          manager: "javascript",
+        },
+      },
+    };
+
+    const allPackages = yield readAllPkgFiles({ config, cwd: jsonFolder });
+
+    yield apply({
+      //@ts-expect-error
+      commands,
+      config,
+      cwd: jsonFolder,
+      allPackages,
+      previewVersion: "branch-name.12345",
+    });
+    const modifiedFile = yield loadFile("package.json", jsonFolder);
+    expect(modifiedFile.content).toBe(
+      "{\n" +
+        '  "private": true,\n' +
+        '  "name": "js-single-json-fixture",\n' +
+        '  "description": "A single package at the root. No monorepo setup.",\n' +
+        '  "repository": "https://www.github.com/jbolda/covector.git",\n' +
+        '  "version": "0.5.9-branch-name.12345"\n' +
+        "}\n"
+    );
+
+    expect({
+      //@ts-expect-error
+      consoleLog: console.log.mock.calls,
+      //@ts-expect-error
+      consoleDir: console.dir.mock.calls,
+    }).toMatchSnapshot();
+  });
+
+  it("bumps multi js json", function* () {
+    const jsonFolder = f.copy("pkg.js-yarn-workspace"); // 1.0.0
+
+    const commands = [
+      {
+        dependencies: ["yarn-workspace-base-pkg-b", "all"],
+        manager: "javascript",
+        path: "./",
+        pkg: "yarn-workspace-base-pkg-a",
+        type: "minor",
+        parents: {},
+      },
+      {
+        dependencies: undefined,
+        manager: "javascript",
+        path: undefined,
+        pkg: "yarn-workspace-base-pkg-b",
+        type: "minor",
+        parents: { "yarn-workspace-base-pkg-a": "null" },
+      },
+      {
+        dependencies: undefined,
+        manager: "javascript",
+        path: undefined,
+        pkg: "all",
+        type: "minor",
+        parents: {
+          "yarn-workspace-base-pkg-a": "null",
+          "yarn-workspace-base-pkg-b": "null",
+        },
+      },
+    ];
+
+    const config = {
+      ...configDefaults,
+      packages: {
+        "yarn-workspace-base-pkg-a": {
+          path: "./packages/pkg-a/",
+          manager: "javascript",
+          dependencies: ["yarn-workspace-base-pkg-b", "all"],
+        },
+        "yarn-workspace-base-pkg-b": {
+          path: "./packages/pkg-b/",
+          manager: "javascript",
+          dependencies: ["all"],
+        },
+        all: { version: true },
+      },
+    };
+
+    //@ts-expect-error
+    const allPackages = yield readAllPkgFiles({ config, cwd: jsonFolder });
+
+    yield apply({
+      //@ts-expect-error
+      commands,
+      config,
+      allPackages,
+      cwd: jsonFolder,
+      previewVersion: "branch-name.12345",
+    });
+    const modifiedPkgAFile = yield loadFile(
+      "packages/pkg-a/package.json",
+      jsonFolder
+    );
+    expect(modifiedPkgAFile.content).toBe(
+      "{\n" +
+        '  "name": "yarn-workspace-base-pkg-a",\n' +
+        '  "version": "1.0.0-branch-name.12345",\n' +
+        '  "dependencies": {\n' +
+        '    "yarn-workspace-base-pkg-b": "1.0.0-branch-name.12345"\n' +
+        "  }\n" +
+        "}\n"
+    );
+
+    const modifiedPkgBFile = yield loadFile(
+      "packages/pkg-b/package.json",
+      jsonFolder
+    );
+    expect(modifiedPkgBFile.content).toBe(
+      "{\n" +
+        '  "name": "yarn-workspace-base-pkg-b",\n' +
+        '  "version": "1.0.0-branch-name.12345"\n' +
+        "}\n"
+    );
+
+    expect({
+      //@ts-expect-error
+      consoleLog: console.log.mock.calls,
+      //@ts-expect-error
+      consoleDir: console.dir.mock.calls,
+    }).toMatchSnapshot();
+  });
+});
+
+describe("package file applies preview bump to pre-release", () => {
+  let restoreConsole: RestoreConsole;
+  beforeEach(() => {
+    restoreConsole = mockConsole(["log", "dir"]);
+  });
+  afterEach(() => {
+    restoreConsole();
+  });
+
+  it("bumps single js json without pre-release", function* () {
+    const jsonFolder = f.copy("pkg.js-single-prerelease-json"); // 0.5.9-abc.2
+
+    const commands = [
+      {
+        dependencies: undefined,
+        manager: "javascript",
+        path: "./",
+        pkg: "js-single-prerelease-json-fixture",
+        type: "minor",
+        parents: {},
+      },
+    ];
+
+    const config = {
+      ...configDefaults,
+      packages: {
+        "js-single-prerelease-json-fixture": {
+          path: "./",
+          manager: "javascript",
+        },
+      },
+    };
+
+    const allPackages = yield readAllPkgFiles({ config, cwd: jsonFolder });
+
+    yield apply({
+      //@ts-expect-error
+      commands,
+      config,
+      allPackages,
+      cwd: jsonFolder,
+      previewVersion: "branch-name.12345",
+    });
+    const modifiedFile = yield loadFile("package.json", jsonFolder);
+    expect(modifiedFile.content).toBe(
+      "{\n" +
+        '  "private": true,\n' +
+        '  "name": "js-single-prerelease-json-fixture",\n' +
+        '  "description": "A single package at the root. No monorepo setup.",\n' +
+        '  "version": "0.5.9-branch-name.12345"\n' +
+        "}\n"
+    );
+
+    expect({
+      //@ts-expect-error
+      consoleLog: console.log.mock.calls,
+      //@ts-expect-error
+      consoleDir: console.dir.mock.calls,
+    }).toMatchSnapshot();
+  });
+
+  it("bumps multi js json without pre-release", function* () {
+    const jsonFolder = f.copy("pkg.js-yarn-prerelease-workspace");
+
+    const commands = [
+      {
+        dependencies: ["yarn-workspace-base-pkg-b", "all"],
+        manager: "javascript",
+        path: "./",
+        pkg: "yarn-workspace-base-pkg-a",
+        type: "minor",
+        parents: {},
+      },
+      {
+        dependencies: undefined,
+        manager: "javascript",
+        path: undefined,
+        pkg: "yarn-workspace-base-pkg-b",
+        type: "minor",
+        parents: { "yarn-workspace-base-pkg-a": "null" },
+      },
+      {
+        dependencies: undefined,
+        manager: "javascript",
+        path: undefined,
+        pkg: "all",
+        type: "minor",
+        parents: {
+          "yarn-workspace-base-pkg-a": "null",
+          "yarn-workspace-base-pkg-b": "null",
+        },
+      },
+    ];
+
+    const config = {
+      packages: {
+        "yarn-workspace-base-pkg-a": {
+          path: "./packages/pkg-a/", // 1.0.0-abc.2
+          manager: "javascript",
+          dependencies: ["yarn-workspace-base-pkg-b", "all"],
+        },
+        "yarn-workspace-base-pkg-b": {
+          path: "./packages/pkg-b/", // 1.0.0-abc.3
+          manager: "javascript",
+          dependencies: ["all"],
+        },
+        all: { version: true },
+      },
+    };
+
+    //@ts-expect-error
+    const allPackages = yield readAllPkgFiles({ config, cwd: jsonFolder });
+
+    yield apply({
+      //@ts-expect-error
+      commands,
+      config,
+      allPackages,
+      cwd: jsonFolder,
+      previewVersion: "branch-name.12345",
+    });
+    const modifiedPkgAFile = yield loadFile(
+      "packages/pkg-a/package.json",
+      jsonFolder
+    );
+    expect(modifiedPkgAFile.content).toBe(
+      "{\n" +
+        '  "name": "yarn-workspace-base-pkg-a",\n' +
+        '  "version": "1.0.0-branch-name.12345",\n' +
+        '  "dependencies": {\n' +
+        '    "yarn-workspace-base-pkg-b": "1.0.0-branch-name.12345"\n' +
+        "  }\n" +
+        "}\n"
+    );
+
+    const modifiedPkgBFile = yield loadFile(
+      "packages/pkg-b/package.json",
+      jsonFolder
+    );
+    expect(modifiedPkgBFile.content).toBe(
+      "{\n" +
+        '  "name": "yarn-workspace-base-pkg-b",\n' +
+        '  "version": "1.0.0-branch-name.12345"\n' +
+        "}\n"
+    );
+
+    expect({
+      //@ts-expect-error
+      consoleLog: console.log.mock.calls,
+      //@ts-expect-error
+      consoleDir: console.dir.mock.calls,
+    }).toMatchSnapshot();
+  });
+});

--- a/packages/apply/test/apply.test.ts
+++ b/packages/apply/test/apply.test.ts
@@ -277,18 +277,19 @@ describe("package file apply bump (snapshot)", () => {
       );
 
       // this is a range dep which will not be patch bumped
-      const modifiedPkgCFile = yield loadFile(
-        "packages/pkg-c/package.json",
+      const modifiedPkgOneFile = yield loadFile(
+        "packages/pkg-one/package.json",
         jsonFolder
       );
-      expect(modifiedPkgCFile.content).toBe(
-        "{\n" +
-          '  "name": "yarn-workspace-base-pkg-c",\n' +
-          '  "version": "1.0.0",\n' +
-          '  "dependencies": {\n' +
-          '    "yarn-workspace-base-pkg-b": "^1.0.0"\n' +
-          "  }\n" +
-          "}\n"
+
+      expect(modifiedPkgOneFile.content).toEqual(
+        "{\r\n" +
+          '  "name": "yarn-workspace-base-pkg-one",\r\n' +
+          '  "version": "1.0.0",\r\n' +
+          '  "dependencies": {\r\n' +
+          '    "yarn-workspace-base-pkg-b": "^1.0.0"\r\n' +
+          "  }\r\n" +
+          "}\r\n"
       );
 
       expect({

--- a/packages/apply/test/apply.test.ts
+++ b/packages/apply/test/apply.test.ts
@@ -19,941 +19,635 @@ describe("package file apply bump (snapshot)", () => {
     restoreConsole();
   });
 
-  it("bumps single js json", function* () {
-    const jsonFolder = f.copy("pkg.js-single-json");
+  describe("on js", () => {
+    it("bumps single", function* () {
+      const jsonFolder = f.copy("pkg.js-single-json");
 
-    const commands = [
-      {
-        dependencies: undefined,
-        manager: "javascript",
-        path: "./",
-        pkg: "js-single-json-fixture",
-        type: "minor",
-        parents: {},
-      },
-    ];
-
-    const config = {
-      ...configDefaults,
-      packages: {
-        "js-single-json-fixture": {
-          path: "./",
+      const commands = [
+        {
+          dependencies: undefined,
           manager: "javascript",
+          path: "./",
+          pkg: "js-single-json-fixture",
+          type: "minor",
+          parents: {},
         },
-      },
-    };
+      ];
 
-    const allPackages = yield readAllPkgFiles({ config, cwd: jsonFolder });
+      const config = {
+        ...configDefaults,
+        packages: {
+          "js-single-json-fixture": {
+            path: "./",
+            manager: "javascript",
+          },
+        },
+      };
 
-    //@ts-expect-error
-    yield apply({ commands, config, allPackages, cwd: jsonFolder });
-    const modifiedFile = yield loadFile("package.json", jsonFolder);
-    expect(modifiedFile.content).toBe(
-      "{\n" +
-        '  "private": true,\n' +
-        '  "name": "js-single-json-fixture",\n' +
-        '  "description": "A single package at the root. No monorepo setup.",\n' +
-        '  "repository": "https://www.github.com/jbolda/covector.git",\n' +
-        '  "version": "0.6.0"\n' +
-        "}\n"
-    );
+      const allPackages = yield readAllPkgFiles({ config, cwd: jsonFolder });
 
-    expect({
       //@ts-expect-error
-      consoleLog: console.log.mock.calls,
+      yield apply({ commands, config, allPackages, cwd: jsonFolder });
+      const modifiedFile = yield loadFile("package.json", jsonFolder);
+      expect(modifiedFile.content).toBe(
+        "{\n" +
+          '  "private": true,\n' +
+          '  "name": "js-single-json-fixture",\n' +
+          '  "description": "A single package at the root. No monorepo setup.",\n' +
+          '  "repository": "https://www.github.com/jbolda/covector.git",\n' +
+          '  "version": "0.6.0"\n' +
+          "}\n"
+      );
+
+      expect({
+        //@ts-expect-error
+        consoleLog: console.log.mock.calls,
+        //@ts-expect-error
+        consoleDir: console.dir.mock.calls,
+      }).toMatchSnapshot();
+    });
+
+    it("fails bump single that satisfies range", function* () {
+      const jsonFolder = f.copy("pkg.js-single-json");
+
+      const commands = [
+        {
+          dependencies: undefined,
+          manager: "javascript",
+          path: "./",
+          pkg: "js-single-json-fixture",
+          type: "minor",
+          parents: {},
+          errorOnVersionRange: ">= 0.6.0",
+        },
+      ];
+
+      const config = {
+        ...configDefaults,
+        packages: {
+          "js-single-json-fixture": {
+            path: "./",
+            manager: "javascript",
+          },
+        },
+      };
+
+      const allPackages = yield readAllPkgFiles({ config, cwd: jsonFolder });
+      const applied = yield captureError(
+        //@ts-expect-error
+        apply({ commands, config, allPackages, cwd: jsonFolder })
+      );
+      expect(applied.message).toBe(
+        "js-single-json-fixture will be bumped to 0.6.0. This satisfies the range >= 0.6.0 which the configuration disallows. Please adjust your bump to accommodate the range or otherwise adjust the allowed range in `errorOnVersionRange`."
+      );
+      expect({
+        //@ts-expect-error
+        consoleLog: console.log.mock.calls,
+        //@ts-expect-error
+        consoleDir: console.dir.mock.calls,
+      }).toMatchSnapshot();
+    });
+
+    it("bumps multi", function* () {
+      const jsonFolder = f.copy("pkg.js-yarn-workspace");
+
+      const commands = [
+        {
+          dependencies: ["yarn-workspace-base-pkg-b", "all"],
+          manager: "javascript",
+          path: "./",
+          pkg: "yarn-workspace-base-pkg-a",
+          type: "minor",
+          parents: {},
+        },
+        {
+          dependencies: undefined,
+          manager: "javascript",
+          path: undefined,
+          pkg: "yarn-workspace-base-pkg-b",
+          type: "minor",
+          parents: { "yarn-workspace-base-pkg-a": "null" },
+        },
+        {
+          dependencies: undefined,
+          manager: "javascript",
+          path: undefined,
+          pkg: "all",
+          type: "minor",
+          parents: {
+            "yarn-workspace-base-pkg-a": "null",
+            "yarn-workspace-base-pkg-b": "null",
+          },
+        },
+      ];
+
+      const config = {
+        ...configDefaults,
+        packages: {
+          "yarn-workspace-base-pkg-a": {
+            path: "./packages/pkg-a/",
+            manager: "javascript",
+            dependencies: ["yarn-workspace-base-pkg-b", "all"],
+          },
+          "yarn-workspace-base-pkg-b": {
+            path: "./packages/pkg-b/",
+            manager: "javascript",
+            dependencies: ["all"],
+          },
+          all: { version: true },
+        },
+      };
+
       //@ts-expect-error
-      consoleDir: console.dir.mock.calls,
-    }).toMatchSnapshot();
+      const allPackages = yield readAllPkgFiles({ config, cwd: jsonFolder });
+
+      //@ts-expect-error
+      yield apply({ commands, config, allPackages, cwd: jsonFolder });
+      const modifiedPkgAFile = yield loadFile(
+        "packages/pkg-a/package.json",
+        jsonFolder
+      );
+      expect(modifiedPkgAFile.content).toBe(
+        "{\n" +
+          '  "name": "yarn-workspace-base-pkg-a",\n' +
+          '  "version": "1.1.0",\n' +
+          '  "dependencies": {\n' +
+          '    "yarn-workspace-base-pkg-b": "1.1.0"\n' +
+          "  }\n" +
+          "}\n"
+      );
+
+      const modifiedPkgBFile = yield loadFile(
+        "packages/pkg-b/package.json",
+        jsonFolder
+      );
+      expect(modifiedPkgBFile.content).toBe(
+        "{\n" +
+          '  "name": "yarn-workspace-base-pkg-b",\n' +
+          '  "version": "1.1.0"\n' +
+          "}\n"
+      );
+
+      expect({
+        //@ts-expect-error
+        consoleLog: console.log.mock.calls,
+        //@ts-expect-error
+        consoleDir: console.dir.mock.calls,
+      }).toMatchSnapshot();
+    });
   });
 
-  it("bumps single rust toml", function* () {
-    const rustFolder = f.copy("pkg.rust-single");
+  describe("on rust", () => {
+    it("bumps single", function* () {
+      const rustFolder = f.copy("pkg.rust-single");
 
-    const commands = [
-      {
-        dependencies: undefined,
-        manager: "rust",
-        path: "./",
-        pkg: "rust-single-fixture",
-        type: "minor" as CommonBumps,
-        parents: {},
-      },
-    ];
-
-    const config = {
-      ...configDefaults,
-      packages: {
-        "rust-single-fixture": {
-          path: "./",
+      const commands = [
+        {
+          dependencies: undefined,
           manager: "rust",
+          path: "./",
+          pkg: "rust-single-fixture",
+          type: "minor" as CommonBumps,
+          parents: {},
         },
-      },
-    };
+      ];
 
-    const allPackages = yield readAllPkgFiles({ config, cwd: rustFolder });
+      const config = {
+        ...configDefaults,
+        packages: {
+          "rust-single-fixture": {
+            path: "./",
+            manager: "rust",
+          },
+        },
+      };
 
-    //@ts-expect-error
-    yield apply({ commands, allPackages, cwd: rustFolder });
-    const modifiedFile = yield loadFile("Cargo.toml", rustFolder);
-    expect(modifiedFile.content).toBe(
-      '[package]\nname = "rust-single-fixture"\nversion = "0.6.0"\n'
-    );
+      const allPackages = yield readAllPkgFiles({ config, cwd: rustFolder });
 
-    expect({
       //@ts-expect-error
-      consoleLog: console.log.mock.calls,
+      yield apply({ commands, allPackages, cwd: rustFolder });
+      const modifiedFile = yield loadFile("Cargo.toml", rustFolder);
+      expect(modifiedFile.content).toBe(
+        '[package]\nname = "rust-single-fixture"\nversion = "0.6.0"\n'
+      );
+
+      expect({
+        //@ts-expect-error
+        consoleLog: console.log.mock.calls,
+        //@ts-expect-error
+        consoleDir: console.dir.mock.calls,
+      }).toMatchSnapshot();
+    });
+
+    it("fails bumps single that satisfies range", function* () {
+      const rustFolder = f.copy("pkg.rust-single");
+
+      const commands = [
+        {
+          dependencies: undefined,
+          manager: "rust",
+          path: "./",
+          pkg: "rust-single-fixture",
+          type: "minor",
+          parents: {},
+          errorOnVersionRange: ">= 0.6.0",
+        },
+      ];
+
+      const config = {
+        ...configDefaults,
+        packages: {
+          "rust-single-fixture": {
+            path: "./",
+            manager: "rust",
+          },
+        },
+      };
+
+      const allPackages = yield readAllPkgFiles({ config, cwd: rustFolder });
+
+      const applied = yield captureError(
+        //@ts-expect-error
+        apply({ commands, config, allPackages, cwd: rustFolder })
+      );
+      expect(applied.message).toBe(
+        "rust-single-fixture will be bumped to 0.6.0. This satisfies the range >= 0.6.0 which the configuration disallows. Please adjust your bump to accommodate the range or otherwise adjust the allowed range in `errorOnVersionRange`."
+      );
+      expect({
+        //@ts-expect-error
+        consoleLog: console.log.mock.calls,
+        //@ts-expect-error
+        consoleDir: console.dir.mock.calls,
+      }).toMatchSnapshot();
+    });
+
+    it("bumps multi", function* () {
+      const rustFolder = f.copy("pkg.rust-multi");
+
+      const commands = [
+        {
+          dependencies: ["rust_pkg_b_fixture"],
+          manager: "rust",
+          path: "./pkg-a/",
+          pkg: "rust_pkg_a_fixture",
+          type: "minor",
+          parents: {},
+        },
+        {
+          dependencies: undefined,
+          manager: "rust",
+          path: "./pkg-b/",
+          pkg: "rust_pkg_b_fixture",
+          type: "minor",
+          parents: {},
+        },
+      ];
+
+      const config = {
+        ...configDefaults,
+        packages: {
+          rust_pkg_a_fixture: {
+            path: "./pkg-a/",
+            manager: "rust",
+          },
+          rust_pkg_b_fixture: {
+            path: "./pkg-b/",
+            manager: "rust",
+          },
+        },
+      };
+
+      const allPackages = yield readAllPkgFiles({ config, cwd: rustFolder });
+
       //@ts-expect-error
-      consoleDir: console.dir.mock.calls,
-    }).toMatchSnapshot();
+      yield apply({ commands, config, allPackages, cwd: rustFolder });
+
+      const modifiedAPKGFile = yield loadFile("pkg-a/Cargo.toml", rustFolder);
+      expect(modifiedAPKGFile.content).toBe(
+        "[package]\n" +
+          'name = "rust_pkg_a_fixture"\n' +
+          'version = "0.6.0"\n' +
+          "\n" +
+          "[dependencies]\n" +
+          'rust_pkg_b_fixture = "0.9.0"\n'
+      );
+
+      const modifiedBPKGFile = yield loadFile("pkg-b/Cargo.toml", rustFolder);
+      expect(modifiedBPKGFile.content).toBe(
+        "[package]\n" + 'name = "rust_pkg_b_fixture"\n' + 'version = "0.9.0"\n'
+      );
+
+      expect({
+        //@ts-expect-error
+        consoleLog: console.log.mock.calls,
+        //@ts-expect-error
+        consoleDir: console.dir.mock.calls,
+      }).toMatchSnapshot();
+    });
+
+    it("bumps multi with object dep", function* () {
+      const rustFolder = f.copy("pkg.rust-multi-object-dep");
+
+      const commands = [
+        {
+          dependencies: ["rust_pkg_b_fixture"],
+          manager: "rust",
+          path: "./pkg-a/",
+          pkg: "rust_pkg_a_fixture",
+          type: "minor",
+          parents: {},
+        },
+        {
+          dependencies: undefined,
+          manager: "rust",
+          path: "./pkg-b/",
+          pkg: "rust_pkg_b_fixture",
+          type: "minor",
+          parents: {},
+        },
+      ];
+
+      const config = {
+        ...configDefaults,
+        packages: {
+          rust_pkg_a_fixture: {
+            path: "./pkg-a/",
+            manager: "rust",
+          },
+          rust_pkg_b_fixture: {
+            path: "./pkg-b/",
+            manager: "rust",
+          },
+        },
+      };
+
+      const allPackages = yield readAllPkgFiles({ config, cwd: rustFolder });
+
+      //@ts-expect-error
+      yield apply({ commands, config, allPackages, cwd: rustFolder });
+
+      const modifiedAPKGFile = yield loadFile("pkg-a/Cargo.toml", rustFolder);
+      expect(modifiedAPKGFile.content).toBe(
+        "[package]\n" +
+          'name = "rust_pkg_a_fixture"\n' +
+          'version = "0.6.0"\n' +
+          "\n" +
+          "[dependencies]\n" +
+          'rust_pkg_b_fixture = { version = "0.9.0", path = "../rust_pkg_b_fixture" }\n'
+      );
+
+      const modifiedBPKGFile = yield loadFile("pkg-b/Cargo.toml", rustFolder);
+      expect(modifiedBPKGFile.content).toBe(
+        "[package]\n" + 'name = "rust_pkg_b_fixture"\n' + 'version = "0.9.0"\n'
+      );
+
+      expect({
+        //@ts-expect-error
+        consoleLog: console.log.mock.calls,
+        //@ts-expect-error
+        consoleDir: console.dir.mock.calls,
+      }).toMatchSnapshot();
+    });
+
+    it("bumps multi with dep missing patch", function* () {
+      const rustFolder = f.copy("pkg.rust-multi-no-patch-dep");
+
+      const commands = [
+        {
+          dependencies: ["rust_pkg_b_fixture"],
+          manager: "rust",
+          path: "./pkg-a/",
+          pkg: "rust_pkg_a_fixture",
+          type: "minor",
+          parents: {},
+        },
+        {
+          dependencies: undefined,
+          manager: "rust",
+          path: "./pkg-b/",
+          pkg: "rust_pkg_b_fixture",
+          type: "minor",
+          parents: {},
+        },
+      ];
+
+      const config = {
+        ...configDefaults,
+        packages: {
+          rust_pkg_a_fixture: {
+            path: "./pkg-a/",
+            manager: "rust",
+          },
+          rust_pkg_b_fixture: {
+            path: "./pkg-b/",
+            manager: "rust",
+          },
+        },
+      };
+
+      const allPackages = yield readAllPkgFiles({ config, cwd: rustFolder });
+
+      //@ts-expect-error
+      yield apply({ commands, config, allPackages, cwd: rustFolder });
+
+      const modifiedAPKGFile = yield loadFile("pkg-a/Cargo.toml", rustFolder);
+      expect(modifiedAPKGFile.content).toBe(
+        "[package]\n" +
+          'name = "rust_pkg_a_fixture"\n' +
+          'version = "0.6.0"\n' +
+          "\n" +
+          "[dependencies]\n" +
+          'rust_pkg_b_fixture = "0.9"\n'
+      );
+
+      const modifiedBPKGFile = yield loadFile("pkg-b/Cargo.toml", rustFolder);
+      expect(modifiedBPKGFile.content).toBe(
+        "[package]\n" + 'name = "rust_pkg_b_fixture"\n' + 'version = "0.9.0"\n'
+      );
+
+      expect({
+        //@ts-expect-error
+        consoleLog: console.log.mock.calls,
+        //@ts-expect-error
+        consoleDir: console.dir.mock.calls,
+      }).toMatchSnapshot();
+    });
+
+    it("bump multi as patch with object dep missing patch", function* () {
+      const rustFolder = f.copy("pkg.rust-multi-object-no-patch-dep");
+
+      const commands = [
+        {
+          dependencies: ["rust_pkg_b_fixture"],
+          manager: "rust",
+          path: "./pkg-a/",
+          pkg: "rust_pkg_a_fixture",
+          type: "patch",
+          parents: {},
+        },
+        {
+          dependencies: undefined,
+          manager: "rust",
+          path: "./pkg-b/",
+          pkg: "rust_pkg_b_fixture",
+          type: "patch",
+          parents: {},
+        },
+      ];
+
+      const config = {
+        ...configDefaults,
+        packages: {
+          rust_pkg_a_fixture: {
+            // version: 0.5.0 with 0.8 dep on pkg-b
+            path: "./pkg-a/",
+            manager: "rust",
+          },
+          rust_pkg_b_fixture: {
+            // version: 0.8.8
+            path: "./pkg-b/",
+            manager: "rust",
+          },
+        },
+      };
+
+      const allPackages = yield readAllPkgFiles({ config, cwd: rustFolder });
+
+      //@ts-expect-error
+      yield apply({ commands, config, allPackages, cwd: rustFolder });
+
+      const modifiedAPKGFile = yield loadFile("pkg-a/Cargo.toml", rustFolder);
+      expect(modifiedAPKGFile.content).toBe(
+        "[package]\n" +
+          'name = "rust_pkg_a_fixture"\n' +
+          'version = "0.5.1"\n' +
+          "\n" +
+          "[dependencies]\n" +
+          'rust_pkg_b_fixture = { version = "0.8", path = "../rust_pkg_b_fixture" }\n'
+      );
+
+      const modifiedBPKGFile = yield loadFile("pkg-b/Cargo.toml", rustFolder);
+      expect(modifiedBPKGFile.content).toBe(
+        "[package]\n" + 'name = "rust_pkg_b_fixture"\n' + 'version = "0.8.9"\n'
+      );
+
+      expect({
+        //@ts-expect-error
+        consoleLog: console.log.mock.calls,
+        //@ts-expect-error
+        consoleDir: console.dir.mock.calls,
+      }).toMatchSnapshot();
+    });
+
+    it("bumps multi as minor with object dep missing patch", function* () {
+      const rustFolder = f.copy("pkg.rust-multi-object-no-patch-dep");
+
+      const commands = [
+        {
+          dependencies: ["rust_pkg_b_fixture"],
+          manager: "rust",
+          path: "./pkg-a/",
+          pkg: "rust_pkg_a_fixture",
+          type: "minor",
+          parents: {},
+        },
+        {
+          dependencies: undefined,
+          manager: "rust",
+          path: "./pkg-b/",
+          pkg: "rust_pkg_b_fixture",
+          type: "minor",
+          parents: {},
+        },
+      ];
+
+      const config = {
+        ...configDefaults,
+        packages: {
+          rust_pkg_a_fixture: {
+            path: "./pkg-a/",
+            manager: "rust",
+          },
+          rust_pkg_b_fixture: {
+            path: "./pkg-b/",
+            manager: "rust",
+          },
+        },
+      };
+
+      const allPackages = yield readAllPkgFiles({ config, cwd: rustFolder });
+
+      //@ts-expect-error
+      yield apply({ commands, config, allPackages, cwd: rustFolder });
+
+      const modifiedAPKGFile = yield loadFile("pkg-a/Cargo.toml", rustFolder);
+      expect(modifiedAPKGFile.content).toBe(
+        "[package]\n" +
+          'name = "rust_pkg_a_fixture"\n' +
+          'version = "0.6.0"\n' +
+          "\n" +
+          "[dependencies]\n" +
+          'rust_pkg_b_fixture = { version = "0.9", path = "../rust_pkg_b_fixture" }\n'
+      );
+
+      const modifiedBPKGFile = yield loadFile("pkg-b/Cargo.toml", rustFolder);
+      expect(modifiedBPKGFile.content).toBe(
+        "[package]\n" + 'name = "rust_pkg_b_fixture"\n' + 'version = "0.9.0"\n'
+      );
+
+      expect({
+        //@ts-expect-error
+        consoleLog: console.log.mock.calls,
+        //@ts-expect-error
+        consoleDir: console.dir.mock.calls,
+      }).toMatchSnapshot();
+    });
   });
 
-  it("bumps single yaml toml", function* () {
-    const flutterFolder = f.copy("pkg.dart-flutter-single");
+  describe("on yaml", () => {
+    it("bumps single", function* () {
+      const flutterFolder = f.copy("pkg.dart-flutter-single");
 
-    const commands = [
-      {
-        dependencies: undefined,
-        manager: "flutter",
-        path: "./",
-        pkg: "test_app",
-        type: "minor",
-        parents: {},
-      },
-    ];
-
-    const config = {
-      ...configDefaults,
-      packages: {
-        test_app: {
-          path: "./",
+      const commands = [
+        {
+          dependencies: undefined,
           manager: "flutter",
-        },
-      },
-    };
-
-    const allPackages = yield readAllPkgFiles({ config, cwd: flutterFolder });
-
-    //@ts-expect-error
-    yield apply({ commands, config, allPackages, cwd: flutterFolder });
-    const modifiedFile = yield loadFile("pubspec.yaml", flutterFolder);
-    expect(modifiedFile.content).toBe(
-      "name: test_app\ndescription: a great one\nhomepage: https://github.com/\nversion: 0.4.0\n" +
-        "environment:\n  sdk: '>=2.10.0 <3.0.0'\n" +
-        "dependencies:\n  flutter:\n    sdk: flutter\n  meta: any\n  provider: ^4.3.2\n  related_package:\n    git:\n      url: git@github.com:jbolda/covector.git\n      ref: main\n      path: __fixtures__/haha/\n" +
-        "dev_dependencies:\n  flutter_test:\n    sdk: flutter\n  build_runner: any\n  json_serializable: any\n  mobx_codegen: any\n" +
-        "flutter:\n  assets:\n    - assets/schema/\n    - assets/localization/\n"
-    );
-
-    expect({
-      //@ts-expect-error
-      consoleLog: console.log.mock.calls,
-      //@ts-expect-error
-      consoleDir: console.dir.mock.calls,
-    }).toMatchSnapshot();
-  });
-
-  it("fails bump single js json that satisfies range", function* () {
-    const jsonFolder = f.copy("pkg.js-single-json");
-
-    const commands = [
-      {
-        dependencies: undefined,
-        manager: "javascript",
-        path: "./",
-        pkg: "js-single-json-fixture",
-        type: "minor",
-        parents: {},
-        errorOnVersionRange: ">= 0.6.0",
-      },
-    ];
-
-    const config = {
-      ...configDefaults,
-      packages: {
-        "js-single-json-fixture": {
           path: "./",
-          manager: "javascript",
+          pkg: "test_app",
+          type: "minor",
+          parents: {},
         },
-      },
-    };
+      ];
 
-    const allPackages = yield readAllPkgFiles({ config, cwd: jsonFolder });
-    const applied = yield captureError(
-      //@ts-expect-error
-      apply({ commands, config, allPackages, cwd: jsonFolder })
-    );
-    expect(applied.message).toBe(
-      "js-single-json-fixture will be bumped to 0.6.0. This satisfies the range >= 0.6.0 which the configuration disallows. Please adjust your bump to accommodate the range or otherwise adjust the allowed range in `errorOnVersionRange`."
-    );
-    expect({
-      //@ts-expect-error
-      consoleLog: console.log.mock.calls,
-      //@ts-expect-error
-      consoleDir: console.dir.mock.calls,
-    }).toMatchSnapshot();
-  });
-
-  it("fails bumps single rust toml that satisfies range", function* () {
-    const rustFolder = f.copy("pkg.rust-single");
-
-    const commands = [
-      {
-        dependencies: undefined,
-        manager: "rust",
-        path: "./",
-        pkg: "rust-single-fixture",
-        type: "minor",
-        parents: {},
-        errorOnVersionRange: ">= 0.6.0",
-      },
-    ];
-
-    const config = {
-      ...configDefaults,
-      packages: {
-        "rust-single-fixture": {
-          path: "./",
-          manager: "rust",
+      const config = {
+        ...configDefaults,
+        packages: {
+          test_app: {
+            path: "./",
+            manager: "flutter",
+          },
         },
-      },
-    };
+      };
 
-    const allPackages = yield readAllPkgFiles({ config, cwd: rustFolder });
+      const allPackages = yield readAllPkgFiles({ config, cwd: flutterFolder });
 
-    const applied = yield captureError(
       //@ts-expect-error
-      apply({ commands, config, allPackages, cwd: rustFolder })
-    );
-    expect(applied.message).toBe(
-      "rust-single-fixture will be bumped to 0.6.0. This satisfies the range >= 0.6.0 which the configuration disallows. Please adjust your bump to accommodate the range or otherwise adjust the allowed range in `errorOnVersionRange`."
-    );
-    expect({
-      //@ts-expect-error
-      consoleLog: console.log.mock.calls,
-      //@ts-expect-error
-      consoleDir: console.dir.mock.calls,
-    }).toMatchSnapshot();
-  });
+      yield apply({ commands, config, allPackages, cwd: flutterFolder });
+      const modifiedFile = yield loadFile("pubspec.yaml", flutterFolder);
+      expect(modifiedFile.content).toBe(
+        "name: test_app\ndescription: a great one\nhomepage: https://github.com/\nversion: 0.4.0\n" +
+          "environment:\n  sdk: '>=2.10.0 <3.0.0'\n" +
+          "dependencies:\n  flutter:\n    sdk: flutter\n  meta: any\n  provider: ^4.3.2\n  related_package:\n    git:\n      url: git@github.com:jbolda/covector.git\n      ref: main\n      path: __fixtures__/haha/\n" +
+          "dev_dependencies:\n  flutter_test:\n    sdk: flutter\n  build_runner: any\n  json_serializable: any\n  mobx_codegen: any\n" +
+          "flutter:\n  assets:\n    - assets/schema/\n    - assets/localization/\n"
+      );
 
-  it("bumps multi js json", function* () {
-    const jsonFolder = f.copy("pkg.js-yarn-workspace");
-
-    const commands = [
-      {
-        dependencies: ["yarn-workspace-base-pkg-b", "all"],
-        manager: "javascript",
-        path: "./",
-        pkg: "yarn-workspace-base-pkg-a",
-        type: "minor",
-        parents: {},
-      },
-      {
-        dependencies: undefined,
-        manager: "javascript",
-        path: undefined,
-        pkg: "yarn-workspace-base-pkg-b",
-        type: "minor",
-        parents: { "yarn-workspace-base-pkg-a": "null" },
-      },
-      {
-        dependencies: undefined,
-        manager: "javascript",
-        path: undefined,
-        pkg: "all",
-        type: "minor",
-        parents: {
-          "yarn-workspace-base-pkg-a": "null",
-          "yarn-workspace-base-pkg-b": "null",
-        },
-      },
-    ];
-
-    const config = {
-      ...configDefaults,
-      packages: {
-        "yarn-workspace-base-pkg-a": {
-          path: "./packages/pkg-a/",
-          manager: "javascript",
-          dependencies: ["yarn-workspace-base-pkg-b", "all"],
-        },
-        "yarn-workspace-base-pkg-b": {
-          path: "./packages/pkg-b/",
-          manager: "javascript",
-          dependencies: ["all"],
-        },
-        all: { version: true },
-      },
-    };
-
-    //@ts-expect-error
-    const allPackages = yield readAllPkgFiles({ config, cwd: jsonFolder });
-
-    //@ts-expect-error
-    yield apply({ commands, config, allPackages, cwd: jsonFolder });
-    const modifiedPkgAFile = yield loadFile(
-      "packages/pkg-a/package.json",
-      jsonFolder
-    );
-    expect(modifiedPkgAFile.content).toBe(
-      "{\n" +
-        '  "name": "yarn-workspace-base-pkg-a",\n' +
-        '  "version": "1.1.0",\n' +
-        '  "dependencies": {\n' +
-        '    "yarn-workspace-base-pkg-b": "1.1.0"\n' +
-        "  }\n" +
-        "}\n"
-    );
-
-    const modifiedPkgBFile = yield loadFile(
-      "packages/pkg-b/package.json",
-      jsonFolder
-    );
-    expect(modifiedPkgBFile.content).toBe(
-      "{\n" +
-        '  "name": "yarn-workspace-base-pkg-b",\n' +
-        '  "version": "1.1.0"\n' +
-        "}\n"
-    );
-
-    expect({
-      //@ts-expect-error
-      consoleLog: console.log.mock.calls,
-      //@ts-expect-error
-      consoleDir: console.dir.mock.calls,
-    }).toMatchSnapshot();
-  });
-
-  it("bumps multi rust toml", function* () {
-    const rustFolder = f.copy("pkg.rust-multi");
-
-    const commands = [
-      {
-        dependencies: ["rust_pkg_b_fixture"],
-        manager: "rust",
-        path: "./pkg-a/",
-        pkg: "rust_pkg_a_fixture",
-        type: "minor",
-        parents: {},
-      },
-      {
-        dependencies: undefined,
-        manager: "rust",
-        path: "./pkg-b/",
-        pkg: "rust_pkg_b_fixture",
-        type: "minor",
-        parents: {},
-      },
-    ];
-
-    const config = {
-      ...configDefaults,
-      packages: {
-        rust_pkg_a_fixture: {
-          path: "./pkg-a/",
-          manager: "rust",
-        },
-        rust_pkg_b_fixture: {
-          path: "./pkg-b/",
-          manager: "rust",
-        },
-      },
-    };
-
-    const allPackages = yield readAllPkgFiles({ config, cwd: rustFolder });
-
-    //@ts-expect-error
-    yield apply({ commands, config, allPackages, cwd: rustFolder });
-
-    const modifiedAPKGFile = yield loadFile("pkg-a/Cargo.toml", rustFolder);
-    expect(modifiedAPKGFile.content).toBe(
-      "[package]\n" +
-        'name = "rust_pkg_a_fixture"\n' +
-        'version = "0.6.0"\n' +
-        "\n" +
-        "[dependencies]\n" +
-        'rust_pkg_b_fixture = "0.9.0"\n'
-    );
-
-    const modifiedBPKGFile = yield loadFile("pkg-b/Cargo.toml", rustFolder);
-    expect(modifiedBPKGFile.content).toBe(
-      "[package]\n" + 'name = "rust_pkg_b_fixture"\n' + 'version = "0.9.0"\n'
-    );
-
-    expect({
-      //@ts-expect-error
-      consoleLog: console.log.mock.calls,
-      //@ts-expect-error
-      consoleDir: console.dir.mock.calls,
-    }).toMatchSnapshot();
-  });
-
-  it("bumps multi rust toml with object dep", function* () {
-    const rustFolder = f.copy("pkg.rust-multi-object-dep");
-
-    const commands = [
-      {
-        dependencies: ["rust_pkg_b_fixture"],
-        manager: "rust",
-        path: "./pkg-a/",
-        pkg: "rust_pkg_a_fixture",
-        type: "minor",
-        parents: {},
-      },
-      {
-        dependencies: undefined,
-        manager: "rust",
-        path: "./pkg-b/",
-        pkg: "rust_pkg_b_fixture",
-        type: "minor",
-        parents: {},
-      },
-    ];
-
-    const config = {
-      ...configDefaults,
-      packages: {
-        rust_pkg_a_fixture: {
-          path: "./pkg-a/",
-          manager: "rust",
-        },
-        rust_pkg_b_fixture: {
-          path: "./pkg-b/",
-          manager: "rust",
-        },
-      },
-    };
-
-    const allPackages = yield readAllPkgFiles({ config, cwd: rustFolder });
-
-    //@ts-expect-error
-    yield apply({ commands, config, allPackages, cwd: rustFolder });
-
-    const modifiedAPKGFile = yield loadFile("pkg-a/Cargo.toml", rustFolder);
-    expect(modifiedAPKGFile.content).toBe(
-      "[package]\n" +
-        'name = "rust_pkg_a_fixture"\n' +
-        'version = "0.6.0"\n' +
-        "\n" +
-        "[dependencies]\n" +
-        'rust_pkg_b_fixture = { version = "0.9.0", path = "../rust_pkg_b_fixture" }\n'
-    );
-
-    const modifiedBPKGFile = yield loadFile("pkg-b/Cargo.toml", rustFolder);
-    expect(modifiedBPKGFile.content).toBe(
-      "[package]\n" + 'name = "rust_pkg_b_fixture"\n' + 'version = "0.9.0"\n'
-    );
-
-    expect({
-      //@ts-expect-error
-      consoleLog: console.log.mock.calls,
-      //@ts-expect-error
-      consoleDir: console.dir.mock.calls,
-    }).toMatchSnapshot();
-  });
-
-  it("bumps multi rust toml with dep missing patch", function* () {
-    const rustFolder = f.copy("pkg.rust-multi-no-patch-dep");
-
-    const commands = [
-      {
-        dependencies: ["rust_pkg_b_fixture"],
-        manager: "rust",
-        path: "./pkg-a/",
-        pkg: "rust_pkg_a_fixture",
-        type: "minor",
-        parents: {},
-      },
-      {
-        dependencies: undefined,
-        manager: "rust",
-        path: "./pkg-b/",
-        pkg: "rust_pkg_b_fixture",
-        type: "minor",
-        parents: {},
-      },
-    ];
-
-    const config = {
-      ...configDefaults,
-      packages: {
-        rust_pkg_a_fixture: {
-          path: "./pkg-a/",
-          manager: "rust",
-        },
-        rust_pkg_b_fixture: {
-          path: "./pkg-b/",
-          manager: "rust",
-        },
-      },
-    };
-
-    const allPackages = yield readAllPkgFiles({ config, cwd: rustFolder });
-
-    //@ts-expect-error
-    yield apply({ commands, config, allPackages, cwd: rustFolder });
-
-    const modifiedAPKGFile = yield loadFile("pkg-a/Cargo.toml", rustFolder);
-    expect(modifiedAPKGFile.content).toBe(
-      "[package]\n" +
-        'name = "rust_pkg_a_fixture"\n' +
-        'version = "0.6.0"\n' +
-        "\n" +
-        "[dependencies]\n" +
-        'rust_pkg_b_fixture = "0.9"\n'
-    );
-
-    const modifiedBPKGFile = yield loadFile("pkg-b/Cargo.toml", rustFolder);
-    expect(modifiedBPKGFile.content).toBe(
-      "[package]\n" + 'name = "rust_pkg_b_fixture"\n' + 'version = "0.9.0"\n'
-    );
-
-    expect({
-      //@ts-expect-error
-      consoleLog: console.log.mock.calls,
-      //@ts-expect-error
-      consoleDir: console.dir.mock.calls,
-    }).toMatchSnapshot();
-  });
-
-  it("bump multi rust toml as patch with object dep missing patch", function* () {
-    const rustFolder = f.copy("pkg.rust-multi-object-no-patch-dep");
-
-    const commands = [
-      {
-        dependencies: ["rust_pkg_b_fixture"],
-        manager: "rust",
-        path: "./pkg-a/",
-        pkg: "rust_pkg_a_fixture",
-        type: "patch",
-        parents: {},
-      },
-      {
-        dependencies: undefined,
-        manager: "rust",
-        path: "./pkg-b/",
-        pkg: "rust_pkg_b_fixture",
-        type: "patch",
-        parents: {},
-      },
-    ];
-
-    const config = {
-      ...configDefaults,
-      packages: {
-        rust_pkg_a_fixture: {
-          // version: 0.5.0 with 0.8 dep on pkg-b
-          path: "./pkg-a/",
-          manager: "rust",
-        },
-        rust_pkg_b_fixture: {
-          // version: 0.8.8
-          path: "./pkg-b/",
-          manager: "rust",
-        },
-      },
-    };
-
-    const allPackages = yield readAllPkgFiles({ config, cwd: rustFolder });
-
-    //@ts-expect-error
-    yield apply({ commands, config, allPackages, cwd: rustFolder });
-
-    const modifiedAPKGFile = yield loadFile("pkg-a/Cargo.toml", rustFolder);
-    expect(modifiedAPKGFile.content).toBe(
-      "[package]\n" +
-        'name = "rust_pkg_a_fixture"\n' +
-        'version = "0.5.1"\n' +
-        "\n" +
-        "[dependencies]\n" +
-        'rust_pkg_b_fixture = { version = "0.8", path = "../rust_pkg_b_fixture" }\n'
-    );
-
-    const modifiedBPKGFile = yield loadFile("pkg-b/Cargo.toml", rustFolder);
-    expect(modifiedBPKGFile.content).toBe(
-      "[package]\n" + 'name = "rust_pkg_b_fixture"\n' + 'version = "0.8.9"\n'
-    );
-
-    expect({
-      //@ts-expect-error
-      consoleLog: console.log.mock.calls,
-      //@ts-expect-error
-      consoleDir: console.dir.mock.calls,
-    }).toMatchSnapshot();
-  });
-
-  it("bumps multi rust toml as minor with object dep missing patch", function* () {
-    const rustFolder = f.copy("pkg.rust-multi-object-no-patch-dep");
-
-    const commands = [
-      {
-        dependencies: ["rust_pkg_b_fixture"],
-        manager: "rust",
-        path: "./pkg-a/",
-        pkg: "rust_pkg_a_fixture",
-        type: "minor",
-        parents: {},
-      },
-      {
-        dependencies: undefined,
-        manager: "rust",
-        path: "./pkg-b/",
-        pkg: "rust_pkg_b_fixture",
-        type: "minor",
-        parents: {},
-      },
-    ];
-
-    const config = {
-      ...configDefaults,
-      packages: {
-        rust_pkg_a_fixture: {
-          path: "./pkg-a/",
-          manager: "rust",
-        },
-        rust_pkg_b_fixture: {
-          path: "./pkg-b/",
-          manager: "rust",
-        },
-      },
-    };
-
-    const allPackages = yield readAllPkgFiles({ config, cwd: rustFolder });
-
-    //@ts-expect-error
-    yield apply({ commands, config, allPackages, cwd: rustFolder });
-
-    const modifiedAPKGFile = yield loadFile("pkg-a/Cargo.toml", rustFolder);
-    expect(modifiedAPKGFile.content).toBe(
-      "[package]\n" +
-        'name = "rust_pkg_a_fixture"\n' +
-        'version = "0.6.0"\n' +
-        "\n" +
-        "[dependencies]\n" +
-        'rust_pkg_b_fixture = { version = "0.9", path = "../rust_pkg_b_fixture" }\n'
-    );
-
-    const modifiedBPKGFile = yield loadFile("pkg-b/Cargo.toml", rustFolder);
-    expect(modifiedBPKGFile.content).toBe(
-      "[package]\n" + 'name = "rust_pkg_b_fixture"\n' + 'version = "0.9.0"\n'
-    );
-
-    expect({
-      //@ts-expect-error
-      consoleLog: console.log.mock.calls,
-      //@ts-expect-error
-      consoleDir: console.dir.mock.calls,
-    }).toMatchSnapshot();
-  });
-});
-
-describe("package file applies preview bump", () => {
-  let restoreConsole: RestoreConsole;
-  beforeEach(() => {
-    restoreConsole = mockConsole(["log", "dir"]);
-  });
-  afterEach(() => {
-    restoreConsole();
-  });
-
-  it("bumps single js json", function* () {
-    const jsonFolder = f.copy("pkg.js-single-json"); // 0.5.9
-
-    const commands = [
-      {
-        dependencies: undefined,
-        manager: "javascript",
-        path: "./",
-        pkg: "js-single-json-fixture",
-        type: "minor",
-        parents: {},
-      },
-    ];
-
-    const config = {
-      ...configDefaults,
-      packages: {
-        "js-single-json-fixture": {
-          path: "./",
-          manager: "javascript",
-        },
-      },
-    };
-
-    const allPackages = yield readAllPkgFiles({ config, cwd: jsonFolder });
-
-    yield apply({
-      //@ts-expect-error
-      commands,
-      config,
-      cwd: jsonFolder,
-      allPackages,
-      previewVersion: "branch-name.12345",
+      expect({
+        //@ts-expect-error
+        consoleLog: console.log.mock.calls,
+        //@ts-expect-error
+        consoleDir: console.dir.mock.calls,
+      }).toMatchSnapshot();
     });
-    const modifiedFile = yield loadFile("package.json", jsonFolder);
-    expect(modifiedFile.content).toBe(
-      "{\n" +
-        '  "private": true,\n' +
-        '  "name": "js-single-json-fixture",\n' +
-        '  "description": "A single package at the root. No monorepo setup.",\n' +
-        '  "repository": "https://www.github.com/jbolda/covector.git",\n' +
-        '  "version": "0.5.9-branch-name.12345"\n' +
-        "}\n"
-    );
-
-    expect({
-      //@ts-expect-error
-      consoleLog: console.log.mock.calls,
-      //@ts-expect-error
-      consoleDir: console.dir.mock.calls,
-    }).toMatchSnapshot();
-  });
-
-  it("bumps multi js json", function* () {
-    const jsonFolder = f.copy("pkg.js-yarn-workspace"); // 1.0.0
-
-    const commands = [
-      {
-        dependencies: ["yarn-workspace-base-pkg-b", "all"],
-        manager: "javascript",
-        path: "./",
-        pkg: "yarn-workspace-base-pkg-a",
-        type: "minor",
-        parents: {},
-      },
-      {
-        dependencies: undefined,
-        manager: "javascript",
-        path: undefined,
-        pkg: "yarn-workspace-base-pkg-b",
-        type: "minor",
-        parents: { "yarn-workspace-base-pkg-a": "null" },
-      },
-      {
-        dependencies: undefined,
-        manager: "javascript",
-        path: undefined,
-        pkg: "all",
-        type: "minor",
-        parents: {
-          "yarn-workspace-base-pkg-a": "null",
-          "yarn-workspace-base-pkg-b": "null",
-        },
-      },
-    ];
-
-    const config = {
-      ...configDefaults,
-      packages: {
-        "yarn-workspace-base-pkg-a": {
-          path: "./packages/pkg-a/",
-          manager: "javascript",
-          dependencies: ["yarn-workspace-base-pkg-b", "all"],
-        },
-        "yarn-workspace-base-pkg-b": {
-          path: "./packages/pkg-b/",
-          manager: "javascript",
-          dependencies: ["all"],
-        },
-        all: { version: true },
-      },
-    };
-
-    //@ts-expect-error
-    const allPackages = yield readAllPkgFiles({ config, cwd: jsonFolder });
-
-    yield apply({
-      //@ts-expect-error
-      commands,
-      config,
-      allPackages,
-      cwd: jsonFolder,
-      previewVersion: "branch-name.12345",
-    });
-    const modifiedPkgAFile = yield loadFile(
-      "packages/pkg-a/package.json",
-      jsonFolder
-    );
-    expect(modifiedPkgAFile.content).toBe(
-      "{\n" +
-        '  "name": "yarn-workspace-base-pkg-a",\n' +
-        '  "version": "1.0.0-branch-name.12345",\n' +
-        '  "dependencies": {\n' +
-        '    "yarn-workspace-base-pkg-b": "1.0.0-branch-name.12345"\n' +
-        "  }\n" +
-        "}\n"
-    );
-
-    const modifiedPkgBFile = yield loadFile(
-      "packages/pkg-b/package.json",
-      jsonFolder
-    );
-    expect(modifiedPkgBFile.content).toBe(
-      "{\n" +
-        '  "name": "yarn-workspace-base-pkg-b",\n' +
-        '  "version": "1.0.0-branch-name.12345"\n' +
-        "}\n"
-    );
-
-    expect({
-      //@ts-expect-error
-      consoleLog: console.log.mock.calls,
-      //@ts-expect-error
-      consoleDir: console.dir.mock.calls,
-    }).toMatchSnapshot();
-  });
-});
-
-describe("package file applies preview bump to pre-release", () => {
-  let restoreConsole: RestoreConsole;
-  beforeEach(() => {
-    restoreConsole = mockConsole(["log", "dir"]);
-  });
-  afterEach(() => {
-    restoreConsole();
-  });
-
-  it("bumps single js json without pre-release", function* () {
-    const jsonFolder = f.copy("pkg.js-single-prerelease-json"); // 0.5.9-abc.2
-
-    const commands = [
-      {
-        dependencies: undefined,
-        manager: "javascript",
-        path: "./",
-        pkg: "js-single-prerelease-json-fixture",
-        type: "minor",
-        parents: {},
-      },
-    ];
-
-    const config = {
-      ...configDefaults,
-      packages: {
-        "js-single-prerelease-json-fixture": {
-          path: "./",
-          manager: "javascript",
-        },
-      },
-    };
-
-    const allPackages = yield readAllPkgFiles({ config, cwd: jsonFolder });
-
-    yield apply({
-      //@ts-expect-error
-      commands,
-      config,
-      allPackages,
-      cwd: jsonFolder,
-      previewVersion: "branch-name.12345",
-    });
-    const modifiedFile = yield loadFile("package.json", jsonFolder);
-    expect(modifiedFile.content).toBe(
-      "{\n" +
-        '  "private": true,\n' +
-        '  "name": "js-single-prerelease-json-fixture",\n' +
-        '  "description": "A single package at the root. No monorepo setup.",\n' +
-        '  "version": "0.5.9-branch-name.12345"\n' +
-        "}\n"
-    );
-
-    expect({
-      //@ts-expect-error
-      consoleLog: console.log.mock.calls,
-      //@ts-expect-error
-      consoleDir: console.dir.mock.calls,
-    }).toMatchSnapshot();
-  });
-
-  it("bumps multi js json without pre-release", function* () {
-    const jsonFolder = f.copy("pkg.js-yarn-prerelease-workspace");
-
-    const commands = [
-      {
-        dependencies: ["yarn-workspace-base-pkg-b", "all"],
-        manager: "javascript",
-        path: "./",
-        pkg: "yarn-workspace-base-pkg-a",
-        type: "minor",
-        parents: {},
-      },
-      {
-        dependencies: undefined,
-        manager: "javascript",
-        path: undefined,
-        pkg: "yarn-workspace-base-pkg-b",
-        type: "minor",
-        parents: { "yarn-workspace-base-pkg-a": "null" },
-      },
-      {
-        dependencies: undefined,
-        manager: "javascript",
-        path: undefined,
-        pkg: "all",
-        type: "minor",
-        parents: {
-          "yarn-workspace-base-pkg-a": "null",
-          "yarn-workspace-base-pkg-b": "null",
-        },
-      },
-    ];
-
-    const config = {
-      packages: {
-        "yarn-workspace-base-pkg-a": {
-          path: "./packages/pkg-a/", // 1.0.0-abc.2
-          manager: "javascript",
-          dependencies: ["yarn-workspace-base-pkg-b", "all"],
-        },
-        "yarn-workspace-base-pkg-b": {
-          path: "./packages/pkg-b/", // 1.0.0-abc.3
-          manager: "javascript",
-          dependencies: ["all"],
-        },
-        all: { version: true },
-      },
-    };
-
-    //@ts-expect-error
-    const allPackages = yield readAllPkgFiles({ config, cwd: jsonFolder });
-
-    yield apply({
-      //@ts-expect-error
-      commands,
-      config,
-      allPackages,
-      cwd: jsonFolder,
-      previewVersion: "branch-name.12345",
-    });
-    const modifiedPkgAFile = yield loadFile(
-      "packages/pkg-a/package.json",
-      jsonFolder
-    );
-    expect(modifiedPkgAFile.content).toBe(
-      "{\n" +
-        '  "name": "yarn-workspace-base-pkg-a",\n' +
-        '  "version": "1.0.0-branch-name.12345",\n' +
-        '  "dependencies": {\n' +
-        '    "yarn-workspace-base-pkg-b": "1.0.0-branch-name.12345"\n' +
-        "  }\n" +
-        "}\n"
-    );
-
-    const modifiedPkgBFile = yield loadFile(
-      "packages/pkg-b/package.json",
-      jsonFolder
-    );
-    expect(modifiedPkgBFile.content).toBe(
-      "{\n" +
-        '  "name": "yarn-workspace-base-pkg-b",\n' +
-        '  "version": "1.0.0-branch-name.12345"\n' +
-        "}\n"
-    );
-
-    expect({
-      //@ts-expect-error
-      consoleLog: console.log.mock.calls,
-      //@ts-expect-error
-      consoleDir: console.dir.mock.calls,
-    }).toMatchSnapshot();
   });
 });

--- a/packages/apply/test/apply.test.ts
+++ b/packages/apply/test/apply.test.ts
@@ -277,19 +277,19 @@ describe("package file apply bump (snapshot)", () => {
       );
 
       // this is a range dep which will not be patch bumped
-      const modifiedPkgOneFile = yield loadFile(
-        "packages/pkg-one/package.json",
+      const modifiedPkgCFile = yield loadFile(
+        "packages/pkg-c/package.json",
         jsonFolder
       );
 
-      expect(modifiedPkgOneFile.content).toEqual(
-        "{\r\n" +
-          '  "name": "yarn-workspace-base-pkg-one",\r\n' +
-          '  "version": "1.0.0",\r\n' +
-          '  "dependencies": {\r\n' +
-          '    "yarn-workspace-base-pkg-b": "^1.0.0"\r\n' +
-          "  }\r\n" +
-          "}\r\n"
+      expect(modifiedPkgCFile.content).toEqual(
+        "{\n" +
+          '  "name": "yarn-workspace-base-pkg-c",\n' +
+          '  "version": "1.0.0",\n' +
+          '  "dependencies": {\n' +
+          '    "yarn-workspace-base-pkg-b": "^1.0.0"\n' +
+          "  }\n" +
+          "}\n"
       );
 
       expect({

--- a/packages/changelog/src/index.ts
+++ b/packages/changelog/src/index.ts
@@ -248,11 +248,14 @@ const applyChanges = ({
               c.meta!.dependencies.forEach((dep) => (acc[dep] = 1));
               return acc;
             }, {} as { [k: string]: any })
-        ).map((dep) => ({
-          summary: getVersionFromApplied(dep, applied)
-            ? `Upgraded to \`${dep}@${getVersionFromApplied(dep, applied)}\``
-            : `Updated to latest \`${dep}\``,
-        }));
+        ).map((dep) => {
+          const appliedVersion = getVersionFromApplied(dep, applied);
+          return {
+          	summary: appliedVersion 
+            	? `Upgraded to \`${dep}@${appliedVersion}\``
+            	: `Upgraded to latest \`${dep}\``,
+            }
+        });
         groupedChangesByTag.deps.push(...dependencies);
 
         assembledChanges.releases[change.changes.name].changes

--- a/packages/changelog/src/index.ts
+++ b/packages/changelog/src/index.ts
@@ -42,6 +42,7 @@ export function* fillChangelogs({
     changelogs,
     assembledChanges,
     config,
+    applied,
   });
 
   if (create) {
@@ -141,10 +142,16 @@ function* readAllChangelogs({
   }));
 }
 
+const getVersionFromApplied = (
+  name: string,
+  applied: { name: string; version: string }[]
+) => applied.find((pkg) => pkg.name === name)?.version;
+
 const applyChanges = ({
   changelogs,
   assembledChanges,
   config,
+  applied,
 }: {
   changelogs: {
     changes: { name: string; version: string };
@@ -152,6 +159,7 @@ const applyChanges = ({
   }[];
   assembledChanges: AssembledChanges;
   config: ConfigFile;
+  applied: { name: string; version: string }[];
 }) => {
   const gitSiteUrl = !config.gitSiteUrl
     ? "/"
@@ -232,7 +240,7 @@ const applyChanges = ({
         Object.keys(changeTags).forEach((k) => (groupedChangesByTag[k] = []));
 
         // fill `deps` tag
-        const dependecies = Object.keys(
+        const dependencies = Object.keys(
           assembledChanges.releases[change.changes.name].changes
             .filter((c) => c.meta?.dependencies)
             // reduce to an object of keys to avoid duplication of deps
@@ -240,8 +248,12 @@ const applyChanges = ({
               c.meta!.dependencies.forEach((dep) => (acc[dep] = 1));
               return acc;
             }, {} as { [k: string]: any })
-        ).map((dep) => ({ summary: `Updated to latest \`${dep}\`` }));
-        groupedChangesByTag.deps.push(...dependecies);
+        ).map((dep) => ({
+          summary: getVersionFromApplied(dep, applied)
+            ? `Upgraded to \`${dep}@${getVersionFromApplied(dep, applied)}\``
+            : `Updated to latest \`${dep}\``,
+        }));
+        groupedChangesByTag.deps.push(...dependencies);
 
         assembledChanges.releases[change.changes.name].changes
           .filter((c) => !c.meta?.dependencies)

--- a/packages/covector/test/__snapshots__/dry-run.test.ts.snap
+++ b/packages/covector/test/__snapshots__/dry-run.test.ts.snap
@@ -534,24 +534,12 @@ Summary about the changes in tauri-updater
             "changes": Array [
               Object {
                 "meta": Object {
-                  "content": "---
-\\"tauri\\": minor
----
-
-Summary about the changes in tauri
-",
                   "dependencies": Array [
                     "tauri",
                   ],
-                  "extname": ".md",
-                  "filename": "first-change",
-                  "path": ".changes/first-change.md",
                 },
-                "releases": Object {
-                  "tauri": "minor",
-                },
-                "summary": "Summary about the changes in tauri",
-                "tag": undefined,
+                "releases": Object {},
+                "summary": "",
               },
             ],
             "parents": Object {},
@@ -14451,24 +14439,12 @@ Summary about the changes in tauri-updater
             "changes": Array [
               Object {
                 "meta": Object {
-                  "content": "---
-\\"tauri\\": minor
----
-
-Summary about the changes in tauri
-",
                   "dependencies": Array [
                     "tauri",
                   ],
-                  "extname": ".md",
-                  "filename": "first-change",
-                  "path": ".changes/first-change.md",
                 },
-                "releases": Object {
-                  "tauri": "minor",
-                },
-                "summary": "Summary about the changes in tauri",
-                "tag": undefined,
+                "releases": Object {},
+                "summary": "",
               },
             ],
             "parents": Object {},
@@ -15566,7 +15542,7 @@ thiserror = \\"1.0.19\\"
           "command": "## [0.6.3]
 ### Dependencies
 
-- Updated to latest \`tauri\`",
+- Upgraded to \`tauri@0.6.0\`",
           "postcommand": false,
           "precommand": false,
         },
@@ -17107,7 +17083,7 @@ thiserror = \\"1.0.19\\"
         "command": "## [0.6.3]
 ### Dependencies
 
-- Updated to latest \`tauri\`",
+- Upgraded to \`tauri@0.6.0\`",
         "postcommand": false,
         "precommand": false,
       },
@@ -17581,24 +17557,12 @@ Summary about the changes in tauri-updater
             "changes": Array [
               Object {
                 "meta": Object {
-                  "content": "---
-\\"tauri\\": minor
----
-
-Summary about the changes in tauri
-",
                   "dependencies": Array [
                     "tauri",
                   ],
-                  "extname": ".md",
-                  "filename": "first-change",
-                  "path": ".changes/first-change.md",
                 },
-                "releases": Object {
-                  "tauri": "minor",
-                },
-                "summary": "Summary about the changes in tauri",
-                "tag": undefined,
+                "releases": Object {},
+                "summary": "",
               },
             ],
             "parents": Object {},

--- a/packages/covector/test/__snapshots__/main.test.ts.snap
+++ b/packages/covector/test/__snapshots__/main.test.ts.snap
@@ -6153,7 +6153,8 @@ flutter:
         "command": "## [0.3.2]
 ### Dependencies
 
-- Updated to latest \`test_app_two\`",
+- Upgraded to \`test_app_two@0.2.0\`
+- Upgraded to \`test_app_three@3.8.98\`",
         "postcommand": false,
         "precommand": false,
       },
@@ -6347,24 +6348,21 @@ flutter:
             "changes": Array [
               Object {
                 "meta": Object {
-                  "content": "---
-\\"test_app_two\\": minor
----
-
-Summary about the changes in test_app_two
-",
                   "dependencies": Array [
                     "test_app_two",
                   ],
-                  "extname": ".md",
-                  "filename": "first-change",
-                  "path": ".changes/first-change.md",
                 },
-                "releases": Object {
-                  "test_app_two": "minor",
+                "releases": Object {},
+                "summary": "",
+              },
+              Object {
+                "meta": Object {
+                  "dependencies": Array [
+                    "test_app_three",
+                  ],
                 },
-                "summary": "Summary about the changes in test_app_two",
-                "tag": undefined,
+                "releases": Object {},
+                "summary": "",
               },
             ],
             "parents": Object {},
@@ -6704,14 +6702,6 @@ Summary about the changes again(!) in test_app
 
 exports[`integration test in production mode runs version for general file 1`] = `
 Object {
-  "consoleInfo": Array [
-    Array [
-      ".changes/first-change.md was deleted",
-    ],
-    Array [
-      ".changes/second-change.md was deleted",
-    ],
-  ],
   "consoleLog": Array [
     Array [
       "bumping general-pkg with minor",
@@ -6815,14 +6805,6 @@ A general summary about the generally changes in general-pkg generally
 
 exports[`integration test in production mode runs version for js and rust 1`] = `
 Object {
-  "consoleInfo": Array [
-    Array [
-      ".changes/first-change.md was deleted",
-    ],
-    Array [
-      ".changes/second-change.md was deleted",
-    ],
-  ],
   "consoleLog": Array [
     Array [
       "bumping tauri with minor",
@@ -7925,7 +7907,7 @@ thiserror = \\"1.0.19\\"
         "command": "## [0.6.3]
 ### Dependencies
 
-- Updated to latest \`tauri\`",
+- Upgraded to \`tauri@0.6.0\`",
         "postcommand": false,
         "precommand": false,
       },
@@ -8399,24 +8381,12 @@ Summary about the changes in tauri-updater
             "changes": Array [
               Object {
                 "meta": Object {
-                  "content": "---
-\\"tauri\\": minor
----
-
-Summary about the changes in tauri
-",
                   "dependencies": Array [
                     "tauri",
                   ],
-                  "extname": ".md",
-                  "filename": "first-change",
-                  "path": ".changes/first-change.md",
                 },
-                "releases": Object {
-                  "tauri": "minor",
-                },
-                "summary": "Summary about the changes in tauri",
-                "tag": undefined,
+                "releases": Object {},
+                "summary": "",
               },
             ],
             "parents": Object {},

--- a/packages/covector/test/__snapshots__/preMode.test.ts.snap
+++ b/packages/covector/test/__snapshots__/preMode.test.ts.snap
@@ -484,24 +484,12 @@ Summary about the changes in tauri-updater
             "changes": Array [
               Object {
                 "meta": Object {
-                  "content": "---
-\\"tauri\\": minor
----
-
-Summary about the changes in tauri
-",
                   "dependencies": Array [
                     "tauri",
                   ],
-                  "extname": ".md",
-                  "filename": "first-change",
-                  "path": ".changes/first-change.md",
                 },
-                "releases": Object {
-                  "tauri": "minor",
-                },
-                "summary": "Summary about the changes in tauri",
-                "tag": undefined,
+                "releases": Object {},
+                "summary": "",
               },
             ],
             "parents": Object {},
@@ -1608,7 +1596,7 @@ thiserror = \\"1.0.19\\"
           "command": "## [0.6.3-beta.0]
 ### Dependencies
 
-- Updated to latest \`tauri\`",
+- Upgraded to \`tauri@0.6.0-beta.0\`",
           "postcommand": false,
           "precommand": false,
         },
@@ -3158,7 +3146,7 @@ thiserror = \\"1.0.19\\"
         "command": "## [0.6.3-beta.0]
 ### Dependencies
 
-- Updated to latest \`tauri\`",
+- Upgraded to \`tauri@0.6.0-beta.0\`",
         "postcommand": false,
         "precommand": false,
       },
@@ -3632,24 +3620,12 @@ Summary about the changes in tauri-updater
             "changes": Array [
               Object {
                 "meta": Object {
-                  "content": "---
-\\"tauri\\": minor
----
-
-Summary about the changes in tauri
-",
                   "dependencies": Array [
                     "tauri",
                   ],
-                  "extname": ".md",
-                  "filename": "first-change",
-                  "path": ".changes/first-change.md",
                 },
-                "releases": Object {
-                  "tauri": "minor",
-                },
-                "summary": "Summary about the changes in tauri",
-                "tag": undefined,
+                "releases": Object {},
+                "summary": "",
               },
             ],
             "parents": Object {},
@@ -4776,7 +4752,7 @@ thiserror = \\"1.0.19\\"
         "command": "## [0.6.3-beta.0]
 ### Dependencies
 
-- Updated to latest \`tauri\`",
+- Upgraded to \`tauri@0.6.0-beta.0\`",
         "postcommand": false,
         "precommand": false,
       },
@@ -5250,24 +5226,12 @@ Summary about the changes in tauri-updater
             "changes": Array [
               Object {
                 "meta": Object {
-                  "content": "---
-\\"tauri\\": minor
----
-
-Summary about the changes in tauri
-",
                   "dependencies": Array [
                     "tauri",
                   ],
-                  "extname": ".md",
-                  "filename": "first-change",
-                  "path": ".changes/first-change.md",
                 },
-                "releases": Object {
-                  "tauri": "minor",
-                },
-                "summary": "Summary about the changes in tauri",
-                "tag": undefined,
+                "releases": Object {},
+                "summary": "",
               },
             ],
             "parents": Object {},
@@ -6406,7 +6370,7 @@ thiserror = \\"1.0.19\\"
         "command": "## [0.6.3-beta.0]
 ### Dependencies
 
-- Updated to latest \`tauri\`",
+- Upgraded to \`tauri@0.6.0-beta.0\`",
         "postcommand": false,
         "precommand": false,
       },
@@ -6880,24 +6844,12 @@ Summary about the changes in tauri-updater
             "changes": Array [
               Object {
                 "meta": Object {
-                  "content": "---
-\\"tauri\\": minor
----
-
-Summary about the changes in tauri
-",
                   "dependencies": Array [
                     "tauri",
                   ],
-                  "extname": ".md",
-                  "filename": "first-change",
-                  "path": ".changes/first-change.md",
                 },
-                "releases": Object {
-                  "tauri": "minor",
-                },
-                "summary": "Summary about the changes in tauri",
-                "tag": undefined,
+                "releases": Object {},
+                "summary": "",
               },
             ],
             "parents": Object {},
@@ -7231,7 +7183,7 @@ path = \\"examples/communication/src-tauri/src/main.rs\\"
         "command": "## [0.6.0-beta.1]
 ### Dependencies
 
-- Updated to latest \`tauri-api\`",
+- Upgraded to \`tauri-api@0.5.2-beta.0\`",
         "postcommand": false,
         "precommand": false,
       },
@@ -8108,8 +8060,7 @@ totems = \\"0.2.7\\"",
         "command": "## [0.6.3-beta.1]
 ### Dependencies
 
-- Updated to latest \`tauri-api\`
-- Updated to latest \`tauri\`",
+- Upgraded to \`tauri@0.6.0-beta.1\`",
         "postcommand": false,
         "precommand": false,
       },
@@ -8134,24 +8085,21 @@ totems = \\"0.2.7\\"",
             "changes": Array [
               Object {
                 "meta": Object {
-                  "content": "---
-\\"tauri-api\\": patch
----
-
-Boop again.
-",
                   "dependencies": Array [
                     "tauri-api",
                   ],
-                  "extname": ".md",
-                  "filename": "third-change",
-                  "path": ".changes/third-change.md",
                 },
-                "releases": Object {
-                  "tauri-api": "patch",
+                "releases": Object {},
+                "summary": "",
+              },
+              Object {
+                "meta": Object {
+                  "dependencies": Array [
+                    "tauri-api",
+                  ],
                 },
-                "summary": "Boop again.",
-                "tag": undefined,
+                "releases": Object {},
+                "summary": "",
               },
             ],
             "parents": Object {
@@ -8708,25 +8656,12 @@ Boop again.
             "changes": Array [
               Object {
                 "meta": Object {
-                  "content": "---
-\\"tauri-api\\": patch
----
-
-Boop again.
-",
                   "dependencies": Array [
-                    "tauri-api",
                     "tauri",
                   ],
-                  "extname": ".md",
-                  "filename": "third-change",
-                  "path": ".changes/third-change.md",
                 },
-                "releases": Object {
-                  "tauri-api": "patch",
-                },
-                "summary": "Boop again.",
-                "tag": undefined,
+                "releases": Object {},
+                "summary": "",
               },
             ],
             "parents": Object {},

--- a/packages/covector/test/main.test.ts
+++ b/packages/covector/test/main.test.ts
@@ -54,9 +54,15 @@ describe("integration test in production mode", () => {
     })) as CovectorVersion;
     if (typeof covectored !== "object")
       throw new Error("We are expecting an object here.");
+
+    expect((console.info as any).mock.calls.flat()).toContain(
+      ".changes/first-change.md was deleted"
+    );
+    expect((console.info as any).mock.calls.flat()).toContain(
+      ".changes/second-change.md was deleted"
+    );
     expect({
       consoleLog: (console.log as any).mock.calls,
-      consoleInfo: (console.info as any).mock.calls,
       covectorReturn: covectored,
     }).toMatchSnapshot();
 
@@ -78,7 +84,7 @@ describe("integration test in production mode", () => {
       "# Changelog\n\n" +
         "## \\[0.6.3]\n\n" +
         "### Dependencies\n\n" +
-        "- Updated to latest `tauri`\n"
+        "- Upgraded to `tauri@0.6.0`\n"
     );
   });
 
@@ -132,7 +138,8 @@ describe("integration test in production mode", () => {
       "# Changelog\n\n" +
         "## \\[0.3.2]\n\n" +
         "### Dependencies\n\n" +
-        "- Updated to latest `test_app_two`\n"
+        "- Upgraded to `test_app_two@0.2.0`\n" +
+        "- Upgraded to `test_app_three@3.8.98`\n"
     );
 
     const versionFile = yield loadFile(
@@ -152,9 +159,15 @@ describe("integration test in production mode", () => {
     })) as CovectorVersion;
     if (typeof covectored !== "object")
       throw new Error("We are expecting an object here.");
+
+    expect((console.info as any).mock.calls.flat()).toContain(
+      ".changes/first-change.md was deleted"
+    );
+    expect((console.info as any).mock.calls.flat()).toContain(
+      ".changes/second-change.md was deleted"
+    );
     expect({
       consoleLog: (console.log as any).mock.calls,
-      consoleInfo: (console.info as any).mock.calls,
       covectorReturn: covectored,
     }).toMatchSnapshot();
 

--- a/packages/covector/test/preMode.test.ts
+++ b/packages/covector/test/preMode.test.ts
@@ -65,7 +65,7 @@ describe("integration test with preMode `on`", () => {
       "# Changelog\n\n" +
         "## \\[0.6.3-beta.0]\n\n" +
         "### Dependencies\n\n" +
-        "- Updated to latest `tauri`\n"
+        "- Upgraded to `tauri@0.6.0-beta.0`\n"
     );
   });
 
@@ -98,7 +98,7 @@ describe("integration test with preMode `on`", () => {
       "# Changelog\n\n" +
         "## \\[0.6.3-beta.0]\n\n" +
         "### Dependencies\n\n" +
-        "- Updated to latest `tauri`\n"
+        "- Upgraded to `tauri@0.6.0-beta.0`\n"
     );
 
     const preOne = yield loadFile(
@@ -142,7 +142,7 @@ Boop again.
       "# Changelog\n\n" +
         "## \\[0.6.0-beta.1]\n\n" +
         "### Dependencies\n\n" +
-        "- Updated to latest `tauri-api`\n" +
+        "- Upgraded to `tauri-api@0.5.2-beta.0`\n" +
         "\n" +
         "## \\[0.6.0-beta.0]\n\n" +
         "- Summary about the changes in tauri\n"
@@ -158,12 +158,11 @@ Boop again.
       "# Changelog\n\n" +
         "## \\[0.6.3-beta.1]\n\n" +
         "### Dependencies\n\n" +
-        "- Updated to latest `tauri-api`\n" +
-        "- Updated to latest `tauri`\n" +
+        "- Upgraded to `tauri@0.6.0-beta.1`\n" +
         "\n" +
         "## \\[0.6.3-beta.0]\n\n" +
         "### Dependencies\n\n" +
-        "- Updated to latest `tauri`\n"
+        "- Upgraded to `tauri@0.6.0-beta.0`\n"
     );
 
     const preTwo = yield loadFile(


### PR DESCRIPTION
## Motivation

Deps with a range such as `^` that did not have a release would throw an `undefined` error.

Also, additional context on the `Dependencies` section in the changelog would be most helpful.

## Approach

Removed and then further adjusted how these roll up bumps are handled. This now relies on the changelog `Dependencies` section logic to note all changes rather than the previous, naive "Bumped due to dependency."
