### PR TITLE
use --provenance for publishes to npm

### DIFF
--- a/.changes/config.json
+++ b/.changes/config.json
@@ -25,7 +25,7 @@
           "pipe": true
         },
         {
-          "command": "npm publish --access public",
+          "command": "npm publish --provenance --access public",
           "dryRunCommand": "echo publish here",
           "pipe": true
         },

--- a/packages/covector/src/init.ts
+++ b/packages/covector/src/init.ts
@@ -144,7 +144,7 @@ export const init = function* init({
         url: "https://registry.npmjs.com/${ pkg.pkg }/${ pkg.pkgFile.version }",
       },
     },
-    publish: ["npm publish --access public"],
+    publish: ["npm publish --provenance --access public"],
   };
 
   const rust = {


### PR DESCRIPTION
## Motivation

Using the `--provenance` in an npm publish creates an annotation on the npm registry which shows that this was published through CI.

![Screenshot 2024-07-05 at 11 34 01 AM](https://github.com/jbolda/covector/assets/2019387/17a13bfc-d54d-4a9c-8d7d-31345b886709)

