### PR TITLE
pass config to prerelease return

### DIFF
--- a/.changes/pass-config-to-prerelease-return.md
+++ b/.changes/pass-config-to-prerelease-return.md
@@ -1,0 +1,5 @@
+---
+"covector": patch:bug
+---
+
+Prerelease versions which post comments require the config passed in the return signature.

--- a/packages/covector/src/status.ts
+++ b/packages/covector/src/status.ts
@@ -122,7 +122,7 @@ export function* status({
         renderAsYAML: changesPaths,
       });
     }
-    return { pkgReadyToPublish: [], response: "No changes." };
+    return { pkgReadyToPublish: [], config, response: "No changes." };
   } else {
     if (logs) {
       logger.info("changes:");


### PR DESCRIPTION
## Motivation

Comments on prerelease were throwing an error because the config was not passed in the return.