### PR TITLE
Support Cargo workspace/path-only dependencies and the pnpm workspace protocol

### DIFF
--- a/.changes/cargo-workspace-and-path-deps.md
+++ b/.changes/cargo-workspace-and-path-deps.md
@@ -1,0 +1,5 @@
+---
+"@covector/files": patch
+---
+
+Handle Cargo dependencies declared with `{ workspace = true }` or as path-only (`{ path = "../pkg" }`): read them as version-less instead of throwing, and leave their declarations untouched when bumping dependent packages.

--- a/.changes/js-workspace-protocol-deps.md
+++ b/.changes/js-workspace-protocol-deps.md
@@ -1,0 +1,5 @@
+---
+"@covector/apply": patch
+---
+
+Leave pnpm/yarn `workspace:*` (and `workspace:^` / `workspace:~`) dependency declarations untouched when bumping dependent packages instead of rewriting them to a bare major version; a declaration with an embedded range like `workspace:^1.2.3` keeps the protocol prefix and bumps the range within it.

--- a/__fixtures__/pkg.js-pnpm-workspace/package.json
+++ b/__fixtures__/pkg.js-pnpm-workspace/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "name": "js-pnpm-workspace",
+  "description": "workspace",
+  "version": "1.0.0"
+}

--- a/__fixtures__/pkg.js-pnpm-workspace/packages/pkg-a/package.json
+++ b/__fixtures__/pkg.js-pnpm-workspace/packages/pkg-a/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "pnpm-workspace-pkg-a",
+  "version": "1.0.0",
+  "dependencies": {
+    "pnpm-workspace-pkg-b": "workspace:*"
+  },
+  "devDependencies": {
+    "pnpm-workspace-pkg-c": "workspace:~"
+  }
+}

--- a/__fixtures__/pkg.js-pnpm-workspace/packages/pkg-b/package.json
+++ b/__fixtures__/pkg.js-pnpm-workspace/packages/pkg-b/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "pnpm-workspace-pkg-b",
+  "version": "1.0.0"
+}

--- a/__fixtures__/pkg.js-pnpm-workspace/packages/pkg-c/package.json
+++ b/__fixtures__/pkg.js-pnpm-workspace/packages/pkg-c/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "pnpm-workspace-pkg-c",
+  "version": "1.0.0",
+  "dependencies": {
+    "pnpm-workspace-pkg-b": "workspace:^1.0.0"
+  }
+}

--- a/__fixtures__/pkg.js-pnpm-workspace/pnpm-workspace.yaml
+++ b/__fixtures__/pkg.js-pnpm-workspace/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - "packages/*"

--- a/__fixtures__/pkg.rust-workspace-deps/Cargo.toml
+++ b/__fixtures__/pkg.rust-workspace-deps/Cargo.toml
@@ -1,0 +1,9 @@
+[workspace]
+members = ["pkg-a", "pkg-b"]
+
+[workspace.package]
+version = "1.0.0"
+
+[workspace.dependencies]
+serde = "1.0"
+rust_workspace_pkg_b_fixture = { path = "pkg-b" }

--- a/__fixtures__/pkg.rust-workspace-deps/pkg-a/Cargo.toml
+++ b/__fixtures__/pkg.rust-workspace-deps/pkg-a/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "rust_workspace_dep_fixture"
+version = "0.5.0"
+
+[dependencies]
+serde = { workspace = true }
+rust_workspace_pkg_b_fixture = { workspace = true }

--- a/__fixtures__/pkg.rust-workspace-deps/pkg-b/Cargo.toml
+++ b/__fixtures__/pkg.rust-workspace-deps/pkg-b/Cargo.toml
@@ -1,0 +1,3 @@
+[package]
+name = "rust_workspace_pkg_b_fixture"
+version = "0.8.0"

