### PR TITLE
`timeout` in `config.json` schema

### DIFF
--- a/.changes/timeout-in-config-schema.md
+++ b/.changes/timeout-in-config-schema.md
@@ -1,0 +1,5 @@
+---
+"@covector/files": patch
+---
+
+Include `timeout` in the `.changes/config.json` schema. It was throwing an error that it was invalid, but it is indeed valid.

--- a/packages/files/src/schema.ts
+++ b/packages/files/src/schema.ts
@@ -89,6 +89,7 @@ export const configFileSchema = (cwd: string = ".") =>
     .object({
       changeFolder: z.string().optional(),
       gitSiteUrl: z.string().optional(),
+      timeout: z.number().optional(),
       additionalBumpTypes: z.string().array().optional(),
       defaultChangeTag: z.string().optional(),
       pkgManagers: z.record(pkgManagerSchema).optional(),


### PR DESCRIPTION
## Motivation

The `timeout` property was missing in the config schema and incorrectly throwing an error.

## Approach

Add it to the schema.
