### PR TITLE
explicit perms on workflow_run to read artifact, write comment

### DIFF
--- a/.github/workflows/comment-on-forks.yml
+++ b/.github/workflows/comment-on-forks.yml
@@ -6,6 +6,13 @@ on:
     types:
       - completed
 
+# note all other permissions are set to none if not specified
+permissions:
+  # to read the action artifacts
+  actions: read
+  # to write the comment
+  pull-requests: write
+
 jobs:
   download:
     runs-on: ubuntu-latest
@@ -17,7 +24,9 @@ jobs:
       - name: covector status
         uses: jbolda/covector/packages/action@release
         id: covector
-        if: github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.head_repository.full_name != github.repository || github.actor == 'dependabot[bot]')
+        # note that this could be shifted to the job, but for future reference we are dumping the full github context
+        if: github.event.workflow_run.conclusion == 'success' &&
+          (github.event.workflow_run.head_repository.full_name != github.repository || github.actor == 'dependabot[bot]')
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           command: "status"


### PR DESCRIPTION
## Motivation

We need to give explicit permissions to read other actions and then write the comment.
