### PR TITLE
fix 'change file add' URL on forks

### DIFF
--- a/.changes/action-supports-dry-run.md
+++ b/.changes/action-supports-dry-run.md
@@ -1,5 +1,5 @@
 ---
-"action": patch:bug
+"action": patch:enhance
 ---
 
 The action now supports running in dry run mode. This enables testing of workflows and publish sequences prior to publishing.

--- a/.changes/change-file-add-url-on-forks.md
+++ b/.changes/change-file-add-url-on-forks.md
@@ -1,0 +1,5 @@
+---
+"action": patch:bug
+---
+
+The URL to create a change file on forks was broken. It was incorrectly pointing at the root repo.

--- a/.changes/change-pr-350.md
+++ b/.changes/change-pr-350.md
@@ -1,6 +1,6 @@
 ---
-"covector": patch
-"action": patch
+"covector": patch:bug
+"action": patch:bug
 ---
 
 Fix GitHub pull request comment link to correctly point at the docs.

--- a/packages/action/src/comment/formatGithubComment.ts
+++ b/packages/action/src/comment/formatGithubComment.ts
@@ -13,7 +13,7 @@ export function formatComment({
   changeFolder: string;
 }) {
   let comment = `### Package Changes Through ${payload.pull_request.head.sha}\n`;
-  let addChangeFileUrl = `${payload.pull_request.html_url}/../../new/${
+  let addChangeFileUrl = `${payload.pull_request.head.repo.html_url}/../../new/${
     payload.pull_request.head.ref
   }${newChangeFile({
     prNumber: payload.pull_request.number,

--- a/packages/action/src/comment/formatGithubComment.ts
+++ b/packages/action/src/comment/formatGithubComment.ts
@@ -13,7 +13,7 @@ export function formatComment({
   changeFolder: string;
 }) {
   let comment = `### Package Changes Through ${payload.pull_request.head.sha}\n`;
-  let addChangeFileUrl = `${payload.pull_request.head.repo.html_url}/../../new/${
+  let addChangeFileUrl = `${payload.pull_request.head.repo.html_url}/new/${
     payload.pull_request.head.ref
   }${newChangeFile({
     prNumber: payload.pull_request.number,


### PR DESCRIPTION
## Motivation

The URL to create a change file on forks was broken. It was incorrectly pointing at the root repo.