--- a/packages/apply/src/apply.ts
+++ b/packages/apply/src/apply.ts
@@ -349,19 +349,37 @@ const getDepBumpVersion = ({
     // if pkg is in dep list
     if (existingDep === depName) {
       const prevVersion = getPreviousVersion();
-      const versionRequirementMatch = /[\^=~]/.exec(prevVersion);
+      // the pnpm/yarn workspace protocol pins `workspace:*` / `workspace:^` /
+      // `workspace:~` deps to whatever version the workspace holds, and the
+      // package manager rewrites them at publish time, so there is no version
+      // in the declaration to bump (aliased deps, `workspace:name@range`, are
+      // also left alone); an embedded range such as `workspace:^1.2.3` keeps
+      // the protocol prefix and bumps the range within it
+      const workspaceProtocol = prevVersion.startsWith("workspace:");
+      const range = workspaceProtocol
+        ? prevVersion.slice("workspace:".length)
+        : prevVersion;
+      if (
+        workspaceProtocol &&
+        (range === "*" || range === "^" || range === "~" || range.includes("@"))
+      ) {
+        return null;
+      }
+
+      const versionRequirementMatch = /[\^=~]/.exec(range);
       const versionRequirement = versionRequirementMatch
         ? versionRequirementMatch[0]
         : "";
 
       const version = deriveVersionConsideringPartials({
         dependency: dep,
-        prevVersion,
+        prevVersion: range,
         versionRequirement,
         previewVersion,
         packageFiles,
       });
-      return version;
+      if (!version) return version;
+      return workspaceProtocol ? `workspace:${version}` : version;
     }
   }
   return null;

--- a/packages/apply/test/apply.test.ts
+++ b/packages/apply/test/apply.test.ts
@@ -205,6 +205,121 @@ describe("package file apply bump (snapshot)", () => {
         ]);
     });
 
+    it("bumps multi with pnpm workspace protocol deps", function* () {
+      const log = yield* logTest.useCapturedLogger();
+      const jsonFolder = f.copy("pkg.js-pnpm-workspace");
+
+      const commands = [
+        {
+          dependencies: ["pnpm-workspace-pkg-b", "pnpm-workspace-pkg-c"],
+          manager: "javascript",
+          path: "./packages/pkg-a/",
+          pkg: "pnpm-workspace-pkg-a",
+          type: "minor",
+          parents: {},
+        },
+        {
+          dependencies: undefined,
+          manager: "javascript",
+          path: "./packages/pkg-b/",
+          pkg: "pnpm-workspace-pkg-b",
+          type: "minor",
+          parents: {},
+        },
+        {
+          dependencies: ["pnpm-workspace-pkg-b"],
+          manager: "javascript",
+          path: "./packages/pkg-c/",
+          pkg: "pnpm-workspace-pkg-c",
+          type: "minor",
+          parents: {},
+        },
+      ];
+
+      const config = {
+        ...configDefaults,
+        packages: {
+          "pnpm-workspace-pkg-a": {
+            path: "./packages/pkg-a/",
+            manager: "javascript",
+            dependencies: ["pnpm-workspace-pkg-b", "pnpm-workspace-pkg-c"],
+          },
+          "pnpm-workspace-pkg-b": {
+            path: "./packages/pkg-b/",
+            manager: "javascript",
+          },
+          "pnpm-workspace-pkg-c": {
+            path: "./packages/pkg-c/",
+            manager: "javascript",
+            dependencies: ["pnpm-workspace-pkg-b"],
+          },
+        },
+      };
+
+      const allPackages = yield* readAllPkgFiles({ config, cwd: jsonFolder });
+
+      yield* apply({
+        logger: logger.operations,
+        //@ts-expect-error
+        commands,
+        config,
+        allPackages,
+        cwd: jsonFolder,
+      });
+
+      // `workspace:*` and `workspace:~` deps resolve to whatever version the
+      // workspace holds and get rewritten by the package manager at publish,
+      // so the declarations survive the bump byte-for-byte
+      const modifiedPkgAFile = yield* loadFile(
+        "packages/pkg-a/package.json",
+        jsonFolder,
+      );
+      expect(modifiedPkgAFile.content).toBe(
+        "{\n" +
+          '  "name": "pnpm-workspace-pkg-a",\n' +
+          '  "version": "1.1.0",\n' +
+          '  "dependencies": {\n' +
+          '    "pnpm-workspace-pkg-b": "workspace:*"\n' +
+          "  },\n" +
+          '  "devDependencies": {\n' +
+          '    "pnpm-workspace-pkg-c": "workspace:~"\n' +
+          "  }\n" +
+          "}\n",
+      );
+
+      // an embedded range keeps the protocol prefix and bumps within it
+      const modifiedPkgCFile = yield* loadFile(
+        "packages/pkg-c/package.json",
+        jsonFolder,
+      );
+      expect(modifiedPkgCFile.content).toBe(
+        "{\n" +
+          '  "name": "pnpm-workspace-pkg-c",\n' +
+          '  "version": "1.1.0",\n' +
+          '  "dependencies": {\n' +
+          '    "pnpm-workspace-pkg-b": "workspace:^1.1.0"\n' +
+          "  }\n" +
+          "}\n",
+      );
+
+      const modifiedPkgBFile = yield* loadFile(
+        "packages/pkg-b/package.json",
+        jsonFolder,
+      );
+      expect(modifiedPkgBFile.content).toBe(
+        "{\n" +
+          '  "name": "pnpm-workspace-pkg-b",\n' +
+          '  "version": "1.1.0"\n' +
+          "}\n",
+      );
+
+      yield* logTest.consecutive(log.all, [
+        { msg: "bumping pnpm-workspace-pkg-a with minor", level: "info" },
+        { msg: "bumping pnpm-workspace-pkg-b with minor", level: "info" },
+        { msg: "bumping pnpm-workspace-pkg-c with minor", level: "info" },
+      ]);
+    });
+
     it("bumps multi with parent as range", function* () {
       const log = yield* logTest.useCapturedLogger();
         const jsonFolder = f.copy("pkg.js-yarn-workspace");

--- a/packages/apply/test/apply.test.ts
+++ b/packages/apply/test/apply.test.ts
@@ -476,6 +476,87 @@ describe("package file apply bump (snapshot)", () => {
         ]);
     });
 
