### PR TITLE
`use` commands for typical operations

### DIFF
--- a/.changes/config.json
+++ b/.changes/config.json
@@ -10,7 +10,12 @@
   "pkgManagers": {
     "javascript": {
       "version": true,
-      "getPublishedVersion": "npm view ${ pkg.pkg } version --silent",
+      "getPublishedVersion": {
+        "use": "fetch:check",
+        "options": {
+          "url": "https://registry.npmjs.com/${ pkg.pkg }/${ pkg.pkgFile.version }"
+        }
+      },
       "prepublish": [{ "command": "npm pack", "dryRunCommand": true }],
       "publish": [
         {
@@ -23,7 +28,14 @@
           "dryRunCommand": "echo publish here",
           "pipe": true
         }
-      ]
+      ],
+      "postpublish": {
+        "use": "fetch:check",
+        "options": {
+          "url": "https://registry.npmjs.com/${ pkg.pkg }/${ pkg.pkgFile.version }"
+        },
+        "retries": [5000, 5000, 5000]
+      }
     }
   },
   "packages": {
@@ -31,6 +43,13 @@
       "path": "./packages/covector",
       "manager": "javascript",
       "postpublish": [
+        {
+          "use": "fetch:check",
+          "options": {
+            "url": "https://registry.npmjs.com/${ pkg.pkg }/${ pkg.pkgFile.version }"
+          },
+          "retries": [5000, 5000, 5000]
+        },
         "git tag ${ pkg.pkg }-v${ pkgFile.versionMajor } -f",
         "git tag ${ pkg.pkg }-v${ pkgFile.versionMajor }.${ pkgFile.versionMinor } -f",
         "git push --tags -f"
@@ -119,11 +138,6 @@
       "getPublishedVersion": false,
       "dependencies": ["covector"],
       "assets": false
-    },
-    "all": {
-      "version": true,
-      "build": false,
-      "publish": false
     }
   }
 }

--- a/.changes/use-functions-for-typical-operations.md
+++ b/.changes/use-functions-for-typical-operations.md
@@ -1,0 +1,5 @@
+---
+"@covector/command": minor:feat
+---
+
+Support built-in commands to simplify typical operations.

