### PR TITLE
`covector add` now includes `additionalBumpTypes` and `changeTags`

### DIFF
--- a/.changes/changeTags-in-add.md
+++ b/.changes/changeTags-in-add.md
@@ -1,0 +1,5 @@
+---
+"covector": minor:enhance
+---
+
+The `covector add` command now considers the `additionalBumpTypes` and `changeTags` configs and includes these in consideration of adding a change file.

--- a/.changes/checkout-v4-create-pr-v6.md
+++ b/.changes/checkout-v4-create-pr-v6.md
@@ -1,5 +1,5 @@
 ---
-"covector": patch
+"covector": patch:enhance
 ---
 
 Bump actions within the covector init command to the latest: actions/checkout@v4 and peter-evans/create-pull-request@v6.

--- a/.changes/config.json
+++ b/.changes/config.json
@@ -5,7 +5,8 @@
     "feat": "New Features",
     "enhance": "Enhancements",
     "bug": "Bug Fixes",
-    "deps": "Dependencies"
+    "deps": "Dependencies",
+    "internal": "Changes Supporting Covector Development"
   },
   "pkgManagers": {
     "javascript": {

--- a/.changes/node-v20.md
+++ b/.changes/node-v20.md
@@ -1,6 +1,6 @@
 ---
-"covector": minor
-"action": minor
+"covector": minor:enhance
+"action": minor:enhance
 ---
 
 Use node v20 in GitHub Action.

--- a/.changes/vitest-conversion.md
+++ b/.changes/vitest-conversion.md
@@ -1,13 +1,13 @@
 ---
-"covector": housekeeping
-"@covector/apply": housekeeping
-"@covector/assemble": housekeeping
-"@covector/changelog": housekeeping
-"@covector/files": housekeeping
-"@covector/command": housekeeping
-"@covector/toml": housekeeping
-"@covector/types": housekeeping
-"action": housekeeping
+"covector": housekeeping:internal
+"@covector/apply": housekeeping:internal
+"@covector/assemble": housekeeping:internal
+"@covector/changelog": housekeeping:internal
+"@covector/files": housekeeping:internal
+"@covector/command": housekeeping:internal
+"@covector/toml": housekeeping:internal
+"@covector/types": housekeeping:internal
+"action": housekeeping:internal
 ---
 
 Switch to Vitest for the test runner. This improves speed and enables improved ability to update to current standards. Additionally, we use `pino-test` with the changes to the logger to more specifically check log output. Along with this, we switch multiple test fixtures to run commands that would return more standard output across OS which reduces test flakiness.

--- a/.changes/workflow_run-post-comment.md
+++ b/.changes/workflow_run-post-comment.md
@@ -1,5 +1,5 @@
 ---
-"action": minor
+"action": minor:feat
 ---
 
 Handle `workflow_run` to enable generating a comment, uploading it as an artifact and post the comment in a workflow which has appropriate permissions.


### PR DESCRIPTION
## Motivation

If the config specifies `additionalBumpTypes` and `changeTags`, we have some expectation that they want to recommend folks consider those when creating a new change file.

## Approach

`covector add` now includes `additionalBumpTypes` and `changeTags` in the options to help facilitate these being included and improving the readability of changelogs.
