### PR TITLE
action supports --dry-run

### DIFF
--- a/.changes/action-supports-dry-run.md
+++ b/.changes/action-supports-dry-run.md
@@ -1,0 +1,5 @@
+---
+"action": patch:bug
+---
+
+The action now supports running in dry run mode. This enables testing of workflows and publish sequences prior to publishing.

--- a/.changes/config.json
+++ b/.changes/config.json
@@ -26,7 +26,7 @@
         },
         {
           "command": "npm publish --provenance --access public",
-          "dryRunCommand": "echo publish here",
+          "dryRunCommand": "npm publish --provenance --access public --dry-run",
           "pipe": true
         },
         {

--- a/.github/workflows/run-version-or-publish.yml
+++ b/.github/workflows/run-version-or-publish.yml
@@ -48,6 +48,12 @@ jobs:
       - name: sync lockfile
         if: steps.covector.outputs.commandRan == 'version'
         run: npm install
+      - name: covector publish --dry-run
+        uses: ./packages/action
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          command: "publish"
+          dryRun: true
       - name: create pull request
         id: cpr
         uses: peter-evans/create-pull-request@v6

--- a/packages/action/action.yml
+++ b/packages/action/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: The directory to run covector within.
     required: false
     default: ""
+  dryRun:
+    description: Run in dry-run mode which skips executing steps, and instead logs. Useful for testing a publish beforehand.
+    required: false
+    defaults: false
   createRelease:
     description: Opt-in to create a release on publish
     required: false

--- a/packages/action/src/index.ts
+++ b/packages/action/src/index.ts
@@ -34,6 +34,7 @@ export function* run(logger: Logger): Generator<any, any, any> {
         ? process.env.GITHUB_TOKEN || ""
         : core.getInput("token");
     const inputCommand = core.getInput("command");
+    const dryRun = core.getInput("dryRun") === "true";
     const releaseCommitish =
       core.getInput("releaseCommitish") || github.context.sha;
 
@@ -74,6 +75,7 @@ export function* run(logger: Logger): Generator<any, any, any> {
       } else {
         const covectored: CovectorStatus = yield covector({
           logger,
+          dryRun,
           command,
           filterPackages,
           cwd,
@@ -153,6 +155,7 @@ export function* run(logger: Logger): Generator<any, any, any> {
     } else if (command === "version") {
       const status: CovectorStatus = yield covector({
         logger,
+        dryRun,
         command: "status",
         cwd,
       });
@@ -207,6 +210,7 @@ export function* run(logger: Logger): Generator<any, any, any> {
 
       const covectored: CovectorVersion = yield covector({
         logger,
+        dryRun,
         command,
         filterPackages,
         cwd,
@@ -238,7 +242,7 @@ export function* run(logger: Logger): Generator<any, any, any> {
         renderAsYAML: covectoredSmushed,
       });
     } else if (command === "publish") {
-      const status = yield covector({ logger, command: "status", cwd });
+      const status = yield covector({ logger, dryRun, command: "status", cwd });
       core.setOutput("status", status.response);
 
       let covectored: CovectorPublish;
@@ -253,6 +257,7 @@ export function* run(logger: Logger): Generator<any, any, any> {
         logger.debug(`Fetched context, owner is ${owner} and repo is ${repo}.`);
         covectored = yield covector({
           logger,
+          dryRun,
           command,
           filterPackages,
           cwd,
@@ -270,6 +275,7 @@ export function* run(logger: Logger): Generator<any, any, any> {
       } else {
         covectored = yield covector({
           logger,
+          dryRun,
           command,
           filterPackages,
           cwd,
@@ -373,6 +379,7 @@ export function* run(logger: Logger): Generator<any, any, any> {
 
         covectored = yield covector({
           logger,
+          dryRun,
           command,
           filterPackages,
           cwd,


### PR DESCRIPTION
## Motivation

Supporting the `--dry-run` arg that users may test a publish sequence prior to officially merging.

## Approach

The CLI and function already supported this, passing it through the action as an input option.
