### PR TITLE
fix github publish details section

### DIFF
--- a/.changes/config.json
+++ b/.changes/config.json
@@ -19,7 +19,7 @@
       "prepublish": [{ "command": "npm pack", "dryRunCommand": true }],
       "publish": [
         {
-          "command": "echo '<details>\n<summary><em><h4>Cargo Publish</h4></em></summary>\n\n```'",
+          "command": "echo '<h2>NPM Publish</h2>\n<details>\n<summary><em>publish details</em></summary>\n\n```'",
           "dryRunCommand": true,
           "pipe": true
         },


### PR DESCRIPTION
## Motivation

The section for the Github Release incorrectly says "Cargo" and looked a bit wonky. Cleaning it up.
