### PR TITLE
provenance in #338 needs id-token

### DIFF
--- a/.github/workflows/run-version-or-publish.yml
+++ b/.github/workflows/run-version-or-publish.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - main
 
+permissions:
+  id-token: write
+
 jobs:
   covector:
     runs-on: ubuntu-latest

--- a/packages/covector/src/init.ts
+++ b/packages/covector/src/init.ts
@@ -416,6 +416,9 @@ on:
     branches:
       - ${branchName}
 
+permissions:
+  id-token: write
+
 jobs:
   version-or-publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Motivation

Missed the `id-token` required to enable `provenance` for npm.
