### PR TITLE
use head_repository on workflow_run to determine fork

### DIFF
--- a/.github/workflows/comment-on-forks.yml
+++ b/.github/workflows/comment-on-forks.yml
@@ -17,6 +17,6 @@ jobs:
       - name: covector status
         uses: jbolda/covector/packages/action@main
         id: covector
-        if: github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.repository.full_name != github.repository || github.actor == 'dependabot[bot]')
+        if: github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.head_repository.full_name != github.repository || github.actor == 'dependabot[bot]')
         with:
           command: "status"


### PR DESCRIPTION
## Motivation

`head_repository` is the ticket for determining if the `workflow_run` is executing off a PR from a fork. This is based on context in #327.
