### PR TITLE
remove github links in version comment

### DIFF
--- a/.changes/remove-github-md-links.md
+++ b/.changes/remove-github-md-links.md
@@ -1,0 +1,5 @@
+---
+"action": patch
+---
+
+Fix links within GitHub by removing the explicit markdown syntax to allow GitHub Flavored Markdown to resolve, render and interlink the Version Packages PR with the change files and their PRs.

--- a/packages/action/src/index.ts
+++ b/packages/action/src/index.ts
@@ -134,7 +134,13 @@ export function* run(): Generator<any, any, any> {
         },
         "# Version Updates\n\nMerging this PR will release new versions of the following packages based on your change files.\n\n"
       );
-      core.setOutput("change", covectoredSmushed);
+      core.setOutput(
+        "change",
+        covectoredSmushed.replace(
+          /\[`?(.*?)`?\]\(.*?https\:\/\/www.github\.com.*?\)/gm,
+          "$1"
+        )
+      );
       const payload = JSON.stringify(covectoredSmushed, undefined, 2);
       core.startGroup(`covector version output`);
       console.log(`The covector output: ${payload}`);


### PR DESCRIPTION
## Motivation

The changelog and subsequent comment include markdown links to GitHub. The links are inserted in the changelog file as it may be viewed in many contexts including outside of GitHub. If we insert the content in GitHub however, it will resolve its own links to provide additional context. We should remove these links to allow the GitHub platform to handle this (including interlinking to the Version Packages PR).

## Approach

As this is GitHub-specific, we handle this directly in the action and remove the links through regex. With the specificity employed, it is unlikely to be accidentally destructive.
