### PR TITLE
missed passing some logger functions appropriate object signature

### DIFF
--- a/.changes/logger-poorly-formatted-objects.md
+++ b/.changes/logger-poorly-formatted-objects.md
@@ -1,0 +1,6 @@
+---
+"covector": patch:bug
+"action": patch:bug
+---
+
+Missed some logger function which were improperly passed an non-message object. If rendering an object, it requires `msg` and `renderAsYAML`.

--- a/packages/covector/src/arbitrary.ts
+++ b/packages/covector/src/arbitrary.ts
@@ -79,8 +79,10 @@ export function* arbitrary({
   });
 
   if (dryRun) {
-    logger.info("==== commands ready to run ===");
-    logger.info(commands);
+    logger.info({
+      msg: "==== commands ready to run ===",
+      renderAsYAML: commands,
+    });
   }
 
   if (commands.length === 0) {
@@ -143,8 +145,7 @@ export function* arbitrary({
   });
 
   if (dryRun) {
-    logger.info("==== result ===");
-    logger.info(pkgCommandsRan);
+    logger.info({ msg: "==== result ===", renderAsYAML: pkgCommandsRan });
   }
 
   return <CovectorPublish>{ commandsRan: pkgCommandsRan, pipeTemplate };

--- a/packages/covector/src/publish.ts
+++ b/packages/covector/src/publish.ts
@@ -79,8 +79,10 @@ export function* publish({
   });
 
   if (dryRun) {
-    logger.info("==== commands ready to run ===");
-    logger.info(commands);
+    logger.info({
+      msg: "==== commands ready to run ===",
+      renderAsYAML: commands,
+    });
   }
 
   if (commands.length === 0) {
@@ -143,8 +145,7 @@ export function* publish({
   });
 
   if (dryRun) {
-    logger.info("==== result ===");
-    logger.info(pkgCommandsRan);
+    logger.info({ msg: "==== result ===", renderAsYAML: pkgCommandsRan });
   }
 
   return <CovectorPublish>{ commandsRan: pkgCommandsRan, pipeTemplate };

--- a/packages/covector/src/status.ts
+++ b/packages/covector/src/status.ts
@@ -117,10 +117,10 @@ export function* status({
   } else if (!!pre && assembledChanges?.changes?.length === 0) {
     if (logs) {
       logger.info("There are no changes.");
-      logger.info(
-        "We have previously released the changes in these files:",
-        changesPaths
-      );
+      logger.info({
+        msg: "We have previously released the changes in these files:",
+        renderAsYAML: changesPaths,
+      });
     }
     return { pkgReadyToPublish: [], response: "No changes." };
   } else {

--- a/packages/covector/src/version.ts
+++ b/packages/covector/src/version.ts
@@ -88,8 +88,10 @@ export function* version({
     cwd,
   });
   if (dryRun) {
-    logger.info("==== commands ready to run ===");
-    logger.info(commands);
+    logger.info({
+      msg: "==== commands ready to run ===",
+      renderAsYAML: commands,
+    });
   }
 
   let pkgCommandsRan: CommandsRan = Object.keys(config.packages).reduce(
@@ -186,8 +188,7 @@ export function* version({
   }
 
   if (dryRun) {
-    logger.info("==== result ===");
-    logger.info(pkgCommandsRan);
+    logger.info({ msg: "==== result ===", renderAsYAML: pkgCommandsRan });
   }
 
   return <CovectorVersion>{ commandsRan: pkgCommandsRan, pipeTemplate };

--- a/packages/covector/test/integration/complex.test.ts
+++ b/packages/covector/test/integration/complex.test.ts
@@ -304,21 +304,13 @@ describe("integration test for complex commands", () => {
             command: "version",
             msg: "==== commands ready to run ===",
             level: 30,
-          },
-          {
-            command: "version",
-            // command data piped
-            level: 30,
+            renderAsYAML: {},
           },
           {
             command: "version",
             msg: "==== result ===",
             level: 30,
-          },
-          {
-            command: "version",
-            // command data piped
-            level: 30,
+            renderAsYAML: {},
           },
           {
             msg: "completed",
@@ -361,21 +353,19 @@ describe("integration test for complex commands", () => {
             command: "publish",
             msg: "==== data piped into commands ===",
             level: 30,
+            renderAsYAML: {},
           },
           {
             command: "publish",
             msg: "==== data piped into commands ===",
             level: 30,
+            renderAsYAML: {},
           },
           {
             command: "publish",
             msg: "==== commands ready to run ===",
             level: 30,
-          },
-          {
-            command: "publish",
-            // TODO this has extra, check render YAML
-            level: 30,
+            renderAsYAML: {},
           },
           {
             command: "publish",
@@ -391,12 +381,7 @@ describe("integration test for complex commands", () => {
             command: "publish",
             msg: "==== result ===",
             level: 30,
-          },
-          {
-            command: "publish",
-            // TODO check YAML render
-            // msg: "boop",
-            level: 30,
+            renderAsYAML: {},
           },
           {
             msg: "completed",
@@ -426,25 +411,20 @@ describe("integration test for complex commands", () => {
           {
             command: "arbitrary",
             msg: "==== data piped into commands ===",
-            // TODO check YAML render
             level: 30,
+            renderAsYAML: {},
           },
           {
             command: "arbitrary",
             msg: "==== data piped into commands ===",
-            // TODO check YAML render
             level: 30,
+            renderAsYAML: {},
           },
           {
             command: "arbitrary",
             msg: "==== commands ready to run ===",
-            // TODO check YAML render
             level: 30,
-          },
-          {
-            command: "arbitrary",
-            // TODO check command output
-            level: 30,
+            renderAsYAML: {},
           },
           {
             command: "arbitrary",
@@ -490,11 +470,7 @@ describe("integration test for complex commands", () => {
             command: "arbitrary",
             msg: "==== result ===",
             level: 30,
-          },
-          {
-            command: "arbitrary",
-            // TODO check result output
-            level: 30,
+            renderAsYAML: {},
           },
           {
             msg: "completed",
@@ -525,22 +501,19 @@ describe("integration test for complex commands", () => {
             command: "arbitrary",
             msg: "==== data piped into commands ===",
             level: 30,
+            renderAsYAML: {},
           },
           {
             command: "arbitrary",
             msg: "==== data piped into commands ===",
             level: 30,
+            renderAsYAML: {},
           },
           {
             command: "arbitrary",
             msg: "==== commands ready to run ===",
             level: 30,
-          },
-          {
-            command: "arbitrary",
-            // msg: "boop",
-            // data pipe
-            level: 30,
+            renderAsYAML: {},
           },
           {
             command: "arbitrary",
@@ -556,12 +529,7 @@ describe("integration test for complex commands", () => {
             command: "arbitrary",
             msg: "==== result ===",
             level: 30,
-          },
-          {
-            command: "arbitrary",
-            // msg: "boop",
-            // result
-            level: 30,
+            renderAsYAML: {},
           },
           {
             msg: "completed",

--- a/packages/covector/test/integration/dry-run.test.ts
+++ b/packages/covector/test/integration/dry-run.test.ts
@@ -128,32 +128,25 @@ describe("integration test in --dry-run mode", () => {
           command: "version",
           msg: "==== data piped into commands ===",
           level: 30,
-          // TODO check render
+          renderAsYAML: {},
         },
         {
           command: "version",
           msg: "==== data piped into commands ===",
           level: 30,
-          // TODO check render
+          renderAsYAML: {},
         },
         {
           command: "version",
           msg: "==== data piped into commands ===",
           level: 30,
-          // TODO check render
+          renderAsYAML: {},
         },
         {
           command: "version",
           msg: "==== commands ready to run ===",
           level: 30,
-          // TODO check render
-        },
-        {
-          command: "version",
-          // TODO no message?
-          // msg: "==== commands ready to run ===",
-          level: 30,
-          // TODO check render
+          renderAsYAML: {},
         },
         {
           command: "version",
@@ -204,12 +197,7 @@ describe("integration test in --dry-run mode", () => {
           command: "version",
           msg: "==== result ===",
           level: 30,
-        },
-        {
-          command: "version",
-          // TODO check render
-          // msg: "completed",
-          level: 30,
+          renderAsYAML: {},
         },
         {
           msg: "completed",
@@ -257,44 +245,37 @@ describe("integration test in --dry-run mode", () => {
           command: "publish",
           msg: "==== data piped into commands ===",
           level: 30,
-          // TODO check render
+          renderAsYAML: {},
         },
         {
           command: "publish",
           msg: "==== data piped into commands ===",
           level: 30,
-          // TODO check render
+          renderAsYAML: {},
         },
         {
           command: "publish",
           msg: "==== data piped into commands ===",
           level: 30,
-          // TODO check render
+          renderAsYAML: {},
         },
         {
           command: "publish",
           msg: "==== data piped into commands ===",
           level: 30,
-          // TODO check render
+          renderAsYAML: {},
         },
         {
           command: "publish",
           msg: "==== data piped into commands ===",
           level: 30,
-          // TODO check render
+          renderAsYAML: {},
         },
         {
           command: "publish",
           msg: "==== commands ready to run ===",
           level: 30,
-          // TODO check render
-        },
-        {
-          command: "publish",
-          // TODO no message?
-          // msg: "==== commands ready to run ===",
-          level: 30,
-          // TODO check render
+          renderAsYAML: {},
         },
         {
           command: "publish",
@@ -440,12 +421,7 @@ describe("integration test in --dry-run mode", () => {
           command: "publish",
           msg: "==== result ===",
           level: 30,
-        },
-        {
-          command: "publish",
-          // msg: "completed",
-          // TODO check render
-          level: 30,
+          renderAsYAML: {},
         },
         {
           msg: "completed",
@@ -477,14 +453,7 @@ describe("integration test in --dry-run mode", () => {
           command: "arbitrary",
           msg: "==== commands ready to run ===",
           level: 30,
-          // TODO check render
-        },
-        {
-          command: "arbitrary",
-          // TODO no message?
-          // msg: "==== commands ready to run ===",
-          level: 30,
-          // TODO check render
+          renderAsYAML: {},
         },
         {
           command: "arbitrary",
@@ -521,44 +490,37 @@ describe("integration test in --dry-run mode", () => {
           command: "arbitrary",
           msg: "==== data piped into commands ===",
           level: 30,
-          // TODO check render
+          renderAsYAML: {},
         },
         {
           command: "arbitrary",
           msg: "==== data piped into commands ===",
           level: 30,
-          // TODO check render
+          renderAsYAML: {},
         },
         {
           command: "arbitrary",
           msg: "==== data piped into commands ===",
           level: 30,
-          // TODO check render
+          renderAsYAML: {},
         },
         {
           command: "arbitrary",
           msg: "==== data piped into commands ===",
           level: 30,
-          // TODO check render
+          renderAsYAML: {},
         },
         {
           command: "arbitrary",
           msg: "==== data piped into commands ===",
           level: 30,
-          // TODO check render
+          renderAsYAML: {},
         },
         {
           command: "arbitrary",
           msg: "==== commands ready to run ===",
           level: 30,
-          // TODO check render
-        },
-        {
-          command: "arbitrary",
-          // TODO no message?
-          // msg: "==== commands ready to run ===",
-          level: 30,
-          // TODO check render
+          renderAsYAML: {},
         },
         {
           command: "arbitrary",
@@ -614,13 +576,6 @@ describe("integration test in --dry-run mode", () => {
           command: "arbitrary",
           msg: "==== result ===",
           level: 30,
-        },
-        {
-          command: "arbitrary",
-          // TODO no message?
-          // msg: "completed",
-          level: 30,
-          // TODO check render
         },
         {
           msg: "completed",


### PR DESCRIPTION
## Motivation

We hit an error downstream in prerelease mode where the logger was passed an object with an improper type signature. Fixing this.

## Approach

This seemed to only occur in one spot in the production code, but we also missed many `--dry-run` instances as well.