--- a/packages/command/src/index.ts
+++ b/packages/command/src/index.ts
@@ -6,7 +6,8 @@ import type {
   PkgVersion,
   PkgPublish,
   RunningCommand,
-  NormalizedCommand,
+  CommandTypes,
+  CommandsRan,
 } from "@covector/types";
 
 export const attemptCommands = function* ({
@@ -19,129 +20,182 @@ export const attemptCommands = function* ({
 }: {
   cwd: string;
   commands: (PkgVersion | PkgPublish)[];
-  command: string; // the covector command that was ran
-  commandPrefix?: string;
-  pkgCommandsRan?: object;
+  command: "version" | "publish" | string; // the covector command that was ran
+  commandPrefix?: "pre" | "post" | "";
+  pkgCommandsRan?: CommandsRan;
   dryRun: boolean;
 }): Operation<{ [k: string]: { [c: string]: string | boolean } }> {
-  let _pkgCommandsRan: { [k: string]: { [c: string]: string | boolean } } = {
+  let pkgCommandsRun: { [k: string]: { [c: string]: string | boolean } } = {
     ...pkgCommandsRan,
   };
   for (let pkg of commands) {
+    const c = pkg[`${commandPrefix}command`];
+    if (!c) continue;
     const initialStdout =
-      pkgCommandsRan &&
-      //@ts-expect-error
-      pkgCommandsRan[pkg.pkg] &&
-      //@ts-expect-error
-      pkgCommandsRan[pkg.pkg][`${commandPrefix}command`] &&
-      //@ts-expect-error
+      pkgCommandsRan?.[pkg.pkg][`${commandPrefix}command`] &&
       typeof pkgCommandsRan[pkg.pkg][`${commandPrefix}command`] === "string"
-        ? //@ts-expect-error
-          pkgCommandsRan[pkg.pkg][`${commandPrefix}command`]
+        ? pkgCommandsRan[pkg.pkg][`${commandPrefix}command`]
         : false;
-    //@ts-expect-error template literals issues
-    if (!pkg[`${commandPrefix}command`]) continue;
-    //@ts-expect-error template literals issues
-    const c: string | Function | [] = pkg[`${commandPrefix}command`];
-    const pubCommands: (NormalizedCommand | string | Function)[] =
+    const pubCommands: CommandTypes[] =
       typeof c === "string" || typeof c === "function" || !Array.isArray(c)
         ? [c]
         : c;
     let stdout = initialStdout ? `${initialStdout}\n` : "";
-    for (let pubCommand of pubCommands) {
-      const runningCommand: RunningCommand = {
-        ...(typeof pubCommand === "object"
-          ? { runFromRoot: pubCommand.runFromRoot }
-          : {}),
-      };
-      if (
-        typeof pubCommand === "object" &&
-        pubCommand.dryRunCommand === false
-      ) {
-        runningCommand.command = pubCommand.command;
-        runningCommand.shouldRunCommand = !dryRun;
-        runningCommand.retries = pubCommand.retries;
-      } else if (typeof pubCommand === "object") {
-        // dryRunCommand will either be a !string (false) or !undefined (true) or !true (false)
-        if (pubCommand.dryRunCommand === true) {
-          runningCommand.command = pubCommand.command;
-          runningCommand.shouldRunCommand = true;
-        } else if (typeof pubCommand.dryRunCommand === "string" && dryRun) {
-          runningCommand.command = pubCommand.dryRunCommand;
-          runningCommand.shouldRunCommand = true;
-        } else {
-          runningCommand.command = pubCommand.command;
-          runningCommand.shouldRunCommand = !dryRun;
-          runningCommand.retries = pubCommand.retries;
-        }
-      } else {
-        runningCommand.command = pubCommand;
-        runningCommand.shouldRunCommand = !dryRun;
-      }
 
-      if (runningCommand.shouldRunCommand && runningCommand.command) {
-        let commandBackoff = (runningCommand?.retries ?? []).concat([0]);
-        for (let [index, attemptTimeout] of commandBackoff.entries()) {
-          try {
-            if (typeof runningCommand.command === "function") {
-              const pipeToFunction = {
-                ...pkg,
-                pkgCommandsRan: {
-                  ..._pkgCommandsRan[pkg.pkg],
-                  [`${commandPrefix}command`]: stdout,
-                },
-              };
-              yield runningCommand.command(pipeToFunction);
-
-              if (typeof pubCommand === "object" && pubCommand.pipe) {
-                console.warn(
-                  `We cannot pipe the function command in ${pkg.pkg}`
-                );
-              }
-            } else {
-              const ranCommand = yield runCommand({
-                command: runningCommand.command,
-                cwd,
-                pkg: pkg.pkg,
-                pkgPath:
-                  runningCommand.runFromRoot === true ? "" : pkg.path || "",
-                log: `${pkg.pkg} [${commandPrefix}${command}${
-                  runningCommand.runFromRoot === true ? " run from the cwd" : ""
-                }]: ${runningCommand.command}`,
-              });
-
-              if (typeof pubCommand === "object" && pubCommand.pipe) {
-                stdout = `${stdout}${ranCommand}\n`;
-              }
-            }
-            // if nothing throws, continue out of the loop
-            break;
-          } catch (e) {
-            console.error(e);
-            if (index + 1 >= commandBackoff.length) throw e;
-            yield sleep(attemptTimeout);
-          }
-        }
-      } else {
-        console.log(
-          `dryRun >> ${pkg.pkg} [${commandPrefix}${command}${
-            runningCommand.runFromRoot === true ? " run from the cwd" : ""
-          }]: ${runningCommand.command}`
-        );
-      }
-    }
+    stdout = yield executeEachCommand({
+      cwd,
+      stdout,
+      dryRun,
+      pkg,
+      pubCommands,
+      pkgCommandsRun,
+      commandPrefix,
+      command,
+    });
 
     if (!!pkgCommandsRan)
-      _pkgCommandsRan[pkg.pkg][`${commandPrefix}command`] =
+      pkgCommandsRun[pkg.pkg][`${commandPrefix}command`] =
         stdout !== "" ? stdout : true;
 
     if (!!pkgCommandsRan && command === "publish" && !commandPrefix)
-      _pkgCommandsRan[pkg.pkg]["published"] = true;
+      pkgCommandsRun[pkg.pkg]["published"] = true;
   }
-  return _pkgCommandsRan;
+  return pkgCommandsRun;
 };
 
-export const confirmCommandsToRun = function* ({
+function* executeEachCommand({
+  cwd,
+  stdout,
+  dryRun,
+  pkg,
+  pubCommands,
+  pkgCommandsRun,
+  command,
+  commandPrefix,
+}: {
+  cwd: string;
+  stdout: string;
+  dryRun: boolean;
+  pkg: PkgVersion | PkgPublish;
+  pubCommands: CommandTypes[];
+  pkgCommandsRun: any;
+  command: string;
+  commandPrefix: string;
+}): Operation<string> {
+  for (let pubCommand of pubCommands) {
+    const runningCommand: RunningCommand = {
+      ...(typeof pubCommand === "object"
+        ? { runFromRoot: pubCommand.runFromRoot }
+        : {}),
+    };
+    if (typeof pubCommand === "object" && pubCommand.dryRunCommand === false) {
+      runningCommand.command = pubCommand.command;
+      runningCommand.shouldRunCommand = !dryRun;
+      runningCommand.retries = pubCommand.retries;
+    } else if (typeof pubCommand === "object") {
+      // dryRunCommand will either be a !string (false) or !undefined (true) or !true (false)
+      if (pubCommand.dryRunCommand === true) {
+        runningCommand.command = pubCommand.command;
+        runningCommand.shouldRunCommand = true;
+      } else if (typeof pubCommand.dryRunCommand === "string" && dryRun) {
+        runningCommand.command = pubCommand.dryRunCommand;
+        runningCommand.shouldRunCommand = true;
+      } else {
+        runningCommand.command = pubCommand.command;
+        runningCommand.shouldRunCommand = !dryRun;
+        runningCommand.retries = pubCommand.retries;
+      }
+    } else {
+      runningCommand.command = pubCommand;
+      runningCommand.shouldRunCommand = !dryRun;
+    }
+
+    if (runningCommand.shouldRunCommand && runningCommand.command) {
+      let commandBackoff = (runningCommand?.retries ?? []).concat([0]);
+      for (let [index, attemptTimeout] of commandBackoff.entries()) {
+        try {
+          stdout = yield callCommand({
+            cwd,
+            pkg,
+            runningCommand,
+            pubCommand,
+            command,
+            commandPrefix,
+            stdout,
+            pkgCommandsRun,
+          });
+          // if nothing throws, continue out of the loop
+          break;
+        } catch (e) {
+          console.error(e);
+          if (index + 1 >= commandBackoff.length) throw e;
+          yield sleep(attemptTimeout);
+        }
+      }
+    } else {
+      console.log(
+        `dryRun >> ${pkg.pkg} [${commandPrefix}${command}${
+          runningCommand.runFromRoot === true ? " run from the cwd" : ""
+        }]: ${runningCommand.command}`
+      );
+    }
+  }
+  return stdout;
+}
+
+function* callCommand({
+  cwd,
+  pkg,
+  runningCommand,
+  pkgCommandsRun,
+  pubCommand,
+  stdout,
+  command,
+  commandPrefix,
+}: {
+  cwd: string;
+  stdout: string;
+  pkg: PkgVersion | PkgPublish;
+  pubCommand: CommandTypes;
+  runningCommand: RunningCommand;
+  pkgCommandsRun: any;
+  command: string;
+  commandPrefix: string;
+}): Operation<string> {
+  if (typeof runningCommand.command === "function") {
+    const pipeToFunction = {
+      ...pkg,
+      pkgCommandsRan: {
+        ...pkgCommandsRun[pkg.pkg],
+        [`${commandPrefix}command`]: stdout,
+      },
+    };
+
+    yield runningCommand.command(pipeToFunction);
+
+    if (typeof pubCommand === "object" && pubCommand.pipe) {
+      console.warn(`We cannot pipe the function command in ${pkg.pkg}`);
+    }
+  } else if (typeof runningCommand.command === "string") {
+    const ranCommand: string = yield runCommand({
+      command: runningCommand.command,
+      cwd,
+      pkg: pkg.pkg,
+      pkgPath: runningCommand.runFromRoot === true ? "" : pkg.path || "",
+      log: `${pkg.pkg} [${commandPrefix}${command}${
+        runningCommand.runFromRoot === true ? " run from the cwd" : ""
+      }]: ${runningCommand.command}`,
+    });
+
+    if (typeof pubCommand === "object" && pubCommand.pipe) {
+      stdout = `${stdout}${ranCommand}\n`;
+    }
+  }
+
+  return stdout;
+}
+
+export function* confirmCommandsToRun({
   cwd,
   commands,
   command,
@@ -178,7 +232,7 @@ export const confirmCommandsToRun = function* ({
   }
 
   return commandsToRun;
-};
+}
 
 export const runCommand = function* ({
   pkg = "package",

--- a/packages/command/test/attemptCommand.test.ts
+++ b/packages/command/test/attemptCommand.test.ts
@@ -31,12 +31,14 @@ describe("attemptCommand", () => {
     yield attemptCommands({
       commands: [
         {
-          name: "pkg-nickname",
+          pkg: "pkg-nickname",
           pkgFile: fillWithDefaults({ version: "0.5.6" }),
-          //@ts-expect-error
           command: async () => console.log("boop"),
         },
       ],
+      command: "publish",
+      cwd: "",
+      dryRun: false,
     });
 
     //@ts-expect-error
@@ -77,7 +79,6 @@ describe("attemptCommand", () => {
         {
           pkg: "pkg-nickname",
           pkgFile: fillWithDefaults({ version: "0.5.6" }),
-          //@ts-expect-error
           command: async (pkg: any) =>
             console.log(`boop ${pkg.pkg}@${pkg.pkgFile.version}`),
         },

--- a/packages/command/test/commandFailure.test.ts
+++ b/packages/command/test/commandFailure.test.ts
@@ -14,7 +14,7 @@ describe("attemptCommand fails", () => {
   });
 
   it("fails a function", function* () {
-    yield captureError(
+    const errored = yield captureError(
       attemptCommands({
         cwd: ".",
         command: "publish",
@@ -29,20 +29,20 @@ describe("attemptCommand fails", () => {
       })
     );
 
+    console.dir(errored);
     if (process.platform === "win32") {
       const errorMessage =
         "'boop' is not recognized as an internal or external command,\r\n" +
         "operable program or batch file.";
-      //@ts-expect-error
-      expect(console.error.mock.calls[0][0]).toBe(errorMessage);
+      expect(errored.message).toBe(errorMessage);
     } else {
-      //@ts-expect-error
-      expect(console.error.mock.calls[0][0].message).toBe("spawn boop ENOENT");
+      const errorMessage = "spawn boop ENOENT";
+      expect(errored.message).toBe(errorMessage);
     }
   });
 
   it("retries a failed function", function* () {
-    yield captureError(
+    const errored = yield captureError(
       attemptCommands({
         cwd: ".",
         command: "",
@@ -61,24 +61,22 @@ describe("attemptCommand fails", () => {
       const errorMessage =
         "'boop' is not recognized as an internal or external command,\r\n" +
         "operable program or batch file.";
-      //@ts-expect-error
-      expect(console.error.mock.calls[0][0]).toBe(errorMessage);
-      //@ts-expect-error
-      expect(console.error.mock.calls[2][0]).toBe(errorMessage);
-      //@ts-expect-error
-      expect(console.error.mock.calls[4][0]).toBe(errorMessage);
-      // ts-expect-error
-      // expect(console.error.mock.calls[3]).toBeUndefined();
+      expect((console.error as any).mock.calls[0][0]).toBe(errorMessage);
+      expect((console.error as any).mock.calls[2][0]).toBe(errorMessage);
+      expect((console.error as any).mock.calls[4][0]).toBeUndefined();
+      expect(errored.message).toBe(errorMessage);
     } else {
       const errorMessage = "spawn boop ENOENT";
-      //@ts-expect-error
-      expect(console.error.mock.calls[0][0].message).toBe(errorMessage);
-      //@ts-expect-error
-      expect(console.error.mock.calls[1][0].message).toBe(errorMessage);
-      //@ts-expect-error
-      expect(console.error.mock.calls[2][0].message).toBe(errorMessage);
-      //@ts-expect-error
-      expect(console.error.mock.calls?.[3]?.[0]?.message).toBeUndefined();
+      expect((console.error as any).mock.calls[0][0].message).toBe(
+        errorMessage
+      );
+      expect((console.error as any).mock.calls[1][0].message).toBe(
+        errorMessage
+      );
+      expect(
+        (console.error as any).mock.calls?.[2]?.[0]?.message
+      ).toBeUndefined();
+      expect(errored.message).toBe(errorMessage);
     }
   });
 });

--- a/packages/command/test/commandFailure.test.ts
+++ b/packages/command/test/commandFailure.test.ts
@@ -29,16 +29,7 @@ describe("attemptCommand fails", () => {
       })
     );
 
-    console.dir(errored);
-    if (process.platform === "win32") {
-      const errorMessage =
-        "'boop' is not recognized as an internal or external command,\r\n" +
-        "operable program or batch file.";
-      expect(errored.message).toBe(errorMessage);
-    } else {
-      const errorMessage = "spawn boop ENOENT";
-      expect(errored.message).toBe(errorMessage);
-    }
+    expect(errored.message).toBe("spawn boop ENOENT");
   });
 
   it("retries a failed function", function* () {
@@ -63,7 +54,8 @@ describe("attemptCommand fails", () => {
         "operable program or batch file.";
       expect((console.error as any).mock.calls[0][0]).toBe(errorMessage);
       expect((console.error as any).mock.calls[2][0]).toBe(errorMessage);
-      expect((console.error as any).mock.calls[4][0]).toBeUndefined();
+      expect((console.error as any).mock.calls[4][0]).toBe(errorMessage);
+      expect((console.error as any).mock.calls[5][0]).toBe(errorMessage);
       expect(errored.message).toBe(errorMessage);
     } else {
       const errorMessage = "spawn boop ENOENT";

--- a/packages/command/test/commandFailure.test.ts
+++ b/packages/command/test/commandFailure.test.ts
@@ -48,17 +48,17 @@ describe("attemptCommand fails", () => {
       })
     );
 
+    const errorMessage = "spawn boop ENOENT";
     if (process.platform === "win32") {
-      const errorMessage =
+      const errorLog =
         "'boop' is not recognized as an internal or external command,\r\n" +
         "operable program or batch file.";
-      expect((console.error as any).mock.calls[0][0]).toBe(errorMessage);
-      expect((console.error as any).mock.calls[2][0]).toBe(errorMessage);
-      expect((console.error as any).mock.calls[4][0]).toBe(errorMessage);
-      expect((console.error as any).mock.calls[6][0]).toBeUndefined();
+      expect((console.error as any).mock.calls[0][0]).toBe(errorLog);
+      expect((console.error as any).mock.calls[2][0]).toBe(errorLog);
+      expect((console.error as any).mock.calls[4][0]).toBe(errorLog);
+      expect((console.error as any).mock.calls[6]).toBeUndefined();
       expect(errored.message).toBe(errorMessage);
     } else {
-      const errorMessage = "spawn boop ENOENT";
       expect((console.error as any).mock.calls[0][0].message).toBe(
         errorMessage
       );

--- a/packages/command/test/commandFailure.test.ts
+++ b/packages/command/test/commandFailure.test.ts
@@ -55,7 +55,7 @@ describe("attemptCommand fails", () => {
       expect((console.error as any).mock.calls[0][0]).toBe(errorMessage);
       expect((console.error as any).mock.calls[2][0]).toBe(errorMessage);
       expect((console.error as any).mock.calls[4][0]).toBe(errorMessage);
-      expect((console.error as any).mock.calls[5][0]).toBe(errorMessage);
+      expect((console.error as any).mock.calls[6][0]).toBeUndefined();
       expect(errored.message).toBe(errorMessage);
     } else {
       const errorMessage = "spawn boop ENOENT";

--- a/packages/command/test/confirmCommandsToRun.test.ts
+++ b/packages/command/test/confirmCommandsToRun.test.ts
@@ -1,0 +1,261 @@
+import { it } from "@effection/jest";
+import { confirmCommandsToRun } from "../src";
+import mockConsole, { RestoreConsole } from "jest-mock-console";
+import fixtures from "fixturez";
+const f = fixtures(__dirname);
+
+const fillWithDefaults = ({ version }: { version: string }) => {
+  const [versionMajor, versionMinor, versionPatch] = version
+    .split(".")
+    .map((v) => parseInt(v));
+  return {
+    version,
+    versionMajor,
+    versionMinor,
+    versionPatch,
+    pkg: { name: "none" },
+    deps: {},
+  };
+};
+
+describe("confirmCommandsToRun", () => {
+  let restoreConsole: RestoreConsole;
+  beforeEach(() => {
+    restoreConsole = mockConsole(["log", "error"]);
+  });
+  afterEach(() => {
+    restoreConsole();
+  });
+
+  describe("processExecute", () => {
+    describe("npm view", () => {
+      it("already published", function* () {
+        const commandsToRun = yield confirmCommandsToRun({
+          commands: [
+            {
+              pkg: "effection",
+              manager: "npm",
+              pkgFile: fillWithDefaults({ version: "0.5.0" }),
+              getPublishedVersion: "npm view effection@0.5.0 version --silent",
+            },
+          ],
+          cwd: "",
+          command: "publish",
+        });
+
+        expect((console.log as any).mock.calls).toEqual([
+          [
+            "Checking if effection@0.5.0 is already published with: npm view effection@0.5.0 version --silent",
+          ],
+          ["0.5.0"],
+          ["effection@0.5.0 is already published. Skipping."],
+        ]);
+        expect(commandsToRun).toEqual([]);
+      });
+
+      it("needs publish", function* () {
+        const commandsToRun = yield confirmCommandsToRun({
+          commands: [
+            {
+              pkg: "effection",
+              manager: "npm",
+              pkgFile: fillWithDefaults({ version: "0.5.99" }),
+              getPublishedVersion: "npm view effection@0.5.0 version --silent",
+            },
+          ],
+          cwd: "",
+          command: "publish",
+        });
+
+        expect((console.log as any).mock.calls).toEqual([
+          [
+            "Checking if effection@0.5.99 is already published with: npm view effection@0.5.0 version --silent",
+          ],
+          ["0.5.0"],
+        ]);
+        expect(commandsToRun).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ pkg: "effection" }),
+          ])
+        );
+      });
+    });
+
+    describe("cargo through curl", () => {
+      it("already published", function* () {
+        const commandsToRun = yield confirmCommandsToRun({
+          commands: [
+            {
+              pkg: "tauri",
+              manager: "cargo",
+              pkgFile: fillWithDefaults({ version: "0.11.0" }),
+              getPublishedVersion:
+                "curl -s https://crates.io/api/v1/crates/tauri/0.11.0 | if grep -q errors; then echo not found; else echo 0.11.0; fi;",
+            },
+          ],
+          cwd: "",
+          command: "publish",
+        });
+
+        expect((console.log as any).mock.calls).toEqual([
+          [
+            "Checking if tauri@0.11.0 is already published with: curl -s https://crates.io/api/v1/crates/tauri/0.11.0 | if grep -q errors; then echo not found; else echo 0.11.0; fi;",
+          ],
+          ["0.11.0"],
+          ["tauri@0.11.0 is already published. Skipping."],
+        ]);
+        expect(commandsToRun).toEqual([]);
+      });
+
+      it("needs publish", function* () {
+        const commandsToRun = yield confirmCommandsToRun({
+          commands: [
+            {
+              pkg: "tauri",
+              manager: "cargo",
+              pkgFile: fillWithDefaults({ version: "0.12.0" }),
+              getPublishedVersion:
+                "curl -s https://crates.io/api/v1/crates/tauri/0.12.0 | if grep -q errors; then echo not found; else echo 0.12.0; fi;",
+            },
+          ],
+          cwd: "",
+          command: "publish",
+        });
+
+        expect((console.log as any).mock.calls).toEqual([
+          [
+            "Checking if tauri@0.12.0 is already published with: curl -s https://crates.io/api/v1/crates/tauri/0.12.0 | if grep -q errors; then echo not found; else echo 0.12.0; fi;",
+          ],
+          ["not found"],
+        ]);
+
+        expect(commandsToRun).toEqual(
+          expect.arrayContaining([expect.objectContaining({ pkg: "tauri" })])
+        );
+      });
+    });
+  });
+
+  describe("fetchCommand", () => {
+    describe("fetch npm registry", () => {
+      it("already published", function* () {
+        const commandsToRun = yield confirmCommandsToRun({
+          commands: [
+            {
+              pkg: "effection",
+              manager: "npm",
+              pkgFile: fillWithDefaults({ version: "0.5.0" }),
+              getPublishedVersion: {
+                use: "fetch:check",
+                options: {
+                  url: "https://registry.npmjs.com/${ pkg.pkg }/${ pkg.pkgFile.version }",
+                },
+              },
+            },
+          ],
+          cwd: "",
+          command: "publish",
+        });
+
+        expect((console.log as any).mock.calls).toEqual([
+          [
+            "Checking if effection@0.5.0 is already published with built-in fetch:check",
+          ],
+          ["effection@0.5.0 is already published. Skipping."],
+        ]);
+        expect(commandsToRun).toEqual([]);
+      });
+
+      it("needs publish", function* () {
+        const commandsToRun = yield confirmCommandsToRun({
+          commands: [
+            {
+              pkg: "effection",
+              manager: "npm",
+              pkgFile: fillWithDefaults({ version: "0.5.99" }),
+              getPublishedVersion: {
+                use: "fetch:check",
+                options: {
+                  url: "https://registry.npmjs.com/${ pkg.pkg }/${ pkg.pkgFile.version }",
+                },
+              },
+            },
+          ],
+          cwd: "",
+          command: "publish",
+        });
+
+        expect((console.log as any).mock.calls).toEqual([
+          [
+            "Checking if effection@0.5.99 is already published with built-in fetch:check",
+          ],
+        ]);
+        expect(commandsToRun).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ pkg: "effection" }),
+          ])
+        );
+      });
+    });
+
+    describe("fetch cargo registry", () => {
+      it("already published", function* () {
+        const commandsToRun = yield confirmCommandsToRun({
+          commands: [
+            {
+              pkg: "tauri",
+              manager: "cargo",
+              pkgFile: fillWithDefaults({ version: "0.11.0" }),
+              getPublishedVersion: {
+                use: "fetch:check",
+                options: {
+                  url: "https://crates.io/api/v1/crates/${ pkg.pkg }/${ pkg.pkgFile.version }",
+                },
+              },
+            },
+          ],
+          cwd: "",
+          command: "publish",
+        });
+
+        expect((console.log as any).mock.calls).toEqual([
+          [
+            "Checking if tauri@0.11.0 is already published with built-in fetch:check",
+          ],
+          ["tauri@0.11.0 is already published. Skipping."],
+        ]);
+        expect(commandsToRun).toEqual([]);
+      });
+
+      it("needs publish", function* () {
+        const commandsToRun = yield confirmCommandsToRun({
+          commands: [
+            {
+              pkg: "tauri",
+              manager: "cargo",
+              pkgFile: fillWithDefaults({ version: "0.12.0" }),
+              getPublishedVersion: {
+                use: "fetch:check",
+                options: {
+                  url: "https://crates.io/api/v1/crates/${ pkg.pkg }/${ pkg.pkgFile.version }",
+                },
+              },
+            },
+          ],
+          cwd: "",
+          command: "publish",
+        });
+
+        expect((console.log as any).mock.calls).toEqual([
+          [
+            "Checking if tauri@0.12.0 is already published with built-in fetch:check",
+          ],
+        ]);
+
+        expect(commandsToRun).toEqual(
+          expect.arrayContaining([expect.objectContaining({ pkg: "tauri" })])
+        );
+      });
+    });
+  });
+});

--- a/packages/command/test/fetchCommand.test.ts
+++ b/packages/command/test/fetchCommand.test.ts
@@ -1,0 +1,201 @@
+import { captureError, it } from "@effection/jest";
+import { attemptCommands } from "../src";
+import mockConsole, { RestoreConsole } from "jest-mock-console";
+import fixtures from "fixturez";
+const f = fixtures(__dirname);
+
+const fillWithDefaults = ({ version }: { version: string }) => {
+  const [versionMajor, versionMinor, versionPatch] = version
+    .split(".")
+    .map((v) => parseInt(v));
+  return {
+    version,
+    versionMajor,
+    versionMinor,
+    versionPatch,
+    pkg: { name: "none" },
+    deps: {},
+  };
+};
+
+describe("fetchCommand", () => {
+  let restoreConsole: RestoreConsole;
+  beforeEach(() => {
+    restoreConsole = mockConsole(["log", "error"]);
+  });
+  afterEach(() => {
+    restoreConsole();
+  });
+
+  describe("fetch npm registry", () => {
+    it("success", function* () {
+      yield attemptCommands({
+        commands: [
+          {
+            pkg: "effection",
+            pkgFile: fillWithDefaults({ version: "0.5.0" }),
+            command: [
+              {
+                use: "fetch:check",
+                options: {
+                  url: "https://registry.npmjs.com/${ pkg.pkg }/${ pkg.pkgFile.version }",
+                },
+              },
+            ],
+          },
+        ],
+        command: "publish",
+        cwd: "",
+        dryRun: false,
+      });
+
+      expect((console.log as any).mock.calls).toEqual([]);
+    });
+
+    it("failure throws", function* () {
+      const errored = yield captureError(
+        attemptCommands({
+          commands: [
+            {
+              pkg: "effection",
+              pkgFile: fillWithDefaults({ version: "0.5.32" }),
+              command: [
+                {
+                  use: "fetch:check",
+                  options: {
+                    url: "https://registry.npmjs.com/${ pkg.pkg }/${ pkg.pkgFile.version }",
+                  },
+                },
+              ],
+            },
+          ],
+          command: "publish",
+          cwd: "",
+          dryRun: false,
+        })
+      );
+
+      expect(errored.message).toEqual("request returned code 404: Not Found");
+    });
+
+    it("failure retries then throws", function* () {
+      const errored = yield captureError(
+        attemptCommands({
+          commands: [
+            {
+              pkg: "effection",
+              pkgFile: fillWithDefaults({ version: "0.5.32" }),
+              command: [
+                {
+                  use: "fetch:check",
+                  options: {
+                    url: "https://registry.npmjs.com/${ pkg.pkg }/${ pkg.pkgFile.version }",
+                  },
+                  retries: [500, 500],
+                },
+              ],
+            },
+          ],
+          command: "publish",
+          cwd: "",
+          dryRun: false,
+        })
+      );
+
+      expect(console.error as any).toBeCalledTimes(2);
+      expect(errored.message).toEqual("request returned code 404: Not Found");
+    });
+  });
+
+  describe("fetch cargo registry", () => {
+    it("success", function* () {
+      yield attemptCommands({
+        commands: [
+          {
+            pkg: "tauri",
+            pkgFile: fillWithDefaults({ version: "0.11.0" }),
+            command: [
+              {
+                use: "fetch:check",
+                options: {
+                  url: "https://crates.io/api/v1/crates/${ pkg.pkg }/${ pkg.pkgFile.version }",
+                },
+              },
+            ],
+          },
+        ],
+        command: "publish",
+        cwd: "",
+        dryRun: false,
+      });
+
+      expect((console.log as any).mock.calls).toEqual([]);
+    });
+
+    it("failure throws", function* () {
+      const errored = yield captureError(
+        attemptCommands({
+          commands: [
+            {
+              pkg: "tauri",
+              pkgFile: fillWithDefaults({ version: "0.12.0" }),
+              command: [
+                {
+                  use: "fetch:check",
+                  options: {
+                    url: "https://crates.io/api/v1/crates/${ pkg.pkg }/${ pkg.pkgFile.version }",
+                  },
+                },
+              ],
+            },
+          ],
+          command: "publish",
+          cwd: "",
+          dryRun: false,
+        })
+      );
+
+      expect(errored.message).toEqual(
+        `request returned errors: [
+  {
+    "detail": "crate \`tauri\` does not have a version \`0.12.0\`"
+  }
+]`
+      );
+    });
+
+    it("failure retries then throws", function* () {
+      const errored = yield captureError(
+        attemptCommands({
+          commands: [
+            {
+              pkg: "tauri",
+              pkgFile: fillWithDefaults({ version: "0.12.0" }),
+              command: [
+                {
+                  use: "fetch:check",
+                  options: {
+                    url: "https://crates.io/api/v1/crates/${ pkg.pkg }/${ pkg.pkgFile.version }",
+                  },
+                  retries: [500, 500],
+                },
+              ],
+            },
+          ],
+          command: "publish",
+          cwd: "",
+          dryRun: false,
+        })
+      );
+
+      expect(console.error as any).toBeCalledTimes(2);
+      expect(errored.message).toEqual(
+        `request returned errors: [
+  {
+    "detail": "crate \`tauri\` does not have a version \`0.12.0\`"
+  }
+]`
+      );
+    });
+  });
+});

--- a/packages/covector/README.md
+++ b/packages/covector/README.md
@@ -181,6 +181,38 @@ The `command` is required. The follow are additional options you may specify.
 
 - `retries`: `number[]` - If the command fails, opt-in to retrying based on this timeout and frequency. Using `[2000, 2000]` would try two additional times with a 2 second delay between attempts. It would throw on the last attempt if they all fail.
 
+## Built-In Commands
+
+Besides specifying a command with additional options, one may `use` a built-in command. The following are the currently available commands.
+
+### `fetch:check`
+
+This requires an `options.url` for use. It will fetch the specified endpoint, and throw if the response returns a code `>= 400` or if the JSON response includes an `errors`. This is useful to check if a version was published. The following would check the registry if this version was published to determine if it needs to run a `covector publish`. After publishing, it checks with `retries` on a five second timeout to confirm the publish appears in the registry.
+
+```json
+{
+  "packages": {
+    "covector": {
+      "path": "./packages/covector",
+      "getPublishedVersion": {
+        "use": "fetch:check",
+        "options": {
+          "url": "https://registry.npmjs.com/${ pkg.pkg }/${ pkg.pkgFile.version }"
+        }
+      },
+      "publish": "npm publish --access public",
+      "postpublish": {
+        "use": "fetch:check",
+        "options": {
+          "url": "https://registry.npmjs.com/${ pkg.pkg }/${ pkg.pkgFile.version }"
+        },
+        "retries": [5000, 5000, 5000]
+      }
+    }
+  }
+}
+```
+
 ## Change Tags
 
 Each bump in a change file could optionally contain a tag (section) in the format of `<bump>:<tag>`, and will be used to group related changes under one tag in the final changelog:

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -102,8 +102,8 @@ export type ConfigFile = {
 };
 
 /* @covector/command */
-type BuiltInCommands = "fetch:check";
-type BuiltInCommandOptions = Record<string, any>;
+export type BuiltInCommands = "fetch:check";
+export type BuiltInCommandOptions = Record<string, any>;
 
 export type RunningCommand = {
   command?: CommandTypes;
@@ -227,7 +227,7 @@ export type PkgPublish = {
   postcommand?: CommandTypes[] | CommandTypes | null;
   manager: string;
   dependencies?: string[];
-  getPublishedVersion?: string;
+  getPublishedVersion?: CommandTypes;
   assets?: { name: string; path: string }[];
   pkgFile?: PackageFile;
   errorOnVersionRange?: string;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -102,8 +102,13 @@ export type ConfigFile = {
 };
 
 /* @covector/command */
+type BuiltInCommands = "fetch:check";
+type BuiltInCommandOptions = Record<string, any>;
+
 export type RunningCommand = {
-  command?: string | Function;
+  command?: CommandTypes;
+  use?: BuiltInCommands;
+  options?: BuiltInCommandOptions;
   shouldRunCommand?: boolean;
   runFromRoot?: boolean;
   retries?: number[];
@@ -111,6 +116,8 @@ export type RunningCommand = {
 
 export type NormalizedCommand = {
   command?: string;
+  use?: BuiltInCommands;
+  options?: BuiltInCommandOptions;
   runFromRoot?: boolean;
   retries?: number[];
   dryRunCommand?: boolean;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -188,15 +188,17 @@ export type Release = {
   parents?: Parents;
 };
 
+export type CommandTypes = NormalizedCommand | string | Function;
+
 export type PkgVersion = {
   pkg: string;
   path?: string;
   packageFileName?: string;
   type?: string;
   parents?: Parents;
-  precommand?: (string | any)[] | null;
-  command?: (string | any)[] | null;
-  postcommand?: (string | any)[] | null;
+  precommand?: CommandTypes[] | CommandTypes | null;
+  command?: CommandTypes[] | CommandTypes | null;
+  postcommand?: CommandTypes[] | CommandTypes | null;
   manager?: string;
   dependencies?: string[];
   errorOnVersionRange?: string;
@@ -213,9 +215,9 @@ export type PkgPublish = {
   packageFileName?: string;
   changelog?: string;
   tag?: string;
-  precommand?: (string | any)[] | null;
-  command?: (string | any)[] | null;
-  postcommand?: (string | any)[] | null;
+  precommand?: CommandTypes[] | CommandTypes | null;
+  command?: CommandTypes[] | CommandTypes | null;
+  postcommand?: CommandTypes[] | CommandTypes | null;
   manager: string;
   dependencies?: string[];
   getPublishedVersion?: string;


### PR DESCRIPTION
## Motivation

In using `covector`, we have found there are a handful of very typical operations that make sense to abstract into "built-in" operations. Specifying the `use` in a command with `options` to access these functions.

## Approach

Added a new API that calls specific abstracted chunks of logic with passed options instead of using shell commands.
