### PR TITLE
assemble handles getPublishedVersion as object

### DIFF
--- a/.changes/assemble-getpublishedversion-object.md
+++ b/.changes/assemble-getpublishedversion-object.md
@@ -1,0 +1,5 @@
+---
+"@covector/assemble": patch:enhance
+---
+
+Consider getPublishedVersion can be either a string or an object.

--- a/packages/assemble/src/index.ts
+++ b/packages/assemble/src/index.ts
@@ -559,10 +559,17 @@ export const mergeIntoConfig = function* ({
       ...(!pkgCommands[pkg][`getPublishedVersion${subPublishCommand}`]
         ? {}
         : {
-            [`getPublishedVersion${subPublishCommand}`]: template(
+            [`getPublishedVersion${subPublishCommand}`]:
               //@ts-expect-error no index type string
-              pkgCommands[pkg][`getPublishedVersion${subPublishCommand}`]
-            )(pipeToTemplate),
+              typeof pkgCommands[pkg][
+                `getPublishedVersion${subPublishCommand}`
+              ] === "object"
+                ? //@ts-expect-error no index type string
+                  pkgCommands[pkg][`getPublishedVersion${subPublishCommand}`]
+                : template(
+                    //@ts-expect-error no index type string
+                    pkgCommands[pkg][`getPublishedVersion${subPublishCommand}`]
+                  )(pipeToTemplate),
           }),
       ...(!pkgCommands[pkg].assets
         ? {}

--- a/packages/command/test/fetchCommand.test.ts
+++ b/packages/command/test/fetchCommand.test.ts
@@ -75,7 +75,9 @@ describe("fetchCommand", () => {
         })
       );
 
-      expect(errored.message).toEqual("request returned code 404: Not Found");
+      expect(errored.message).toEqual(
+        "effection request to https://registry.npmjs.com/effection/0.5.32 returned code 404: Not Found"
+      );
     });
 
     it("failure retries then throws", function* () {
@@ -103,7 +105,9 @@ describe("fetchCommand", () => {
       );
 
       expect(console.error as any).toBeCalledTimes(2);
-      expect(errored.message).toEqual("request returned code 404: Not Found");
+      expect(errored.message).toEqual(
+        "effection request to https://registry.npmjs.com/effection/0.5.32 returned code 404: Not Found"
+      );
     });
   });
 
@@ -156,7 +160,7 @@ describe("fetchCommand", () => {
       );
 
       expect(errored.message).toEqual(
-        `request returned errors: [
+        `tauri request to https://crates.io/api/v1/crates/tauri/0.12.0 returned errors: [
   {
     "detail": "crate \`tauri\` does not have a version \`0.12.0\`"
   }
@@ -190,7 +194,7 @@ describe("fetchCommand", () => {
 
       expect(console.error as any).toBeCalledTimes(2);
       expect(errored.message).toEqual(
-        `request returned errors: [
+        `tauri request to https://crates.io/api/v1/crates/tauri/0.12.0 returned errors: [
   {
     "detail": "crate \`tauri\` does not have a version \`0.12.0\`"
   }


### PR DESCRIPTION
## Motivation

The command handled a `getPublishedVersion` as object, but assemble didn't. Fixing that.

## Approach

Check for an object in the assemble process.
