### PR TITLE
fix covector docs link

### DIFF
--- a/.changes/change-pr-350.md
+++ b/.changes/change-pr-350.md
@@ -1,0 +1,6 @@
+---
+"covector": patch
+"action": patch
+---
+
+Fix GitHub pull request comment link to correctly point at the docs.

--- a/packages/action/src/comment/formatGithubComment.ts
+++ b/packages/action/src/comment/formatGithubComment.ts
@@ -25,7 +25,7 @@ export function formatComment({
     projectReadmeExists
       ? `about <a href='../tree/HEAD/${changeFolder}'>change files</a><em> or`
       : ""
-  } the docs at <a href='https://github.com/jbolda/covector/tree/main/covector'>github.com/jbolda/covector</a><em></p>`;
+  } the docs at <a href='https://github.com/jbolda/covector/tree/main/packages/covector'>github.com/jbolda/covector</a><em></p>`;
 
   if ("applied" in covectored) {
     return (


### PR DESCRIPTION
it links to the wrong (maybe old?) directory currently