### PR TITLE
fix: render `deps` tag fallback after config tags

### DIFF
--- a/.changes/change-log-fallback-deps-tag.md
+++ b/.changes/change-log-fallback-deps-tag.md
@@ -1,0 +1,5 @@
+---
+"@covector/changelog": patch:bug
+---
+
+Fix the built-in fallback `deps: Dependecies` tag always appearing first in changelog when it should be the last one.

--- a/packages/changelog/src/index.ts
+++ b/packages/changelog/src/index.ts
@@ -214,10 +214,9 @@ const applyChanges = ({
 
         const changeTags: { [k: string]: string } = config.changeTags ?? {};
         // ensures there is a `deps` tag if one wasn't defined
-        if (!('deps' in changeTags)) {
-          changeTags.deps = "Dependencies"
+        if (!("deps" in changeTags)) {
+          changeTags.deps = "Dependencies";
         }
-        
 
         /**
          * Untagged changes are changes that don't have a tag associated with and `config.defaultChangeTag` is not set.
@@ -252,10 +251,10 @@ const applyChanges = ({
         ).map((dep) => {
           const appliedVersion = getVersionFromApplied(dep, applied);
           return {
-          	summary: appliedVersion 
-            	? `Upgraded to \`${dep}@${appliedVersion}\``
-            	: `Upgraded to latest \`${dep}\``,
-            }
+            summary: appliedVersion
+              ? `Upgraded to \`${dep}@${appliedVersion}\``
+              : `Upgraded to latest \`${dep}\``,
+          };
         });
         groupedChangesByTag.deps.push(...dependencies);
 

--- a/packages/changelog/src/index.ts
+++ b/packages/changelog/src/index.ts
@@ -212,11 +212,12 @@ const applyChanges = ({
           }
         };
 
-        const changeTags: { [k: string]: string } = {
-          // ensures there is a `deps` tag if `none` is defined
-          deps: "Dependencies",
-          ...(config.changeTags ?? {}),
-        };
+        const changeTags: { [k: string]: string } = config.changeTags ?? {};
+        // ensures there is a `deps` tag if one wasn't defined
+        if (!('deps' in changeTags)) {
+          changeTags.deps = "Dependencies"
+        }
+        
 
         /**
          * Untagged changes are changes that don't have a tag associated with and `config.defaultChangeTag` is not set.


### PR DESCRIPTION
## Motivation

<!-- REQUIRED
  Why are you introducing this change? Why is this change necessary? What
  are you trying to achieve with this change?
  If you have a relevant issue, add a link directly to the URL here.
 -->

The built-in `deps` tag fallback was always rendered before the tags defined in the config when it should've been rendered last.