### PR TITLE
comment-on-fork name fix

### DIFF
--- a/.github/workflows/comment-on-forks.yml
+++ b/.github/workflows/comment-on-forks.yml
@@ -2,7 +2,7 @@ name: covector comment on forks
 
 on:
   workflow_run:
-    workflows: [covector]
+    workflows: [covector status]
     types:
       - completed
 


### PR DESCRIPTION
## Motivation

The name didn't match the workflow for commenting on forks. This meant the workflow was not run.
