### PR TITLE
Dependabot Ignores Fixture Directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # no update PRs
+    open-pull-requests-limit: 0
+  # ignore the fixtures directory
+  - package-ecosystem: "npm"
+    directory: "/__fixtures__"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # no update PRs
+    open-pull-requests-limit: 0
+  # ignore the fixtures directory
+  - package-ecosystem: "cargo"
+    directory: "/__fixtures__"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"


### PR DESCRIPTION
## Motivation

We don't need to update deps in the fixtures directory as we are not installing these nor shipping them.

## Approach

Try honing in dependabot to ignore fixture dirs.