+    it("bumps multi with workspace inherited dep", function* () {
+      const log = yield* logTest.useCapturedLogger();
+      const rustFolder = f.copy("pkg.rust-workspace-deps");
+
+      const commands = [
+        {
+          dependencies: ["rust_workspace_pkg_b_fixture"],
+          manager: "rust",
+          path: "./pkg-a/",
+          pkg: "rust_workspace_dep_fixture",
+          type: "minor",
+          parents: {},
+        },
+        {
+          dependencies: undefined,
+          manager: "rust",
+          path: "./pkg-b/",
+          pkg: "rust_workspace_pkg_b_fixture",
+          type: "minor",
+          parents: {},
+        },
+      ];
+
+      const config = {
+        ...configDefaults,
+        packages: {
+          rust_workspace_dep_fixture: {
+            path: "./pkg-a/",
+            manager: "rust",
+          },
+          rust_workspace_pkg_b_fixture: {
+            path: "./pkg-b/",
+            manager: "rust",
+          },
+        },
+      };
+
+      const allPackages = yield* readAllPkgFiles({ config, cwd: rustFolder });
+
+      yield* apply({
+        logger: logger.operations,
+        //@ts-expect-error
+        commands,
+        config,
+        allPackages,
+        cwd: rustFolder,
+      });
+
+      // the version of a `{ workspace = true }` dependency lives in the
+      // workspace root manifest, so the member manifest is left untouched
+      // aside from its own version bump
+      const modifiedAPKGFile = yield* loadFile("pkg-a/Cargo.toml", rustFolder);
+      expect(modifiedAPKGFile.content).toBe(
+        "[package]\n" +
+          'name = "rust_workspace_dep_fixture"\n' +
+          'version = "0.6.0"\n' +
+          "\n" +
+          "[dependencies]\n" +
+          "serde = { workspace = true }\n" +
+          "rust_workspace_pkg_b_fixture = { workspace = true }\n",
+      );
+
+      const modifiedBPKGFile = yield* loadFile("pkg-b/Cargo.toml", rustFolder);
+      expect(modifiedBPKGFile.content).toBe(
+        "[package]\n" +
+          'name = "rust_workspace_pkg_b_fixture"\n' +
+          'version = "0.9.0"\n',
+      );
+
+      yield* logTest.consecutive(log.all, [
+        {
+          msg: "bumping rust_workspace_dep_fixture with minor",
+          level: "info",
+        },
+        {
+          msg: "bumping rust_workspace_pkg_b_fixture with minor",
+          level: "info",
+        },
+      ]);
+    });
+
     it("bumps multi with object dep", function* () {
       const log = yield* logTest.useCapturedLogger();
         const rustFolder = f.copy("pkg.rust-multi-object-dep");

--- a/packages/apply/test/validate.test.ts
+++ b/packages/apply/test/validate.test.ts
@@ -2,7 +2,7 @@ import { validateApply } from "../src";
 import { readAllPkgFiles } from "@covector/files";
 import { PackageCommand, PackageFile } from "@covector/types";
 
-import { describe, it, captureError } from "@effectionx/vitest";
+import { describe, it } from "@effectionx/vitest";
 import { expect } from "vitest";
 import * as logTest from "../../../helpers/test-logger.ts";
 // @ts-expect-error has no types
@@ -325,9 +325,12 @@ describe("validate apply", () => {
     expect(validated).toBe(true);
   });
 
-  it("bumps multi rust toml as minor with object dep without version number", function* () {
+  it("bumps multi rust toml as minor with object dep without version number (path-only)", function* () {
     const log = yield* logTest.useCapturedLogger();
 
+    // a path-only dependency, e.g. `{ path = "../pkg" }`, is valid in Cargo
+    // for crates that are not published to a registry, so it should not
+    // fail validation
     const rustFolder: string = f.copy("pkg.rust-multi-object-path-dep-only");
 
     const config = {
@@ -366,20 +369,63 @@ describe("validate apply", () => {
       },
     ];
 
-    const errored = yield* captureError(
-      validateApply({
-        logger: logger.operations,
-        commands,
-        allPackages,
-      }),
-    );
-    yield* logger.operations.info("completed");
-    expect(errored.message).toMatch(
-      "rust_pkg_a_fixture has a dependency on rust_pkg_b_fixture, and rust_pkg_b_fixture does not have a version number. " +
-        "This cannot be published. Please pin it to a MAJOR.MINOR.PATCH reference.",
-    );
+    const validated = yield* validateApply({
+      logger: logger.operations,
+      commands,
+      allPackages,
+    });
+    expect(validated).toBe(true);
+  });
 
-    // to confirm that no error logs have been returned
-    yield* logTest.consecutive(log.all, [{ msg: "completed", level: "info" }]);
+  it("bumps multi rust toml as minor with workspace inherited dep", function* () {
+    const log = yield* logTest.useCapturedLogger();
+
+    // a `{ workspace = true }` dependency inherits its version from the
+    // workspace root manifest, so the member manifest has no version to
+    // validate
+    const rustFolder: string = f.copy("pkg.rust-workspace-deps");
+
+    const config = {
+      packages: {
+        rust_workspace_dep_fixture: {
+          path: "./pkg-a/",
+          manager: "rust",
+        },
+        rust_workspace_pkg_b_fixture: {
+          path: "./pkg-b/",
+          manager: "rust",
+        },
+      },
+    };
+    const allPackages: Record<string, PackageFile> = yield* readAllPkgFiles({
+      config,
+      cwd: rustFolder,
+    });
+
+    const commands: PackageCommand[] = [
+      {
+        dependencies: ["rust_workspace_pkg_b_fixture"],
+        manager: "rust",
+        path: "./pkg-a/",
+        pkg: "rust_workspace_dep_fixture",
+        type: "minor",
+        parents: {},
+      },
+      {
+        dependencies: undefined,
+        manager: "rust",
+        path: "./pkg-b/",
+        pkg: "rust_workspace_pkg_b_fixture",
+        type: "minor",
+        parents: {},
+      },
+    ];
+
+    const validated = yield* validateApply({
+      logger: logger.operations,
+      commands,
+      allPackages,
+    });
+    expect(validated).toBe(true);
   });
 });

--- a/packages/files/src/index.ts
+++ b/packages/files/src/index.ts
@@ -366,6 +366,18 @@ export const getPackageFileVersion = ({
               case "string":
                 return depDefinition;
               case "object":
+                // a Cargo dependency declared with `{ workspace = true }` inherits
+                // its version from the workspace root manifest, so there is no
+                // version here to read (or bump)
+                if (depDefinition.workspace === true) {
+                  return depDefinition.version || "";
+                }
+                // a Cargo path-only dependency, e.g. `{ path = "../pkg" }`, is
+                // valid without a version for crates that are not published to
+                // a registry
+                if (depDefinition.path && !depDefinition.version) {
+                  return "";
+                }
                 if (!depDefinition.version) {
                   throw new Error(
                     `${pkg.name} has a dependency on ${dep}, and ${dep} does not have a version number. ` +

--- a/packages/files/test/toml.test.ts
+++ b/packages/files/test/toml.test.ts
@@ -3,7 +3,12 @@ import { expect } from "vitest";
 import path from "path";
 // @ts-expect-error has no types
 import fixtures from "fixturez";
-import { readPkgFile, setPackageFileVersion, writePkgFile } from "../src";
+import {
+  readPkgFile,
+  setPackageFileVersion,
+  getPackageFileVersion,
+  writePkgFile,
+} from "../src";
 
 const f = fixtures(__dirname);
 
@@ -81,6 +86,30 @@ describe("toml", () => {
         expect(cargoFilePkgB.name).toBe("rust_pkg_b_fixture");
         expect(cargoFilePkgB?.pkg?.package?.name).toBe("rust_pkg_b_fixture");
         expect(cargoFilePkgB.version).toBe("0.8.8");
+      });
+
+      it("with workspace = true dependencies", function* () {
+        const cargoFolder = f.copy("pkg.rust-workspace-deps");
+
+        const cargoFilePkgA = yield* readPkgFile({
+          file: "Cargo.toml",
+          cwd: path.join(cargoFolder, "pkg-a"),
+          nickname: "rust_workspace_dep_fixture",
+        });
+        expect(cargoFilePkgA.name).toBe("rust_workspace_dep_fixture");
+        expect(cargoFilePkgA?.pkg?.package?.name).toBe(
+          "rust_workspace_dep_fixture",
+        );
+        expect(cargoFilePkgA.version).toBe("0.5.0");
+
+        // a `{ workspace = true }` dependency inherits its version from the
+        // workspace root manifest, so there is no version to read here
+        const depVersion = getPackageFileVersion({
+          pkg: cargoFilePkgA,
+          property: "dependencies",
+          dep: "serde",
+        });
+        expect(depVersion).toBe("");
       });
     });
   });


### PR DESCRIPTION
Supersedes #369. I lost write access to the fork that branch lives on (left the org), so this is the same change rebuilt from scratch on current main: one commit, tests written against the Effection v4 / vitest v4 setup, no lockfile churn this time.

And your February question deserves an actual answer, so:

> Are you defining and publishing/changelog multiple crates as part monorepo where some/all have their version actually defined in the `Cargo.toml` at the root? Or is it just if _any_ deps don't have a version number?

The second one. Every crate keeps its own `[package] version` in its own manifest; the root version inheritance covector already supports isn't involved. What breaks is two dependency shapes that are legitimately version-less in Cargo:

- `dep = { workspace = true }`: the version lives in the root `[workspace.dependencies]`, not in the member manifest covector is reading
- `dep = { path = "../pkg" }`: no version anywhere, which is normal for internal crates that never touch a registry

The real-world setup this came from (a private aviation monorepo, ~60 covector-managed crates): the root `[workspace.dependencies]` declares each internal crate as `{ path = "...", version = "*" }`, members consume them with `{ workspace = true }`, covector runs the version/changelog cascade, and nothing publishes to crates.io. `getPackageFileVersion` throws on both shapes today, so `covector version` can't run at all on that repo.

Your intent (bump a dep's declared version if it has one) is preserved:

- String deps and object deps with a `version` bump exactly as before.
- For the two shapes above there is no version string in the member manifest to bump, and `setPackageFileVersion` already skips version-less object deps, so the manifest is left untouched and cargo resolves through the workspace/path. There's an apply test now asserting a `{ workspace = true }` table survives a cascade bump byte-for-byte.
- Any other version-less object dep (git-only, say) still throws, so the publish guard stays.

One honest flag: the existing validate test for path-only deps flips from "expects an error" to "expects success". That IS the behavior change, not collateral damage.

What this deliberately does not do: bump versions inside the root `[workspace.dependencies]` table, which a workspace that publishes to crates.io with real requirements there would eventually want. Happy to take that as a follow-up if you're interested.

For whatever it's worth: this exact change ran in production on that monorepo for about six months of releases before I left. It held up.

---

**Update: pnpm/yarn `workspace:` protocol for JS packages (second commit, same branch)**

Following up from Discord: the JS side had the same class of bug. A `"workspace:*"` dependency contains no `.`, so `deriveVersionConsideringPartials` treated it as a partial version pin and rewrote it to the dep's bare major version — `"0"` for any 0.x package. `workspace:^` became `"^0"`, and `workspace:~1.2.3` lost its protocol prefix entirely.

Handling now lives in `getDepBumpVersion`:

- `workspace:*` / `workspace:^` / `workspace:~` (and aliased `workspace:name@range` declarations) are left untouched: they pin to whatever version the workspace holds and the package manager rewrites them at publish time, so there is no version in the declaration to bump.
- An embedded range like `workspace:^1.2.3` keeps the protocol prefix and bumps the range within it (so a minor bump of the dep yields `workspace:^1.3.0`), preserving the existing partial-pin semantics.

An apply-level test (new fixture `pkg.js-pnpm-workspace`) asserts the float forms survive a cascade bump byte-for-byte, the embedded range bumps in place, and the dependent's own version still bumps.
