### PR TITLE
include fetch command user agent

### DIFF
--- a/.changes/fetch-command-user-agent.md
+++ b/.changes/fetch-command-user-agent.md
@@ -1,0 +1,5 @@
+---
+"@covector/command": patch
+---
+
+The crates.io API endpoint requires a User Agent otherwise it returns a 403. Added agent to the fetch calls.

--- a/packages/command/src/index.ts
+++ b/packages/command/src/index.ts
@@ -180,11 +180,14 @@ function* useFunction({
   if (use === "fetch:check") {
     if (options?.url) {
       const url = template(options.url)({ pkg });
-      let request = yield fetch(url);
+      let request = yield fetch(url, {
+        headers: { ["user-agent"]: "covector/0 github.com/jbolda/covector" },
+      });
       if (request.status >= 400) {
+        const errorText = yield request.text();
         throw new MainError({
           exitCode: 1,
-          message: `${pkg.pkg} request to ${url} returned code ${request.status}: ${request.statusText}`,
+          message: `${pkg.pkg} request to ${url} returned code ${request.status} ${request.statusText}: ${errorText}`,
         });
       }
       const response = yield request.json();

--- a/packages/command/test/fetchCommand.test.ts
+++ b/packages/command/test/fetchCommand.test.ts
@@ -86,7 +86,7 @@ describe("fetchCommand", () => {
       );
 
       expect(errored.message).toEqual(
-        "effection request to https://registry.npmjs.com/effection/0.5.32 returned code 404: Not Found"
+        'effection request to https://registry.npmjs.com/effection/0.5.32 returned code 404 Not Found: "version not found: 0.5.32"'
       );
     });
 
@@ -117,7 +117,7 @@ describe("fetchCommand", () => {
 
       expect(console.error as any).toBeCalledTimes(2);
       expect(errored.message).toEqual(
-        "effection request to https://registry.npmjs.com/effection/0.5.32 returned code 404: Not Found"
+        'effection request to https://registry.npmjs.com/effection/0.5.32 returned code 404 Not Found: "version not found: 0.5.32"'
       );
     });
   });
@@ -173,11 +173,7 @@ describe("fetchCommand", () => {
       );
 
       expect(errored.message).toEqual(
-        `tauri request to https://crates.io/api/v1/crates/tauri/0.12.0 returned errors: [
-  {
-    "detail": "crate \`tauri\` does not have a version \`0.12.0\`"
-  }
-]`
+        `tauri request to https://crates.io/api/v1/crates/tauri/0.12.0 returned code 404 Not Found: {"errors":[{"detail":"crate \`tauri\` does not have a version \`0.12.0\`"}]}`
       );
     });
 
@@ -208,11 +204,7 @@ describe("fetchCommand", () => {
 
       expect(console.error as any).toBeCalledTimes(2);
       expect(errored.message).toEqual(
-        `tauri request to https://crates.io/api/v1/crates/tauri/0.12.0 returned errors: [
-  {
-    "detail": "crate \`tauri\` does not have a version \`0.12.0\`"
-  }
-]`
+        `tauri request to https://crates.io/api/v1/crates/tauri/0.12.0 returned code 404 Not Found: {"errors":[{"detail":"crate \`tauri\` does not have a version \`0.12.0\`"}]}`
       );
     });
   });


### PR DESCRIPTION
## Motivation

The `crates.io` endpoint now requires a user agent. Including an agent with all fetch requests to avoid the 403 from crates.io.
