### PR TITLE
GitHub Release needs contents: write permission

### DIFF
--- a/.github/workflows/run-version-or-publish.yml
+++ b/.github/workflows/run-version-or-publish.yml
@@ -5,7 +5,10 @@ on:
       - main
 
 permissions:
+  # required for npm provenance
   id-token: write
+  # required to create the GitHub Release
+  contents: write
 
 jobs:
   covector:


### PR DESCRIPTION
## Motivation

We scoped the permissions too tight in #340. Adjusting to allow creating GitHub Releases.
