### PR TITLE
update changelog regex for naked github url

### DIFF
--- a/packages/action/src/index.ts
+++ b/packages/action/src/index.ts
@@ -187,7 +187,7 @@ export function* run(): Generator<any, any, any> {
       core.setOutput(
         "change",
         covectoredSmushed.replace(
-          /\[`?(.*?)`?\]\(.*?https\:\/\/www.github\.com.*?\)/gm,
+          /\[`?(.*?)`?\]\(.*?https\:\/\/(www\.)?github\.com.*?\)/gm,
           "$1"
         )
       );


### PR DESCRIPTION
## Motivation

The changelog regex didn't consider naked github.com urls, and it should.

## Approach

Updated the regex to consider `www.` as optional.
