### PR TITLE
remove reviewer recognition and shift contributor note

### DIFF
--- a/.changes/recognize-contributors.md
+++ b/.changes/recognize-contributors.md
@@ -3,4 +3,4 @@
 "action": minor
 ---
 
-Query the GitHub API for the PR creator and reviewers, and highlight their names in the changelogs for recognition of their contribution.
+Query the GitHub API for the PR creator, and highlight their names in the changelogs for recognition of their contribution.

--- a/packages/action/src/pr/getCommitContext.ts
+++ b/packages/action/src/pr/getCommitContext.ts
@@ -30,19 +30,20 @@ export function* getCommitContext(
         ) {
           ... on Commit {
             abbreviatedOid
-            associatedPullRequests(first: 2) {
+            associatedPullRequests(first: 1) {
               nodes {
                 number
                 author {
                   login
                 }
-                reviews(first: 5, states: [APPROVED]) {
-                  nodes {
-                    author {
-                      login
-                    }
-                  }
-                }
+                # Hard to support reviewers without possible excessive verbosity and spam, disabling
+                # reviews(first: 5, states: [APPROVED]) {
+                #   nodes {
+                #     author {
+                #       login
+                #     }
+                #   }
+                # }
               }
             }
           }

--- a/packages/changelog/src/index.ts
+++ b/packages/changelog/src/index.ts
@@ -130,22 +130,17 @@ const renderRelease = (
     const matches = commit.commitSubject.match(/(#[0-9]+)/g) ?? [];
     const len = matches.length;
     const pr = len === 0 ? null : len === 1 ? matches[0] : matches[len - 1];
-    const prLink = pr ? `([${pr}](${gitSiteUrl}pull/${pr.slice(1)}))` : "";
     const hashLookup = `sha_${commit.hashLong}`;
+    const prLink = pr ? `[${pr}](${gitSiteUrl}pull/${pr.slice(1)})` : "";
     const personLink = (person: string) =>
       `[@${person}](${gitSiteUrl}../../${person})`;
     const recognizeContributions = context?.[hashLookup]?.author
-      ? ` by ${personLink(context[hashLookup].author)}${
-          context?.[hashLookup]?.reviewed
-            ? `, reviewed by ${context[hashLookup].reviewed
-                .split(", ")
-                .map((person) => personLink(person))
-                .join(", ")}`
-            : ``
-        }`
+      ? ` by ${personLink(context[hashLookup].author)}`
       : ``;
 
-    return `\n- ${commitLink}${prLink} ${summary}${recognizeContributions}`;
+    return `\n- ${commitLink}${
+      pr ? ` (${prLink}${recognizeContributions})` : ""
+    } ${summary}${recognizeContributions}`;
   }
 };
 

--- a/packages/changelog/test/fill-changelog.test.ts
+++ b/packages/changelog/test/fill-changelog.test.ts
@@ -80,7 +80,7 @@ describe("fills changelog", () => {
         "## \\[0.5.6]\n\n" +
         "- This is a test.\n" +
         "- This is another test.\n" +
-        "- This is the last test.\n",
+        "- This is the last test.\n"
     );
   });
 
@@ -178,9 +178,9 @@ describe("fills changelog", () => {
     expect(changelog.content).toBe(
       "# Changelog\n\n" +
         "## \\[0.5.6]\n\n" +
-        "- [`3ca0504`](/commit/3ca05042c51821d229209e18391535c266b6b200)([#719999](/pull/719999)) This is a test.\n" +
-        "- [`3ca0504`](/commit/3ca05042c51821d229209e18391535c266b6b200)([#123](/pull/123)) This is another test.\n" +
-        "- [`3ca0504`](/commit/3ca05042c51821d229209e18391535c266b6b200)([#8873](/pull/8873)) This is the last test.\n",
+        "- [`3ca0504`](/commit/3ca05042c51821d229209e18391535c266b6b200) ([#719999](/pull/719999)) This is a test.\n" +
+        "- [`3ca0504`](/commit/3ca05042c51821d229209e18391535c266b6b200) ([#123](/pull/123)) This is another test.\n" +
+        "- [`3ca0504`](/commit/3ca05042c51821d229209e18391535c266b6b200) ([#8873](/pull/8873)) This is the last test.\n"
     );
   });
 
@@ -248,7 +248,7 @@ describe("fills changelog", () => {
         "## \\[0.5.6]\n\n" +
         "- This is a test.\n" +
         "- This is another test.\n" +
-        "- This is the last test.\n",
+        "- This is the last test.\n"
     );
   });
 
@@ -320,7 +320,7 @@ describe("fills changelog", () => {
         "- Fixes no-server mode not running on another machine due to fs::read_to_string usage instead of the include_str macro.\n" +
         "- Build no longer fails when compiling without environment variables, now the app will show an error.\n" +
         "- Adds desktop notifications API.\n" +
-        "- Properly reflect tauri.conf.json changes on app when running tauri dev.\n",
+        "- Properly reflect tauri.conf.json changes on app when running tauri dev.\n"
     );
   });
 });

--- a/packages/changelog/test/read-changelog.test.ts
+++ b/packages/changelog/test/read-changelog.test.ts
@@ -131,9 +131,9 @@ describe("reads changelog", () => {
     });
     expect(pkgCommandsRan[pkgName].command).toBe(
       "## \\[0.5.6]\n\n" +
-        "- [`3ca0504`](/commit/3ca05042c51821d229209e18391535c266b6b200)([#719999](/pull/719999)) This is a test.\n" +
-        "- [`3ca0504`](/commit/3ca05042c51821d229209e18391535c266b6b200)([#123](/pull/123)) This is another test.\n" +
-        "- [`3ca0504`](/commit/3ca05042c51821d229209e18391535c266b6b200)([#8873](/pull/8873)) This is the last test.\n"
+        "- [`3ca0504`](/commit/3ca05042c51821d229209e18391535c266b6b200) ([#719999](/pull/719999)) This is a test.\n" +
+        "- [`3ca0504`](/commit/3ca05042c51821d229209e18391535c266b6b200) ([#123](/pull/123)) This is another test.\n" +
+        "- [`3ca0504`](/commit/3ca05042c51821d229209e18391535c266b6b200) ([#8873](/pull/8873)) This is the last test.\n"
     );
   });
 
@@ -227,7 +227,7 @@ describe("reads changelog", () => {
         "- This is the final test.\n\n" +
         "### Bugs\n\n" +
         "- This is a test.\n" +
-        "- This is another test.\n",
+        "- This is another test.\n"
     );
   });
 });


### PR DESCRIPTION
## Motivation

In #307, we added the opt-in feature to recognize contributors and reviewers. After discussions with @amrbashir, we removed reviewers over concerns of spam and possible verbosity issues. Additionally, the placement of the contributor recognition was awkward.

## Approach

By removing the reviewers, this made it easier to justify putting the PR author directly after the number.
