### PR TITLE
Additional Status Outputs

### DIFF
--- a/.changes/status-output-options.md
+++ b/.changes/status-output-options.md
@@ -1,0 +1,5 @@
+---
+"covector": patch:enhance
+---
+
+Adding a few more outputs from the `status` command for use cases which want to work off the derived state.

--- a/packages/action/README.md
+++ b/packages/action/README.md
@@ -34,18 +34,22 @@ Note that command can also use `version-or-publish` which is an input command un
 
 See the [action.yml](./action.yml) for outputs for your use or see below.
 
-| output            | description                                                                                             | command                           |
-| ----------------- | ------------------------------------------------------------------------------------------------------- | --------------------------------- |
-| status            | Returns either "No changes." or a dyanmic list of packages changed.                                     | status, version, publish          |
-| willPublish       | Will be set as `"true"` (stringified boolean) if the next step is to try publishing.                    | status                            |
-| change            | The changes that were applied                                                                           | version, preview                  |
-| commandRan        | The command ran (particularly useful for 'version-or-publish' input option).                            | all                               |
-| successfulPublish | Boolean as a string if we published. Useful to skip follow-on steps with nothing published.             | publish, preview                  |
-| packagesPublished | Comma separated list of all of the packages that published.                                             | publish, preview                  |
-| templatePipe      | A stringified key/value pair object of the `pipe` that is passed to each command.                       | status, version, publish, preview |
-| releaseId         | The ID of the created release. Only present when `createRelease` is set to true.                        | publish                           |
-| releaseUrl        | The URL users can navigate to in order to view the release.                                             | publish                           |
-| releaseUploadUrl  | The URL for uploading assets to the release, which could be used by GitHub Actions for additional uses. | publish                           |
+| output                   | description                                                                                             | command                           |
+| ------------------------ | ------------------------------------------------------------------------------------------------------- | --------------------------------- |
+| status                   | Returns either "No changes." or a dyanmic list of packages changed.                                     | status, version, publish          |
+| willPublish              | Will be set as `"true"` (stringified boolean) if the next step is to try publishing.                    | status                            |
+| packagesReady            | Comma separated list of packages with changes: `covector,action`                                        | status                            |
+| packagesReadyPaths       | Command separated list of paths to packages with changes: `./packages/covector,./packages/action`       | status                            |
+| packagesReadySpaced      | Space separated list of packages with changes: `'covector' 'action'`                                    | status                            |
+| packagesReadyPathsSpaced | Space separated list of paths to packages with changes: `'./packages/covector' './packages/action'`     | status                            |
+| change                   | The changes that were applied                                                                           | version, preview                  |
+| commandRan               | The command ran (particularly useful for 'version-or-publish' input option).                            | all                               |
+| successfulPublish        | Boolean as a string if we published. Useful to skip follow-on steps with nothing published.             | publish, preview                  |
+| packagesPublished        | Comma separated list of all of the packages that published.                                             | publish, preview                  |
+| templatePipe             | A stringified key/value pair object of the `pipe` that is passed to each command.                       | status, version, publish, preview |
+| releaseId                | The ID of the created release. Only present when `createRelease` is set to true.                        | publish                           |
+| releaseUrl               | The URL users can navigate to in order to view the release.                                             | publish                           |
+| releaseUploadUrl         | The URL for uploading assets to the release, which could be used by GitHub Actions for additional uses. | publish                           |
 
 Besides these static outputs, we also supply dynamic outputs for each of your packages. Replace the `*` with your package name. Note, this will not be listed in the [action.yml](./action.yml). Outputs can only alphanumeric characters, and are replaced with a dash: `-`. For example, a scoped npm package of `@covector/awesome` would be `willPublish--covector-awesome`.
 

--- a/packages/action/src/index.ts
+++ b/packages/action/src/index.ts
@@ -80,6 +80,7 @@ export function* run(logger: Logger): Generator<any, any, any> {
           filterPackages,
           cwd,
         });
+        console.dir(covectored)
         core.setOutput("status", covectored.response);
         core.setOutput("templatePipe", covectored.pipeTemplate);
 

--- a/packages/action/src/index.ts
+++ b/packages/action/src/index.ts
@@ -80,9 +80,25 @@ export function* run(logger: Logger): Generator<any, any, any> {
           filterPackages,
           cwd,
         });
-        console.dir(covectored)
+        console.dir(covectored, { depth: 7 });
         core.setOutput("status", covectored.response);
         core.setOutput("templatePipe", covectored.pipeTemplate);
+        core.setOutput(
+          "packagesReady",
+          covectored.pkgVersion.map((p) => p.pkg).join(",")
+        );
+        core.setOutput(
+          "packagesReadyPaths",
+          covectored.pkgVersion.map((p) => p.path).join(",")
+        );
+        core.setOutput(
+          "packagesReadySpaced",
+          covectored.pkgVersion.map((p) => `'${p.pkg}'`).join(" ")
+        );
+        core.setOutput(
+          "packagesReadyPathsSpaced",
+          covectored.pkgVersion.map((p) => `'${p.path}'`).join(" ")
+        );
 
         core.setOutput(
           `willPublish`,

--- a/packages/action/src/index.ts
+++ b/packages/action/src/index.ts
@@ -80,25 +80,27 @@ export function* run(logger: Logger): Generator<any, any, any> {
           filterPackages,
           cwd,
         });
-        console.dir(covectored, { depth: 7 });
         core.setOutput("status", covectored.response);
         core.setOutput("templatePipe", covectored.pipeTemplate);
-        core.setOutput(
-          "packagesReady",
-          covectored.pkgVersion.map((p) => p.pkg).join(",")
-        );
-        core.setOutput(
-          "packagesReadyPaths",
-          covectored.pkgVersion.map((p) => p.path).join(",")
-        );
-        core.setOutput(
-          "packagesReadySpaced",
-          covectored.pkgVersion.map((p) => `'${p.pkg}'`).join(" ")
-        );
-        core.setOutput(
-          "packagesReadyPathsSpaced",
-          covectored.pkgVersion.map((p) => `'${p.path}'`).join(" ")
-        );
+        // as TS isn't helping to know if this will actually be defined...
+        if (covectored?.pkgVersion) {
+          core.setOutput(
+            "packagesReady",
+            covectored.pkgVersion.map((p) => p.pkg).join(",")
+          );
+          core.setOutput(
+            "packagesReadyPaths",
+            covectored.pkgVersion.map((p) => p.path).join(",")
+          );
+          core.setOutput(
+            "packagesReadySpaced",
+            covectored.pkgVersion.map((p) => `'${p.pkg}'`).join(" ")
+          );
+          core.setOutput(
+            "packagesReadyPathsSpaced",
+            covectored.pkgVersion.map((p) => `'${p.path}'`).join(" ")
+          );
+        }
 
         core.setOutput(
           `willPublish`,

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -290,6 +290,7 @@ export type CovectorStatus =
       response: string;
       pipeTemplate?: object;
       config: Config;
+      pkgVersion: PkgVersion[];
       pkgReadyToPublish: PkgPublish[];
     }
   | {


### PR DESCRIPTION
## Motivation

Adding a few more outputs from the `status` command for use cases which want to work off the derived state.

## Approach

Using the existing returns to pipe some more information into outputs. The types aren't terribly helpful at the moment, so including some guards as well.
