### PR TITLE
changelog pull should consider headings deeper than two

### DIFF
--- a/.changes/pull-changelog-depth-two.md
+++ b/.changes/pull-changelog-depth-two.md
@@ -1,0 +1,5 @@
+---
+"@covector/changelog": patch:bug
+---
+
+The changelog function to pull the last version in the changelog did not properly consider headings deeper than level 1 and level 2. When a third level was added, this caused the function to return the full changelog. Search for next heading with a specific depth of 2.

--- a/packages/changelog/src/index.ts
+++ b/packages/changelog/src/index.ts
@@ -320,7 +320,7 @@ const pullChanges = ({
       const startNode = 1;
       const nextNode: number = changelogParsed.children
         .slice(startNode + 1)
-        .findIndex((node: any) => node.type === "heading");
+        .findIndex((node: any) => node.type === "heading" && node.depth === 2);
       const endNode =
         nextNode && nextNode > 0 ? nextNode + startNode + 1 : 9999;
       let changelogAST = {

--- a/packages/changelog/test/read-changelog.test.ts
+++ b/packages/changelog/test/read-changelog.test.ts
@@ -10,6 +10,7 @@ const f = fixtures(__dirname);
 
 const configDefaults = {
   changeFolder: ".changes",
+  changeTags: { feat: "Features", bug: "Bugs" },
 };
 
 describe("reads changelog", () => {
@@ -155,24 +156,28 @@ describe("reads changelog", () => {
                 "changelog-js-pkg-fixture": "patch",
               },
               summary: "This is a test.",
+              tag: "bug",
             },
             {
               releases: {
                 "changelog-js-pkg-fixture": "patch",
               },
               summary: "This is another test.",
+              tag: "bug",
             },
             {
               releases: {
                 "changelog-js-pkg-fixture": "minor",
               },
               summary: "This is the last test.",
+              tag: "feat",
             },
             {
               releases: {
                 "changelog-js-pkg-fixture": "minor",
               },
               summary: "This is the final test.",
+              tag: "feat",
             },
           ],
           type: "minor",
@@ -217,10 +222,12 @@ describe("reads changelog", () => {
     });
     expect(pkgCommandsRan[pkgName].command).toBe(
       "## \\[0.9.0]\n\n" +
-        "- This is a test.\n" +
-        "- This is another test.\n" +
+        "### Features\n\n" +
         "- This is the last test.\n" +
-        "- This is the final test.\n"
+        "- This is the final test.\n\n" +
+        "### Bugs\n\n" +
+        "- This is a test.\n" +
+        "- This is another test.\n"
     );
   });
 });


### PR DESCRIPTION
## Motivation

The Github releases were pulling in the full changelog instead of strictly the last change. Fixing this.

## Approach

The approach to grab the appropriate text did not consider headings deeper than two. Prior to adding changeTags, we only had a level one and level two heading so this issue did not present itself until _after_ publishes had gone out that contained level three headings (from the changeTags).
