### PR TITLE
GitHub comment notes sha in response without changes

### DIFF
--- a/.changes/no-changes-note-sha.md
+++ b/.changes/no-changes-note-sha.md
@@ -1,0 +1,5 @@
+---
+"action": patch
+---
+
+The GitHub comment was previously rather terse. We are now including the sha within the comment so as to make it clear when the command last ran.

--- a/packages/action/src/comment/formatGithubComment.ts
+++ b/packages/action/src/comment/formatGithubComment.ts
@@ -12,8 +12,8 @@ export function formatComment({
   projectReadmeExists: boolean;
   changeFolder: string;
 }) {
+  let comment = `### Package Changes Through ${payload.pull_request.head.sha}\n`;
   if ("applied" in covectored) {
-    let comment = `### Changes Through ${payload.pull_request.head.sha}\n`;
     let addChangeFileUrl = `${payload.pull_request.html_url}/../../new/${
       payload.pull_request.head.ref
     }${newChangeFile({
@@ -42,7 +42,7 @@ export function formatComment({
       defaultFooter
     );
   } else if ("pkgReadyToPublish" in covectored) {
-    return covectored.response;
+    return `${comment}${covectored.response}\n\n`;
   }
 }
 


### PR DESCRIPTION
## Motivation

The GitHub comment was previously rather terse. We are now including the sha within the comment so as to make it clear when the command last ran.

## Approach

Use header comment on both cases with changes or no changes.
