### PR TITLE
bump fixture babel version so dependabot goes away

### DIFF
--- a/__fixtures__/integration.js-and-rust-with-changes/cli/tauri.js/package.json
+++ b/__fixtures__/integration.js-and-rust-with-changes/cli/tauri.js/package.json
@@ -58,9 +58,9 @@
     "webpack-shell-plugin": "0.5.0"
   },
   "devDependencies": {
-    "@babel/core": "7.10.2",
-    "@babel/preset-env": "7.10.2",
-    "@babel/preset-typescript": "7.10.1",
+    "@babel/core": "7.29.6",
+    "@babel/preset-env": "7.29.6",
+    "@babel/preset-typescript": "7.29.6",
     "@types/cross-spawn": "6.0.2",
     "@types/fs-extra": "9.0.1",
     "@types/http-proxy": "1.17.4",
@@ -73,7 +73,7 @@
     "@types/webpack-merge": "4.1.5",
     "@typescript-eslint/eslint-plugin": "3.1.0",
     "@typescript-eslint/parser": "3.1.0",
-    "babel-jest": "26.0.1",
+    "babel-jest": "26.6.3",
     "dotenv": "8.2.0",
     "eslint": "7.1.0",
     "eslint-config-standard-with-typescript": "18.0.2",

--- a/packages/covector/test/integration/__snapshots__/dry-run.test.ts.snap
+++ b/packages/covector/test/integration/__snapshots__/dry-run.test.ts.snap
@@ -9,19 +9,19 @@ exports[`integration test in --dry-run mode > passes correct config for js and r
         "@babel/core": [
           {
             "type": "devDependencies",
-            "version": "7.10.2",
+            "version": "7.29.6",
           },
         ],
         "@babel/preset-env": [
           {
             "type": "devDependencies",
-            "version": "7.10.2",
+            "version": "7.29.6",
           },
         ],
         "@babel/preset-typescript": [
           {
             "type": "devDependencies",
-            "version": "7.10.1",
+            "version": "7.29.6",
           },
         ],
         "@tauri-apps/tauri-inliner": [
@@ -111,7 +111,7 @@ exports[`integration test in --dry-run mode > passes correct config for js and r
         "babel-jest": [
           {
             "type": "devDependencies",
-            "version": "26.0.1",
+            "version": "26.6.3",
           },
         ],
         "chalk": [
@@ -434,9 +434,9 @@ exports[`integration test in --dry-run mode > passes correct config for js and r
     "webpack-shell-plugin": "0.5.0"
   },
   "devDependencies": {
-    "@babel/core": "7.10.2",
-    "@babel/preset-env": "7.10.2",
-    "@babel/preset-typescript": "7.10.1",
+    "@babel/core": "7.29.6",
+    "@babel/preset-env": "7.29.6",
+    "@babel/preset-typescript": "7.29.6",
     "@types/cross-spawn": "6.0.2",
     "@types/fs-extra": "9.0.1",
     "@types/http-proxy": "1.17.4",
@@ -449,7 +449,7 @@ exports[`integration test in --dry-run mode > passes correct config for js and r
     "@types/webpack-merge": "4.1.5",
     "@typescript-eslint/eslint-plugin": "3.1.0",
     "@typescript-eslint/parser": "3.1.0",
-    "babel-jest": "26.0.1",
+    "babel-jest": "26.6.3",
     "dotenv": "8.2.0",
     "eslint": "7.1.0",
     "eslint-config-standard-with-typescript": "18.0.2",
@@ -525,9 +525,9 @@ exports[`integration test in --dry-run mode > passes correct config for js and r
         },
         "description": "Multi-binding collection of libraries and templates for building Tauri apps",
         "devDependencies": {
-          "@babel/core": "7.10.2",
-          "@babel/preset-env": "7.10.2",
-          "@babel/preset-typescript": "7.10.1",
+          "@babel/core": "7.29.6",
+          "@babel/preset-env": "7.29.6",
+          "@babel/preset-typescript": "7.29.6",
           "@types/cross-spawn": "6.0.2",
           "@types/fs-extra": "9.0.1",
           "@types/http-proxy": "1.17.4",
@@ -540,7 +540,7 @@ exports[`integration test in --dry-run mode > passes correct config for js and r
           "@types/webpack-merge": "4.1.5",
           "@typescript-eslint/eslint-plugin": "3.1.0",
           "@typescript-eslint/parser": "3.1.0",
-          "babel-jest": "26.0.1",
+          "babel-jest": "26.6.3",
           "dotenv": "8.2.0",
           "eslint": "7.1.0",
           "eslint-config-standard-with-typescript": "18.0.2",
@@ -1067,19 +1067,19 @@ Summary about the changes in tauri
               "@babel/core": [
                 {
                   "type": "devDependencies",
-                  "version": "7.10.2",
+                  "version": "7.29.6",
                 },
               ],
               "@babel/preset-env": [
                 {
                   "type": "devDependencies",
-                  "version": "7.10.2",
+                  "version": "7.29.6",
                 },
               ],
               "@babel/preset-typescript": [
                 {
                   "type": "devDependencies",
-                  "version": "7.10.1",
+                  "version": "7.29.6",
                 },
               ],
               "@tauri-apps/tauri-inliner": [
@@ -1169,7 +1169,7 @@ Summary about the changes in tauri
               "babel-jest": [
                 {
                   "type": "devDependencies",
-                  "version": "26.0.1",
+                  "version": "26.6.3",
                 },
               ],
               "chalk": [
@@ -1526,19 +1526,19 @@ Summary about the changes in tauri-updater
           "@babel/core": [
             {
               "type": "devDependencies",
-              "version": "7.10.2",
+              "version": "7.29.6",
             },
           ],
           "@babel/preset-env": [
             {
               "type": "devDependencies",
-              "version": "7.10.2",
+              "version": "7.29.6",
             },
           ],
           "@babel/preset-typescript": [
             {
               "type": "devDependencies",
-              "version": "7.10.1",
+              "version": "7.29.6",
             },
           ],
           "@tauri-apps/tauri-inliner": [
@@ -1628,7 +1628,7 @@ Summary about the changes in tauri-updater
           "babel-jest": [
             {
               "type": "devDependencies",
-              "version": "26.0.1",
+              "version": "26.6.3",
             },
           ],
           "chalk": [
@@ -3390,19 +3390,19 @@ thiserror = "1.0.19"",
             "@babel/core": [
               {
                 "type": "devDependencies",
-                "version": "7.10.2",
+                "version": "7.29.6",
               },
             ],
             "@babel/preset-env": [
               {
                 "type": "devDependencies",
-                "version": "7.10.2",
+                "version": "7.29.6",
               },
             ],
             "@babel/preset-typescript": [
               {
                 "type": "devDependencies",
-                "version": "7.10.1",
+                "version": "7.29.6",
               },
             ],
             "@tauri-apps/tauri-inliner": [
@@ -3492,7 +3492,7 @@ thiserror = "1.0.19"",
             "babel-jest": [
               {
                 "type": "devDependencies",
-                "version": "26.0.1",
+                "version": "26.6.3",
               },
             ],
             "chalk": [
@@ -3815,9 +3815,9 @@ thiserror = "1.0.19"",
     "webpack-shell-plugin": "0.5.0"
   },
   "devDependencies": {
-    "@babel/core": "7.10.2",
-    "@babel/preset-env": "7.10.2",
-    "@babel/preset-typescript": "7.10.1",
+    "@babel/core": "7.29.6",
+    "@babel/preset-env": "7.29.6",
+    "@babel/preset-typescript": "7.29.6",
     "@types/cross-spawn": "6.0.2",
     "@types/fs-extra": "9.0.1",
     "@types/http-proxy": "1.17.4",
@@ -3830,7 +3830,7 @@ thiserror = "1.0.19"",
     "@types/webpack-merge": "4.1.5",
     "@typescript-eslint/eslint-plugin": "3.1.0",
     "@typescript-eslint/parser": "3.1.0",
-    "babel-jest": "26.0.1",
+    "babel-jest": "26.6.3",
     "dotenv": "8.2.0",
     "eslint": "7.1.0",
     "eslint-config-standard-with-typescript": "18.0.2",
@@ -3906,9 +3906,9 @@ thiserror = "1.0.19"",
             },
             "description": "Multi-binding collection of libraries and templates for building Tauri apps",
             "devDependencies": {
-              "@babel/core": "7.10.2",
-              "@babel/preset-env": "7.10.2",
-              "@babel/preset-typescript": "7.10.1",
+              "@babel/core": "7.29.6",
+              "@babel/preset-env": "7.29.6",
+              "@babel/preset-typescript": "7.29.6",
               "@types/cross-spawn": "6.0.2",
               "@types/fs-extra": "9.0.1",
               "@types/http-proxy": "1.17.4",
@@ -3921,7 +3921,7 @@ thiserror = "1.0.19"",
               "@types/webpack-merge": "4.1.5",
               "@typescript-eslint/eslint-plugin": "3.1.0",
               "@typescript-eslint/parser": "3.1.0",
-              "babel-jest": "26.0.1",
+              "babel-jest": "26.6.3",
               "dotenv": "8.2.0",
               "eslint": "7.1.0",
               "eslint-config-standard-with-typescript": "18.0.2",
@@ -4579,19 +4579,19 @@ thiserror = "1.0.19"",
             "@babel/core": [
               {
                 "type": "devDependencies",
-                "version": "7.10.2",
+                "version": "7.29.6",
               },
             ],
             "@babel/preset-env": [
               {
                 "type": "devDependencies",
-                "version": "7.10.2",
+                "version": "7.29.6",
               },
             ],
             "@babel/preset-typescript": [
               {
                 "type": "devDependencies",
-                "version": "7.10.1",
+                "version": "7.29.6",
               },
             ],
             "@tauri-apps/tauri-inliner": [
@@ -4681,7 +4681,7 @@ thiserror = "1.0.19"",
             "babel-jest": [
               {
                 "type": "devDependencies",
-                "version": "26.0.1",
+                "version": "26.6.3",
               },
             ],
             "chalk": [
@@ -4981,9 +4981,9 @@ thiserror = "1.0.19"",
             },
             "description": "Multi-binding collection of libraries and templates for building Tauri apps",
             "devDependencies": {
-              "@babel/core": "7.10.2",
-              "@babel/preset-env": "7.10.2",
-              "@babel/preset-typescript": "7.10.1",
+              "@babel/core": "7.29.6",
+              "@babel/preset-env": "7.29.6",
+              "@babel/preset-typescript": "7.29.6",
               "@types/cross-spawn": "6.0.2",
               "@types/fs-extra": "9.0.1",
               "@types/http-proxy": "1.17.4",
@@ -4996,7 +4996,7 @@ thiserror = "1.0.19"",
               "@types/webpack-merge": "4.1.5",
               "@typescript-eslint/eslint-plugin": "3.1.0",
               "@typescript-eslint/parser": "3.1.0",
-              "babel-jest": "26.0.1",
+              "babel-jest": "26.6.3",
               "dotenv": "8.2.0",
               "eslint": "7.1.0",
               "eslint-config-standard-with-typescript": "18.0.2",
@@ -5405,19 +5405,19 @@ thiserror = "1.0.19"
           "@babel/core": [
             {
               "type": "devDependencies",
-              "version": "7.10.2",
+              "version": "7.29.6",
             },
           ],
           "@babel/preset-env": [
             {
               "type": "devDependencies",
-              "version": "7.10.2",
+              "version": "7.29.6",
             },
           ],
           "@babel/preset-typescript": [
             {
               "type": "devDependencies",
-              "version": "7.10.1",
+              "version": "7.29.6",
             },
           ],
           "@tauri-apps/tauri-inliner": [
@@ -5507,7 +5507,7 @@ thiserror = "1.0.19"
           "babel-jest": [
             {
               "type": "devDependencies",
-              "version": "26.0.1",
+              "version": "26.6.3",
             },
           ],
           "chalk": [
@@ -5830,9 +5830,9 @@ thiserror = "1.0.19"
     "webpack-shell-plugin": "0.5.0"
   },
   "devDependencies": {
-    "@babel/core": "7.10.2",
-    "@babel/preset-env": "7.10.2",
-    "@babel/preset-typescript": "7.10.1",
+    "@babel/core": "7.29.6",
+    "@babel/preset-env": "7.29.6",
+    "@babel/preset-typescript": "7.29.6",
     "@types/cross-spawn": "6.0.2",
     "@types/fs-extra": "9.0.1",
     "@types/http-proxy": "1.17.4",
@@ -5845,7 +5845,7 @@ thiserror = "1.0.19"
     "@types/webpack-merge": "4.1.5",
     "@typescript-eslint/eslint-plugin": "3.1.0",
     "@typescript-eslint/parser": "3.1.0",
-    "babel-jest": "26.0.1",
+    "babel-jest": "26.6.3",
     "dotenv": "8.2.0",
     "eslint": "7.1.0",
     "eslint-config-standard-with-typescript": "18.0.2",
@@ -5921,9 +5921,9 @@ thiserror = "1.0.19"
           },
           "description": "Multi-binding collection of libraries and templates for building Tauri apps",
           "devDependencies": {
-            "@babel/core": "7.10.2",
-            "@babel/preset-env": "7.10.2",
-            "@babel/preset-typescript": "7.10.1",
+            "@babel/core": "7.29.6",
+            "@babel/preset-env": "7.29.6",
+            "@babel/preset-typescript": "7.29.6",
             "@types/cross-spawn": "6.0.2",
             "@types/fs-extra": "9.0.1",
             "@types/http-proxy": "1.17.4",
@@ -5936,7 +5936,7 @@ thiserror = "1.0.19"
             "@types/webpack-merge": "4.1.5",
             "@typescript-eslint/eslint-plugin": "3.1.0",
             "@typescript-eslint/parser": "3.1.0",
-            "babel-jest": "26.0.1",
+            "babel-jest": "26.6.3",
             "dotenv": "8.2.0",
             "eslint": "7.1.0",
             "eslint-config-standard-with-typescript": "18.0.2",
@@ -6050,19 +6050,19 @@ Summary about the changes in tauri
               "@babel/core": [
                 {
                   "type": "devDependencies",
-                  "version": "7.10.2",
+                  "version": "7.29.6",
                 },
               ],
               "@babel/preset-env": [
                 {
                   "type": "devDependencies",
-                  "version": "7.10.2",
+                  "version": "7.29.6",
                 },
               ],
               "@babel/preset-typescript": [
                 {
                   "type": "devDependencies",
-                  "version": "7.10.1",
+                  "version": "7.29.6",
                 },
               ],
               "@tauri-apps/tauri-inliner": [
@@ -6152,7 +6152,7 @@ Summary about the changes in tauri
               "babel-jest": [
                 {
                   "type": "devDependencies",
-                  "version": "26.0.1",
+                  "version": "26.6.3",
                 },
               ],
               "chalk": [

--- a/packages/covector/test/integration/__snapshots__/main.test.ts.snap
+++ b/packages/covector/test/integration/__snapshots__/main.test.ts.snap
@@ -808,19 +808,19 @@ thiserror = "1.0.19"",
             "@babel/core": [
               {
                 "type": "devDependencies",
-                "version": "7.10.2",
+                "version": "7.29.6",
               },
             ],
             "@babel/preset-env": [
               {
                 "type": "devDependencies",
-                "version": "7.10.2",
+                "version": "7.29.6",
               },
             ],
             "@babel/preset-typescript": [
               {
                 "type": "devDependencies",
-                "version": "7.10.1",
+                "version": "7.29.6",
               },
             ],
             "@tauri-apps/tauri-inliner": [
@@ -910,7 +910,7 @@ thiserror = "1.0.19"",
             "babel-jest": [
               {
                 "type": "devDependencies",
-                "version": "26.0.1",
+                "version": "26.6.3",
               },
             ],
             "chalk": [
@@ -1233,9 +1233,9 @@ thiserror = "1.0.19"",
     "webpack-shell-plugin": "0.5.0"
   },
   "devDependencies": {
-    "@babel/core": "7.10.2",
-    "@babel/preset-env": "7.10.2",
-    "@babel/preset-typescript": "7.10.1",
+    "@babel/core": "7.29.6",
+    "@babel/preset-env": "7.29.6",
+    "@babel/preset-typescript": "7.29.6",
     "@types/cross-spawn": "6.0.2",
     "@types/fs-extra": "9.0.1",
     "@types/http-proxy": "1.17.4",
@@ -1248,7 +1248,7 @@ thiserror = "1.0.19"",
     "@types/webpack-merge": "4.1.5",
     "@typescript-eslint/eslint-plugin": "3.1.0",
     "@typescript-eslint/parser": "3.1.0",
-    "babel-jest": "26.0.1",
+    "babel-jest": "26.6.3",
     "dotenv": "8.2.0",
     "eslint": "7.1.0",
     "eslint-config-standard-with-typescript": "18.0.2",
@@ -1324,9 +1324,9 @@ thiserror = "1.0.19"",
             },
             "description": "Multi-binding collection of libraries and templates for building Tauri apps",
             "devDependencies": {
-              "@babel/core": "7.10.2",
-              "@babel/preset-env": "7.10.2",
-              "@babel/preset-typescript": "7.10.1",
+              "@babel/core": "7.29.6",
+              "@babel/preset-env": "7.29.6",
+              "@babel/preset-typescript": "7.29.6",
               "@types/cross-spawn": "6.0.2",
               "@types/fs-extra": "9.0.1",
               "@types/http-proxy": "1.17.4",
@@ -1339,7 +1339,7 @@ thiserror = "1.0.19"",
               "@types/webpack-merge": "4.1.5",
               "@typescript-eslint/eslint-plugin": "3.1.0",
               "@typescript-eslint/parser": "3.1.0",
-              "babel-jest": "26.0.1",
+              "babel-jest": "26.6.3",
               "dotenv": "8.2.0",
               "eslint": "7.1.0",
               "eslint-config-standard-with-typescript": "18.0.2",
@@ -2012,19 +2012,19 @@ thiserror = "1.0.19"",
             "@babel/core": [
               {
                 "type": "devDependencies",
-                "version": "7.10.2",
+                "version": "7.29.6",
               },
             ],
             "@babel/preset-env": [
               {
                 "type": "devDependencies",
-                "version": "7.10.2",
+                "version": "7.29.6",
               },
             ],
             "@babel/preset-typescript": [
               {
                 "type": "devDependencies",
-                "version": "7.10.1",
+                "version": "7.29.6",
               },
             ],
             "@tauri-apps/tauri-inliner": [
@@ -2114,7 +2114,7 @@ thiserror = "1.0.19"",
             "babel-jest": [
               {
                 "type": "devDependencies",
-                "version": "26.0.1",
+                "version": "26.6.3",
               },
             ],
             "chalk": [
@@ -2414,9 +2414,9 @@ thiserror = "1.0.19"",
             },
             "description": "Multi-binding collection of libraries and templates for building Tauri apps",
             "devDependencies": {
-              "@babel/core": "7.10.2",
-              "@babel/preset-env": "7.10.2",
-              "@babel/preset-typescript": "7.10.1",
+              "@babel/core": "7.29.6",
+              "@babel/preset-env": "7.29.6",
+              "@babel/preset-typescript": "7.29.6",
               "@types/cross-spawn": "6.0.2",
               "@types/fs-extra": "9.0.1",
               "@types/http-proxy": "1.17.4",
@@ -2429,7 +2429,7 @@ thiserror = "1.0.19"",
               "@types/webpack-merge": "4.1.5",
               "@typescript-eslint/eslint-plugin": "3.1.0",
               "@typescript-eslint/parser": "3.1.0",
-              "babel-jest": "26.0.1",
+              "babel-jest": "26.6.3",
               "dotenv": "8.2.0",
               "eslint": "7.1.0",
               "eslint-config-standard-with-typescript": "18.0.2",
@@ -2506,19 +2506,19 @@ exports[`integration test in production mode > handles config > passes correct c
         "@babel/core": [
           {
             "type": "devDependencies",
-            "version": "7.10.2",
+            "version": "7.29.6",
           },
         ],
         "@babel/preset-env": [
           {
             "type": "devDependencies",
-            "version": "7.10.2",
+            "version": "7.29.6",
           },
         ],
         "@babel/preset-typescript": [
           {
             "type": "devDependencies",
-            "version": "7.10.1",
+            "version": "7.29.6",
           },
         ],
         "@tauri-apps/tauri-inliner": [
@@ -2608,7 +2608,7 @@ exports[`integration test in production mode > handles config > passes correct c
         "babel-jest": [
           {
             "type": "devDependencies",
-            "version": "26.0.1",
+            "version": "26.6.3",
           },
         ],
         "chalk": [
@@ -2931,9 +2931,9 @@ exports[`integration test in production mode > handles config > passes correct c
     "webpack-shell-plugin": "0.5.0"
   },
   "devDependencies": {
-    "@babel/core": "7.10.2",
-    "@babel/preset-env": "7.10.2",
-    "@babel/preset-typescript": "7.10.1",
+    "@babel/core": "7.29.6",
+    "@babel/preset-env": "7.29.6",
+    "@babel/preset-typescript": "7.29.6",
     "@types/cross-spawn": "6.0.2",
     "@types/fs-extra": "9.0.1",
     "@types/http-proxy": "1.17.4",
@@ -2946,7 +2946,7 @@ exports[`integration test in production mode > handles config > passes correct c
     "@types/webpack-merge": "4.1.5",
     "@typescript-eslint/eslint-plugin": "3.1.0",
     "@typescript-eslint/parser": "3.1.0",
-    "babel-jest": "26.0.1",
+    "babel-jest": "26.6.3",
     "dotenv": "8.2.0",
     "eslint": "7.1.0",
     "eslint-config-standard-with-typescript": "18.0.2",
@@ -3022,9 +3022,9 @@ exports[`integration test in production mode > handles config > passes correct c
         },
         "description": "Multi-binding collection of libraries and templates for building Tauri apps",
         "devDependencies": {
-          "@babel/core": "7.10.2",
-          "@babel/preset-env": "7.10.2",
-          "@babel/preset-typescript": "7.10.1",
+          "@babel/core": "7.29.6",
+          "@babel/preset-env": "7.29.6",
+          "@babel/preset-typescript": "7.29.6",
           "@types/cross-spawn": "6.0.2",
           "@types/fs-extra": "9.0.1",
           "@types/http-proxy": "1.17.4",
@@ -3037,7 +3037,7 @@ exports[`integration test in production mode > handles config > passes correct c
           "@types/webpack-merge": "4.1.5",
           "@typescript-eslint/eslint-plugin": "3.1.0",
           "@typescript-eslint/parser": "3.1.0",
-          "babel-jest": "26.0.1",
+          "babel-jest": "26.6.3",
           "dotenv": "8.2.0",
           "eslint": "7.1.0",
           "eslint-config-standard-with-typescript": "18.0.2",
@@ -3564,19 +3564,19 @@ Summary about the changes in tauri
               "@babel/core": [
                 {
                   "type": "devDependencies",
-                  "version": "7.10.2",
+                  "version": "7.29.6",
                 },
               ],
               "@babel/preset-env": [
                 {
                   "type": "devDependencies",
-                  "version": "7.10.2",
+                  "version": "7.29.6",
                 },
               ],
               "@babel/preset-typescript": [
                 {
                   "type": "devDependencies",
-                  "version": "7.10.1",
+                  "version": "7.29.6",
                 },
               ],
               "@tauri-apps/tauri-inliner": [
@@ -3666,7 +3666,7 @@ Summary about the changes in tauri
               "babel-jest": [
                 {
                   "type": "devDependencies",
-                  "version": "26.0.1",
+                  "version": "26.6.3",
                 },
               ],
               "chalk": [
@@ -4023,19 +4023,19 @@ Summary about the changes in tauri-updater
           "@babel/core": [
             {
               "type": "devDependencies",
-              "version": "7.10.2",
+              "version": "7.29.6",
             },
           ],
           "@babel/preset-env": [
             {
               "type": "devDependencies",
-              "version": "7.10.2",
+              "version": "7.29.6",
             },
           ],
           "@babel/preset-typescript": [
             {
               "type": "devDependencies",
-              "version": "7.10.1",
+              "version": "7.29.6",
             },
           ],
           "@tauri-apps/tauri-inliner": [
@@ -4125,7 +4125,7 @@ Summary about the changes in tauri-updater
           "babel-jest": [
             {
               "type": "devDependencies",
-              "version": "26.0.1",
+              "version": "26.6.3",
             },
           ],
           "chalk": [
@@ -5238,19 +5238,19 @@ thiserror = "1.0.19"",
             "@babel/core": [
               {
                 "type": "devDependencies",
-                "version": "7.10.2",
+                "version": "7.29.6",
               },
             ],
             "@babel/preset-env": [
               {
                 "type": "devDependencies",
-                "version": "7.10.2",
+                "version": "7.29.6",
               },
             ],
             "@babel/preset-typescript": [
               {
                 "type": "devDependencies",
-                "version": "7.10.1",
+                "version": "7.29.6",
               },
             ],
             "@tauri-apps/tauri-inliner": [
@@ -5340,7 +5340,7 @@ thiserror = "1.0.19"",
             "babel-jest": [
               {
                 "type": "devDependencies",
-                "version": "26.0.1",
+                "version": "26.6.3",
               },
             ],
             "chalk": [
@@ -5663,9 +5663,9 @@ thiserror = "1.0.19"",
     "webpack-shell-plugin": "0.5.0"
   },
   "devDependencies": {
-    "@babel/core": "7.10.2",
-    "@babel/preset-env": "7.10.2",
-    "@babel/preset-typescript": "7.10.1",
+    "@babel/core": "7.29.6",
+    "@babel/preset-env": "7.29.6",
+    "@babel/preset-typescript": "7.29.6",
     "@types/cross-spawn": "6.0.2",
     "@types/fs-extra": "9.0.1",
     "@types/http-proxy": "1.17.4",
@@ -5678,7 +5678,7 @@ thiserror = "1.0.19"",
     "@types/webpack-merge": "4.1.5",
     "@typescript-eslint/eslint-plugin": "3.1.0",
     "@typescript-eslint/parser": "3.1.0",
-    "babel-jest": "26.0.1",
+    "babel-jest": "26.6.3",
     "dotenv": "8.2.0",
     "eslint": "7.1.0",
     "eslint-config-standard-with-typescript": "18.0.2",
@@ -5754,9 +5754,9 @@ thiserror = "1.0.19"",
             },
             "description": "Multi-binding collection of libraries and templates for building Tauri apps",
             "devDependencies": {
-              "@babel/core": "7.10.2",
-              "@babel/preset-env": "7.10.2",
-              "@babel/preset-typescript": "7.10.1",
+              "@babel/core": "7.29.6",
+              "@babel/preset-env": "7.29.6",
+              "@babel/preset-typescript": "7.29.6",
               "@types/cross-spawn": "6.0.2",
               "@types/fs-extra": "9.0.1",
               "@types/http-proxy": "1.17.4",
@@ -5769,7 +5769,7 @@ thiserror = "1.0.19"",
               "@types/webpack-merge": "4.1.5",
               "@typescript-eslint/eslint-plugin": "3.1.0",
               "@typescript-eslint/parser": "3.1.0",
-              "babel-jest": "26.0.1",
+              "babel-jest": "26.6.3",
               "dotenv": "8.2.0",
               "eslint": "7.1.0",
               "eslint-config-standard-with-typescript": "18.0.2",
@@ -6439,19 +6439,19 @@ thiserror = "1.0.19"",
             "@babel/core": [
               {
                 "type": "devDependencies",
-                "version": "7.10.2",
+                "version": "7.29.6",
               },
             ],
             "@babel/preset-env": [
               {
                 "type": "devDependencies",
-                "version": "7.10.2",
+                "version": "7.29.6",
               },
             ],
             "@babel/preset-typescript": [
               {
                 "type": "devDependencies",
-                "version": "7.10.1",
+                "version": "7.29.6",
               },
             ],
             "@tauri-apps/tauri-inliner": [
@@ -6541,7 +6541,7 @@ thiserror = "1.0.19"",
             "babel-jest": [
               {
                 "type": "devDependencies",
-                "version": "26.0.1",
+                "version": "26.6.3",
               },
             ],
             "chalk": [
@@ -6841,9 +6841,9 @@ thiserror = "1.0.19"",
             },
             "description": "Multi-binding collection of libraries and templates for building Tauri apps",
             "devDependencies": {
-              "@babel/core": "7.10.2",
-              "@babel/preset-env": "7.10.2",
-              "@babel/preset-typescript": "7.10.1",
+              "@babel/core": "7.29.6",
+              "@babel/preset-env": "7.29.6",
+              "@babel/preset-typescript": "7.29.6",
               "@types/cross-spawn": "6.0.2",
               "@types/fs-extra": "9.0.1",
               "@types/http-proxy": "1.17.4",
@@ -6856,7 +6856,7 @@ thiserror = "1.0.19"",
               "@types/webpack-merge": "4.1.5",
               "@typescript-eslint/eslint-plugin": "3.1.0",
               "@typescript-eslint/parser": "3.1.0",
-              "babel-jest": "26.0.1",
+              "babel-jest": "26.6.3",
               "dotenv": "8.2.0",
               "eslint": "7.1.0",
               "eslint-config-standard-with-typescript": "18.0.2",
@@ -8011,19 +8011,19 @@ thiserror = "1.0.19"",
             "@babel/core": [
               {
                 "type": "devDependencies",
-                "version": "7.10.2",
+                "version": "7.29.6",
               },
             ],
             "@babel/preset-env": [
               {
                 "type": "devDependencies",
-                "version": "7.10.2",
+                "version": "7.29.6",
               },
             ],
             "@babel/preset-typescript": [
               {
                 "type": "devDependencies",
-                "version": "7.10.1",
+                "version": "7.29.6",
               },
             ],
             "@tauri-apps/tauri-inliner": [
@@ -8113,7 +8113,7 @@ thiserror = "1.0.19"",
             "babel-jest": [
               {
                 "type": "devDependencies",
-                "version": "26.0.1",
+                "version": "26.6.3",
               },
             ],
             "chalk": [
@@ -8436,9 +8436,9 @@ thiserror = "1.0.19"",
     "webpack-shell-plugin": "0.5.0"
   },
   "devDependencies": {
-    "@babel/core": "7.10.2",
-    "@babel/preset-env": "7.10.2",
-    "@babel/preset-typescript": "7.10.1",
+    "@babel/core": "7.29.6",
+    "@babel/preset-env": "7.29.6",
+    "@babel/preset-typescript": "7.29.6",
     "@types/cross-spawn": "6.0.2",
     "@types/fs-extra": "9.0.1",
     "@types/http-proxy": "1.17.4",
@@ -8451,7 +8451,7 @@ thiserror = "1.0.19"",
     "@types/webpack-merge": "4.1.5",
     "@typescript-eslint/eslint-plugin": "3.1.0",
     "@typescript-eslint/parser": "3.1.0",
-    "babel-jest": "26.0.1",
+    "babel-jest": "26.6.3",
     "dotenv": "8.2.0",
     "eslint": "7.1.0",
     "eslint-config-standard-with-typescript": "18.0.2",
@@ -8527,9 +8527,9 @@ thiserror = "1.0.19"",
             },
             "description": "Multi-binding collection of libraries and templates for building Tauri apps",
             "devDependencies": {
-              "@babel/core": "7.10.2",
-              "@babel/preset-env": "7.10.2",
-              "@babel/preset-typescript": "7.10.1",
+              "@babel/core": "7.29.6",
+              "@babel/preset-env": "7.29.6",
+              "@babel/preset-typescript": "7.29.6",
               "@types/cross-spawn": "6.0.2",
               "@types/fs-extra": "9.0.1",
               "@types/http-proxy": "1.17.4",
@@ -8542,7 +8542,7 @@ thiserror = "1.0.19"",
               "@types/webpack-merge": "4.1.5",
               "@typescript-eslint/eslint-plugin": "3.1.0",
               "@typescript-eslint/parser": "3.1.0",
-              "babel-jest": "26.0.1",
+              "babel-jest": "26.6.3",
               "dotenv": "8.2.0",
               "eslint": "7.1.0",
               "eslint-config-standard-with-typescript": "18.0.2",
@@ -9200,19 +9200,19 @@ thiserror = "1.0.19"",
             "@babel/core": [
               {
                 "type": "devDependencies",
-                "version": "7.10.2",
+                "version": "7.29.6",
               },
             ],
             "@babel/preset-env": [
               {
                 "type": "devDependencies",
-                "version": "7.10.2",
+                "version": "7.29.6",
               },
             ],
             "@babel/preset-typescript": [
               {
                 "type": "devDependencies",
-                "version": "7.10.1",
+                "version": "7.29.6",
               },
             ],
             "@tauri-apps/tauri-inliner": [
@@ -9302,7 +9302,7 @@ thiserror = "1.0.19"",
             "babel-jest": [
               {
                 "type": "devDependencies",
-                "version": "26.0.1",
+                "version": "26.6.3",
               },
             ],
             "chalk": [
@@ -9602,9 +9602,9 @@ thiserror = "1.0.19"",
             },
             "description": "Multi-binding collection of libraries and templates for building Tauri apps",
             "devDependencies": {
-              "@babel/core": "7.10.2",
-              "@babel/preset-env": "7.10.2",
-              "@babel/preset-typescript": "7.10.1",
+              "@babel/core": "7.29.6",
+              "@babel/preset-env": "7.29.6",
+              "@babel/preset-typescript": "7.29.6",
               "@types/cross-spawn": "6.0.2",
               "@types/fs-extra": "9.0.1",
               "@types/http-proxy": "1.17.4",
@@ -9617,7 +9617,7 @@ thiserror = "1.0.19"",
               "@types/webpack-merge": "4.1.5",
               "@typescript-eslint/eslint-plugin": "3.1.0",
               "@typescript-eslint/parser": "3.1.0",
-              "babel-jest": "26.0.1",
+              "babel-jest": "26.6.3",
               "dotenv": "8.2.0",
               "eslint": "7.1.0",
               "eslint-config-standard-with-typescript": "18.0.2",
@@ -11457,19 +11457,19 @@ thiserror = "1.0.19"
           "@babel/core": [
             {
               "type": "devDependencies",
-              "version": "7.10.2",
+              "version": "7.29.6",
             },
           ],
           "@babel/preset-env": [
             {
               "type": "devDependencies",
-              "version": "7.10.2",
+              "version": "7.29.6",
             },
           ],
           "@babel/preset-typescript": [
             {
               "type": "devDependencies",
-              "version": "7.10.1",
+              "version": "7.29.6",
             },
           ],
           "@tauri-apps/tauri-inliner": [
@@ -11559,7 +11559,7 @@ thiserror = "1.0.19"
           "babel-jest": [
             {
               "type": "devDependencies",
-              "version": "26.0.1",
+              "version": "26.6.3",
             },
           ],
           "chalk": [
@@ -11882,9 +11882,9 @@ thiserror = "1.0.19"
     "webpack-shell-plugin": "0.5.0"
   },
   "devDependencies": {
-    "@babel/core": "7.10.2",
-    "@babel/preset-env": "7.10.2",
-    "@babel/preset-typescript": "7.10.1",
+    "@babel/core": "7.29.6",
+    "@babel/preset-env": "7.29.6",
+    "@babel/preset-typescript": "7.29.6",
     "@types/cross-spawn": "6.0.2",
     "@types/fs-extra": "9.0.1",
     "@types/http-proxy": "1.17.4",
@@ -11897,7 +11897,7 @@ thiserror = "1.0.19"
     "@types/webpack-merge": "4.1.5",
     "@typescript-eslint/eslint-plugin": "3.1.0",
     "@typescript-eslint/parser": "3.1.0",
-    "babel-jest": "26.0.1",
+    "babel-jest": "26.6.3",
     "dotenv": "8.2.0",
     "eslint": "7.1.0",
     "eslint-config-standard-with-typescript": "18.0.2",
@@ -11973,9 +11973,9 @@ thiserror = "1.0.19"
           },
           "description": "Multi-binding collection of libraries and templates for building Tauri apps",
           "devDependencies": {
-            "@babel/core": "7.10.2",
-            "@babel/preset-env": "7.10.2",
-            "@babel/preset-typescript": "7.10.1",
+            "@babel/core": "7.29.6",
+            "@babel/preset-env": "7.29.6",
+            "@babel/preset-typescript": "7.29.6",
             "@types/cross-spawn": "6.0.2",
             "@types/fs-extra": "9.0.1",
             "@types/http-proxy": "1.17.4",
@@ -11988,7 +11988,7 @@ thiserror = "1.0.19"
             "@types/webpack-merge": "4.1.5",
             "@typescript-eslint/eslint-plugin": "3.1.0",
             "@typescript-eslint/parser": "3.1.0",
-            "babel-jest": "26.0.1",
+            "babel-jest": "26.6.3",
             "dotenv": "8.2.0",
             "eslint": "7.1.0",
             "eslint-config-standard-with-typescript": "18.0.2",
@@ -12102,19 +12102,19 @@ Summary about the changes in tauri
               "@babel/core": [
                 {
                   "type": "devDependencies",
-                  "version": "7.10.2",
+                  "version": "7.29.6",
                 },
               ],
               "@babel/preset-env": [
                 {
                   "type": "devDependencies",
-                  "version": "7.10.2",
+                  "version": "7.29.6",
                 },
               ],
               "@babel/preset-typescript": [
                 {
                   "type": "devDependencies",
-                  "version": "7.10.1",
+                  "version": "7.29.6",
                 },
               ],
               "@tauri-apps/tauri-inliner": [
@@ -12204,7 +12204,7 @@ Summary about the changes in tauri
               "babel-jest": [
                 {
                   "type": "devDependencies",
-                  "version": "26.0.1",
+                  "version": "26.6.3",
                 },
               ],
               "chalk": [

--- a/packages/covector/test/integration/__snapshots__/preMode.test.ts.snap
+++ b/packages/covector/test/integration/__snapshots__/preMode.test.ts.snap
@@ -341,19 +341,19 @@ thiserror = "1.0.19"
           "@babel/core": [
             {
               "type": "devDependencies",
-              "version": "7.10.2",
+              "version": "7.29.6",
             },
           ],
           "@babel/preset-env": [
             {
               "type": "devDependencies",
-              "version": "7.10.2",
+              "version": "7.29.6",
             },
           ],
           "@babel/preset-typescript": [
             {
               "type": "devDependencies",
-              "version": "7.10.1",
+              "version": "7.29.6",
             },
           ],
           "@tauri-apps/tauri-inliner": [
@@ -443,7 +443,7 @@ thiserror = "1.0.19"
           "babel-jest": [
             {
               "type": "devDependencies",
-              "version": "26.0.1",
+              "version": "26.6.3",
             },
           ],
           "chalk": [
@@ -766,9 +766,9 @@ thiserror = "1.0.19"
     "webpack-shell-plugin": "0.5.0"
   },
   "devDependencies": {
-    "@babel/core": "7.10.2",
-    "@babel/preset-env": "7.10.2",
-    "@babel/preset-typescript": "7.10.1",
+    "@babel/core": "7.29.6",
+    "@babel/preset-env": "7.29.6",
+    "@babel/preset-typescript": "7.29.6",
     "@types/cross-spawn": "6.0.2",
     "@types/fs-extra": "9.0.1",
     "@types/http-proxy": "1.17.4",
@@ -781,7 +781,7 @@ thiserror = "1.0.19"
     "@types/webpack-merge": "4.1.5",
     "@typescript-eslint/eslint-plugin": "3.1.0",
     "@typescript-eslint/parser": "3.1.0",
-    "babel-jest": "26.0.1",
+    "babel-jest": "26.6.3",
     "dotenv": "8.2.0",
     "eslint": "7.1.0",
     "eslint-config-standard-with-typescript": "18.0.2",
@@ -857,9 +857,9 @@ thiserror = "1.0.19"
           },
           "description": "Multi-binding collection of libraries and templates for building Tauri apps",
           "devDependencies": {
-            "@babel/core": "7.10.2",
-            "@babel/preset-env": "7.10.2",
-            "@babel/preset-typescript": "7.10.1",
+            "@babel/core": "7.29.6",
+            "@babel/preset-env": "7.29.6",
+            "@babel/preset-typescript": "7.29.6",
             "@types/cross-spawn": "6.0.2",
             "@types/fs-extra": "9.0.1",
             "@types/http-proxy": "1.17.4",
@@ -872,7 +872,7 @@ thiserror = "1.0.19"
             "@types/webpack-merge": "4.1.5",
             "@typescript-eslint/eslint-plugin": "3.1.0",
             "@typescript-eslint/parser": "3.1.0",
-            "babel-jest": "26.0.1",
+            "babel-jest": "26.6.3",
             "dotenv": "8.2.0",
             "eslint": "7.1.0",
             "eslint-config-standard-with-typescript": "18.0.2",
@@ -989,19 +989,19 @@ Summary about the changes in tauri
               "@babel/core": [
                 {
                   "type": "devDependencies",
-                  "version": "7.10.2",
+                  "version": "7.29.6",
                 },
               ],
               "@babel/preset-env": [
                 {
                   "type": "devDependencies",
-                  "version": "7.10.2",
+                  "version": "7.29.6",
                 },
               ],
               "@babel/preset-typescript": [
                 {
                   "type": "devDependencies",
-                  "version": "7.10.1",
+                  "version": "7.29.6",
                 },
               ],
               "@tauri-apps/tauri-inliner": [
@@ -1091,7 +1091,7 @@ Summary about the changes in tauri
               "babel-jest": [
                 {
                   "type": "devDependencies",
-                  "version": "26.0.1",
+                  "version": "26.6.3",
                 },
               ],
               "chalk": [
@@ -1780,19 +1780,19 @@ thiserror = "1.0.19"
           "@babel/core": [
             {
               "type": "devDependencies",
-              "version": "7.10.2",
+              "version": "7.29.6",
             },
           ],
           "@babel/preset-env": [
             {
               "type": "devDependencies",
-              "version": "7.10.2",
+              "version": "7.29.6",
             },
           ],
           "@babel/preset-typescript": [
             {
               "type": "devDependencies",
-              "version": "7.10.1",
+              "version": "7.29.6",
             },
           ],
           "@tauri-apps/tauri-inliner": [
@@ -1882,7 +1882,7 @@ thiserror = "1.0.19"
           "babel-jest": [
             {
               "type": "devDependencies",
-              "version": "26.0.1",
+              "version": "26.6.3",
             },
           ],
           "chalk": [
@@ -2205,9 +2205,9 @@ thiserror = "1.0.19"
     "webpack-shell-plugin": "0.5.0"
   },
   "devDependencies": {
-    "@babel/core": "7.10.2",
-    "@babel/preset-env": "7.10.2",
-    "@babel/preset-typescript": "7.10.1",
+    "@babel/core": "7.29.6",
+    "@babel/preset-env": "7.29.6",
+    "@babel/preset-typescript": "7.29.6",
     "@types/cross-spawn": "6.0.2",
     "@types/fs-extra": "9.0.1",
     "@types/http-proxy": "1.17.4",
@@ -2220,7 +2220,7 @@ thiserror = "1.0.19"
     "@types/webpack-merge": "4.1.5",
     "@typescript-eslint/eslint-plugin": "3.1.0",
     "@typescript-eslint/parser": "3.1.0",
-    "babel-jest": "26.0.1",
+    "babel-jest": "26.6.3",
     "dotenv": "8.2.0",
     "eslint": "7.1.0",
     "eslint-config-standard-with-typescript": "18.0.2",
@@ -2296,9 +2296,9 @@ thiserror = "1.0.19"
           },
           "description": "Multi-binding collection of libraries and templates for building Tauri apps",
           "devDependencies": {
-            "@babel/core": "7.10.2",
-            "@babel/preset-env": "7.10.2",
-            "@babel/preset-typescript": "7.10.1",
+            "@babel/core": "7.29.6",
+            "@babel/preset-env": "7.29.6",
+            "@babel/preset-typescript": "7.29.6",
             "@types/cross-spawn": "6.0.2",
             "@types/fs-extra": "9.0.1",
             "@types/http-proxy": "1.17.4",
@@ -2311,7 +2311,7 @@ thiserror = "1.0.19"
             "@types/webpack-merge": "4.1.5",
             "@typescript-eslint/eslint-plugin": "3.1.0",
             "@typescript-eslint/parser": "3.1.0",
-            "babel-jest": "26.0.1",
+            "babel-jest": "26.6.3",
             "dotenv": "8.2.0",
             "eslint": "7.1.0",
             "eslint-config-standard-with-typescript": "18.0.2",
@@ -2428,19 +2428,19 @@ Summary about the changes in tauri
               "@babel/core": [
                 {
                   "type": "devDependencies",
-                  "version": "7.10.2",
+                  "version": "7.29.6",
                 },
               ],
               "@babel/preset-env": [
                 {
                   "type": "devDependencies",
-                  "version": "7.10.2",
+                  "version": "7.29.6",
                 },
               ],
               "@babel/preset-typescript": [
                 {
                   "type": "devDependencies",
-                  "version": "7.10.1",
+                  "version": "7.29.6",
                 },
               ],
               "@tauri-apps/tauri-inliner": [
@@ -2530,7 +2530,7 @@ Summary about the changes in tauri
               "babel-jest": [
                 {
                   "type": "devDependencies",
-                  "version": "26.0.1",
+                  "version": "26.6.3",
                 },
               ],
               "chalk": [
@@ -3220,19 +3220,19 @@ thiserror = "1.0.19"
             "@babel/core": [
               {
                 "type": "devDependencies",
-                "version": "7.10.2",
+                "version": "7.29.6",
               },
             ],
             "@babel/preset-env": [
               {
                 "type": "devDependencies",
-                "version": "7.10.2",
+                "version": "7.29.6",
               },
             ],
             "@babel/preset-typescript": [
               {
                 "type": "devDependencies",
-                "version": "7.10.1",
+                "version": "7.29.6",
               },
             ],
             "@tauri-apps/tauri-inliner": [
@@ -3322,7 +3322,7 @@ thiserror = "1.0.19"
             "babel-jest": [
               {
                 "type": "devDependencies",
-                "version": "26.0.1",
+                "version": "26.6.3",
               },
             ],
             "chalk": [
@@ -3645,9 +3645,9 @@ thiserror = "1.0.19"
     "webpack-shell-plugin": "0.5.0"
   },
   "devDependencies": {
-    "@babel/core": "7.10.2",
-    "@babel/preset-env": "7.10.2",
-    "@babel/preset-typescript": "7.10.1",
+    "@babel/core": "7.29.6",
+    "@babel/preset-env": "7.29.6",
+    "@babel/preset-typescript": "7.29.6",
     "@types/cross-spawn": "6.0.2",
     "@types/fs-extra": "9.0.1",
     "@types/http-proxy": "1.17.4",
@@ -3660,7 +3660,7 @@ thiserror = "1.0.19"
     "@types/webpack-merge": "4.1.5",
     "@typescript-eslint/eslint-plugin": "3.1.0",
     "@typescript-eslint/parser": "3.1.0",
-    "babel-jest": "26.0.1",
+    "babel-jest": "26.6.3",
     "dotenv": "8.2.0",
     "eslint": "7.1.0",
     "eslint-config-standard-with-typescript": "18.0.2",
@@ -3736,9 +3736,9 @@ thiserror = "1.0.19"
             },
             "description": "Multi-binding collection of libraries and templates for building Tauri apps",
             "devDependencies": {
-              "@babel/core": "7.10.2",
-              "@babel/preset-env": "7.10.2",
-              "@babel/preset-typescript": "7.10.1",
+              "@babel/core": "7.29.6",
+              "@babel/preset-env": "7.29.6",
+              "@babel/preset-typescript": "7.29.6",
               "@types/cross-spawn": "6.0.2",
               "@types/fs-extra": "9.0.1",
               "@types/http-proxy": "1.17.4",
@@ -3751,7 +3751,7 @@ thiserror = "1.0.19"
               "@types/webpack-merge": "4.1.5",
               "@typescript-eslint/eslint-plugin": "3.1.0",
               "@typescript-eslint/parser": "3.1.0",
-              "babel-jest": "26.0.1",
+              "babel-jest": "26.6.3",
               "dotenv": "8.2.0",
               "eslint": "7.1.0",
               "eslint-config-standard-with-typescript": "18.0.2",
@@ -3868,19 +3868,19 @@ Summary about the changes in tauri
                 "@babel/core": [
                   {
                     "type": "devDependencies",
-                    "version": "7.10.2",
+                    "version": "7.29.6",
                   },
                 ],
                 "@babel/preset-env": [
                   {
                     "type": "devDependencies",
-                    "version": "7.10.2",
+                    "version": "7.29.6",
                   },
                 ],
                 "@babel/preset-typescript": [
                   {
                     "type": "devDependencies",
-                    "version": "7.10.1",
+                    "version": "7.29.6",
                   },
                 ],
                 "@tauri-apps/tauri-inliner": [
@@ -3970,7 +3970,7 @@ Summary about the changes in tauri
                 "babel-jest": [
                   {
                     "type": "devDependencies",
-                    "version": "26.0.1",
+                    "version": "26.6.3",
                   },
                 ],
                 "chalk": [
@@ -4750,19 +4750,19 @@ totems = "0.2.7"",
             "@babel/core": [
               {
                 "type": "devDependencies",
-                "version": "7.10.2",
+                "version": "7.29.6",
               },
             ],
             "@babel/preset-env": [
               {
                 "type": "devDependencies",
-                "version": "7.10.2",
+                "version": "7.29.6",
               },
             ],
             "@babel/preset-typescript": [
               {
                 "type": "devDependencies",
-                "version": "7.10.1",
+                "version": "7.29.6",
               },
             ],
             "@tauri-apps/tauri-inliner": [
@@ -4852,7 +4852,7 @@ totems = "0.2.7"",
             "babel-jest": [
               {
                 "type": "devDependencies",
-                "version": "26.0.1",
+                "version": "26.6.3",
               },
             ],
             "chalk": [
@@ -5175,9 +5175,9 @@ totems = "0.2.7"",
     "webpack-shell-plugin": "0.5.0"
   },
   "devDependencies": {
-    "@babel/core": "7.10.2",
-    "@babel/preset-env": "7.10.2",
-    "@babel/preset-typescript": "7.10.1",
+    "@babel/core": "7.29.6",
+    "@babel/preset-env": "7.29.6",
+    "@babel/preset-typescript": "7.29.6",
     "@types/cross-spawn": "6.0.2",
     "@types/fs-extra": "9.0.1",
     "@types/http-proxy": "1.17.4",
@@ -5190,7 +5190,7 @@ totems = "0.2.7"",
     "@types/webpack-merge": "4.1.5",
     "@typescript-eslint/eslint-plugin": "3.1.0",
     "@typescript-eslint/parser": "3.1.0",
-    "babel-jest": "26.0.1",
+    "babel-jest": "26.6.3",
     "dotenv": "8.2.0",
     "eslint": "7.1.0",
     "eslint-config-standard-with-typescript": "18.0.2",
@@ -5266,9 +5266,9 @@ totems = "0.2.7"",
             },
             "description": "Multi-binding collection of libraries and templates for building Tauri apps",
             "devDependencies": {
-              "@babel/core": "7.10.2",
-              "@babel/preset-env": "7.10.2",
-              "@babel/preset-typescript": "7.10.1",
+              "@babel/core": "7.29.6",
+              "@babel/preset-env": "7.29.6",
+              "@babel/preset-typescript": "7.29.6",
               "@types/cross-spawn": "6.0.2",
               "@types/fs-extra": "9.0.1",
               "@types/http-proxy": "1.17.4",
@@ -5281,7 +5281,7 @@ totems = "0.2.7"",
               "@types/webpack-merge": "4.1.5",
               "@typescript-eslint/eslint-plugin": "3.1.0",
               "@typescript-eslint/parser": "3.1.0",
-              "babel-jest": "26.0.1",
+              "babel-jest": "26.6.3",
               "dotenv": "8.2.0",
               "eslint": "7.1.0",
               "eslint-config-standard-with-typescript": "18.0.2",
@@ -5400,19 +5400,19 @@ totems = "0.2.7"",
                 "@babel/core": [
                   {
                     "type": "devDependencies",
-                    "version": "7.10.2",
+                    "version": "7.29.6",
                   },
                 ],
                 "@babel/preset-env": [
                   {
                     "type": "devDependencies",
-                    "version": "7.10.2",
+                    "version": "7.29.6",
                   },
                 ],
                 "@babel/preset-typescript": [
                   {
                     "type": "devDependencies",
-                    "version": "7.10.1",
+                    "version": "7.29.6",
                   },
                 ],
                 "@tauri-apps/tauri-inliner": [
@@ -5502,7 +5502,7 @@ totems = "0.2.7"",
                 "babel-jest": [
                   {
                     "type": "devDependencies",
-                    "version": "26.0.1",
+                    "version": "26.6.3",
                   },
                 ],
                 "chalk": [


### PR DESCRIPTION
## Motivation

Sick of seeing #390 even though it doesn't matter for this lib.
