### PR TITLE
Bump Cargo workspace root dependency requirements

### DIFF
--- a/.changes/js-pnpm-catalogs.md
+++ b/.changes/js-pnpm-catalogs.md
@@ -1,0 +1,6 @@
+---
+"@covector/apply": minor
+"@covector/files": minor
+---
+
+Handle pnpm catalog dependencies: `catalog:` references in package.json are left untouched (pnpm rewrites them at publish; previously they were corrupted to a bare major version), and the `catalog:`/`catalogs:` tables in pnpm-workspace.yaml are bumped to track member versions with the same form-preserving rules as the cargo workspace root table.

--- a/.changes/js-pnpm-catalogs.md
+++ b/.changes/js-pnpm-catalogs.md
@@ -1,6 +1,5 @@
 ---
 "@covector/apply": minor
-"@covector/files": minor
 ---
 
-Handle pnpm catalog dependencies: `catalog:` references in package.json are left untouched (pnpm rewrites them at publish; previously they were corrupted to a bare major version), and the `catalog:`/`catalogs:` tables in pnpm-workspace.yaml are bumped to track member versions with the same form-preserving rules as the cargo workspace root table.
+`catalog:` references in package.json are left untouched during dependency bumps: pnpm rewrites them at publish time from the catalog tables in pnpm-workspace.yaml, and previously they were corrupted to a bare major version.

--- a/.changes/range-requirement-guard.md
+++ b/.changes/range-requirement-guard.md
@@ -1,0 +1,5 @@
+---
+"@covector/apply": patch
+---
+
+Leave a dependency requirement that spans a range or floats alone instead of collapsing it onto the bumped version. A comparator range (`>=1.0 <2`), a wildcard (`1.x`), and `*` already cover the bumped version, and were previously narrowed to a single pin — `">=1.0 <2"` became `"=1.1"`. This covers requirements written behind the pnpm workspace protocol prefix (`workspace:1.x`) as well as plain ones.

--- a/.changes/rust-target-workspace-dep.md
+++ b/.changes/rust-target-workspace-dep.md
@@ -1,0 +1,5 @@
+---
+"@covector/apply": patch
+---
+
+Skip dependencies declared without a version of their own in a cargo `[target]` table, such as `{ workspace = true }` or a path-only entry. Bumping a package that another crate depends on through a target table previously threw.

--- a/.changes/rust-workspace-inherited-version-read.md
+++ b/.changes/rust-workspace-inherited-version-read.md
@@ -1,0 +1,5 @@
+---
+"@covector/files": patch
+---
+
+Read the version off `[workspace.package]` when a Cargo manifest inherits it, matching the existing write support. Applying a bump to a crate whose version is declared at the workspace root previously left the manifest unchanged.

--- a/.changes/rust-workspace-root-deps.md
+++ b/.changes/rust-workspace-root-deps.md
@@ -3,4 +3,4 @@
 "@covector/files": minor
 ---
 
-Bump version requirements for member crates declared in a cargo workspace root manifest's `[workspace.dependencies]` table. Requirements keep their form (partial pins stay partial, range prefixes are preserved), while path-only entries and `*` requirements float on the workspace and are left untouched.
+Bump version requirements for member crates declared in a cargo workspace root manifest's `[workspace.dependencies]` table. Requirements keep their form (partial pins stay partial, range prefixes are preserved), while path-only entries, `*` requirements, and comparator or wildcard ranges (`>=1.2, <2`, `1.*`) are left untouched.

--- a/.changes/rust-workspace-root-deps.md
+++ b/.changes/rust-workspace-root-deps.md
@@ -1,0 +1,6 @@
+---
+"@covector/apply": minor
+"@covector/files": minor
+---
+
+Bump version requirements for member crates declared in a cargo workspace root manifest's `[workspace.dependencies]` table. Requirements keep their form (partial pins stay partial, range prefixes are preserved), while path-only entries and `*` requirements float on the workspace and are left untouched.

--- a/__fixtures__/pkg.js-pnpm-catalog/package.json
+++ b/__fixtures__/pkg.js-pnpm-catalog/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "name": "js-pnpm-catalog",
+  "description": "workspace with pnpm catalogs",
+  "version": "1.0.0"
+}

--- a/__fixtures__/pkg.js-pnpm-catalog/packages/pkg-a/package.json
+++ b/__fixtures__/pkg.js-pnpm-catalog/packages/pkg-a/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "js-catalog-pkg-a",
+  "version": "1.0.0",
+  "dependencies": {
+    "react": "catalog:",
+    "js-catalog-pkg-b": "catalog:"
+  },
+  "devDependencies": {
+    "js-catalog-pkg-c": "catalog:tools"
+  }
+}

--- a/__fixtures__/pkg.js-pnpm-catalog/packages/pkg-b/package.json
+++ b/__fixtures__/pkg.js-pnpm-catalog/packages/pkg-b/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "js-catalog-pkg-b",
+  "version": "1.0.0"
+}

--- a/__fixtures__/pkg.js-pnpm-catalog/packages/pkg-c/package.json
+++ b/__fixtures__/pkg.js-pnpm-catalog/packages/pkg-c/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "js-catalog-pkg-c",
+  "version": "1.0.0"
+}

--- a/__fixtures__/pkg.js-pnpm-catalog/pnpm-workspace.yaml
+++ b/__fixtures__/pkg.js-pnpm-catalog/pnpm-workspace.yaml
@@ -1,0 +1,11 @@
+packages:
+  - "packages/*"
+
+# internal packages pinned here
+catalog:
+  react: ^18.2.0
+  js-catalog-pkg-b: ^1.0.0
+
+catalogs:
+  tools:
+    js-catalog-pkg-c: "1.0"

--- a/__fixtures__/pkg.js-pnpm-workspace/packages/pkg-d/package.json
+++ b/__fixtures__/pkg.js-pnpm-workspace/packages/pkg-d/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "pnpm-workspace-pkg-d",
+  "version": "1.0.0",
+  "dependencies": {
+    "pnpm-workspace-pkg-b": "workspace:1.x"
+  },
+  "devDependencies": {
+    "pnpm-workspace-pkg-c": "workspace:>=1.0 <2"
+  }
+}

--- a/__fixtures__/pkg.js-range-deps/package.json
+++ b/__fixtures__/pkg.js-range-deps/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "name": "js-range-deps",
+  "description": "workspace",
+  "version": "1.0.0",
+  "workspaces": [
+    "packages/*"
+  ]
+}

--- a/__fixtures__/pkg.js-range-deps/packages/pkg-a/package.json
+++ b/__fixtures__/pkg.js-range-deps/packages/pkg-a/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "range-deps-pkg-a",
+  "version": "1.0.0",
+  "dependencies": {
+    "range-deps-pkg-b": ">=1.0 <2",
+    "range-deps-pkg-c": "*"
+  },
+  "devDependencies": {
+    "range-deps-pkg-d": "1.x"
+  }
+}

--- a/__fixtures__/pkg.js-range-deps/packages/pkg-b/package.json
+++ b/__fixtures__/pkg.js-range-deps/packages/pkg-b/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "range-deps-pkg-b",
+  "version": "1.0.0"
+}

--- a/__fixtures__/pkg.js-range-deps/packages/pkg-c/package.json
+++ b/__fixtures__/pkg.js-range-deps/packages/pkg-c/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "range-deps-pkg-c",
+  "version": "1.0.0"
+}

--- a/__fixtures__/pkg.js-range-deps/packages/pkg-d/package.json
+++ b/__fixtures__/pkg.js-range-deps/packages/pkg-d/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "range-deps-pkg-d",
+  "version": "1.0.0"
+}

--- a/__fixtures__/pkg.rust-single-nested/crates/pkg-a/Cargo.toml
+++ b/__fixtures__/pkg.rust-single-nested/crates/pkg-a/Cargo.toml
@@ -1,0 +1,3 @@
+[package]
+name = "rust_single_nested_fixture"
+version = "0.5.0"

--- a/__fixtures__/pkg.rust-workspace-root-deps-inherited/Cargo.toml
+++ b/__fixtures__/pkg.rust-workspace-root-deps-inherited/Cargo.toml
@@ -1,0 +1,9 @@
+[workspace]
+members = ["pkg-a", "pkg-b"]
+
+[workspace.package]
+version = "1.2.3"
+
+[workspace.dependencies]
+rust_root_inherited_fixture = { version = "1.2", path = "pkg-a" }
+rust_root_inherited_helper_fixture = { path = "pkg-b", default-features = false }

--- a/__fixtures__/pkg.rust-workspace-root-deps-inherited/pkg-a/Cargo.toml
+++ b/__fixtures__/pkg.rust-workspace-root-deps-inherited/pkg-a/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "rust_root_inherited_fixture"
+version.workspace = true
+
+[dependencies]
+rust_root_inherited_helper_fixture = { workspace = true }

--- a/__fixtures__/pkg.rust-workspace-root-deps-inherited/pkg-b/Cargo.toml
+++ b/__fixtures__/pkg.rust-workspace-root-deps-inherited/pkg-b/Cargo.toml
@@ -1,0 +1,3 @@
+[package]
+name = "rust_root_inherited_helper_fixture"
+version.workspace = true

--- a/__fixtures__/pkg.rust-workspace-root-deps-multi/core/Cargo.toml
+++ b/__fixtures__/pkg.rust-workspace-root-deps-multi/core/Cargo.toml
@@ -1,0 +1,6 @@
+[workspace]
+members = ["pkg-a", "pkg-b"]
+
+[workspace.dependencies]
+serde = "1.0"
+rust_multi_root_pkg_a_fixture = { version = "0.5", path = "pkg-a" }

--- a/__fixtures__/pkg.rust-workspace-root-deps-multi/core/pkg-a/Cargo.toml
+++ b/__fixtures__/pkg.rust-workspace-root-deps-multi/core/pkg-a/Cargo.toml
@@ -1,0 +1,3 @@
+[package]
+name = "rust_multi_root_pkg_a_fixture"
+version = "0.5.0"

--- a/__fixtures__/pkg.rust-workspace-root-deps-multi/core/pkg-b/Cargo.toml
+++ b/__fixtures__/pkg.rust-workspace-root-deps-multi/core/pkg-b/Cargo.toml
@@ -1,0 +1,3 @@
+[package]
+name = "rust_multi_root_pkg_b_fixture"
+version = "0.2.0"

--- a/__fixtures__/pkg.rust-workspace-root-deps-multi/tools/Cargo.toml
+++ b/__fixtures__/pkg.rust-workspace-root-deps-multi/tools/Cargo.toml
@@ -1,0 +1,6 @@
+[workspace]
+members = ["pkg-c"]
+
+[workspace.dependencies]
+rust_multi_root_pkg_a_fixture = { version = "^0.5", path = "../core/pkg-a" }
+rust_multi_root_pkg_c_fixture = { version = "1.0", path = "pkg-c" }

--- a/__fixtures__/pkg.rust-workspace-root-deps-multi/tools/pkg-c/Cargo.toml
+++ b/__fixtures__/pkg.rust-workspace-root-deps-multi/tools/pkg-c/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "rust_multi_root_pkg_c_fixture"
+version = "1.0.0"
+
+[dependencies]
+rust_multi_root_pkg_a_fixture = { workspace = true }

--- a/__fixtures__/pkg.rust-workspace-root-deps/Cargo.toml
+++ b/__fixtures__/pkg.rust-workspace-root-deps/Cargo.toml
@@ -1,0 +1,9 @@
+[workspace]
+members = ["pkg-a", "pkg-b", "pkg-c", "pkg-d"]
+
+[workspace.dependencies]
+serde = "1.0"
+rust_root_pkg_a_fixture = { version = "0.5", path = "pkg-a", default-features = false }
+rust_root_pkg_b_fixture = "^0.8.0"
+rust_root_pkg_c_fixture = { path = "pkg-c", version = "*" }
+rust_root_pkg_d_fixture = { path = "pkg-d" }

--- a/__fixtures__/pkg.rust-workspace-root-deps/Cargo.toml
+++ b/__fixtures__/pkg.rust-workspace-root-deps/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["pkg-a", "pkg-b", "pkg-c", "pkg-d"]
+members = ["pkg-a", "pkg-b", "pkg-c", "pkg-d", "pkg-e", "pkg-f"]
 
 [workspace.dependencies]
 serde = "1.0"
@@ -7,3 +7,5 @@ rust_root_pkg_a_fixture = { version = "0.5", path = "pkg-a", default-features = 
 rust_root_pkg_b_fixture = "^0.8.0"
 rust_root_pkg_c_fixture = { path = "pkg-c", version = "*" }
 rust_root_pkg_d_fixture = { path = "pkg-d" }
+rust_root_pkg_e_fixture = ">=0.2, <0.4"
+rust_root_pkg_f_fixture = "0.*"

--- a/__fixtures__/pkg.rust-workspace-root-deps/Cargo.toml
+++ b/__fixtures__/pkg.rust-workspace-root-deps/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["pkg-a", "pkg-b", "pkg-c", "pkg-d", "pkg-e", "pkg-f"]
+members = ["pkg-a", "pkg-b", "pkg-c", "pkg-d", "pkg-e", "pkg-f", "pkg-g"]
 
 [workspace.dependencies]
 serde = "1.0"
@@ -9,3 +9,4 @@ rust_root_pkg_c_fixture = { path = "pkg-c", version = "*" }
 rust_root_pkg_d_fixture = { path = "pkg-d" }
 rust_root_pkg_e_fixture = ">=0.2, <0.4"
 rust_root_pkg_f_fixture = "0.*"
+rust_root_pkg_g_fixture = "=0.5"

--- a/__fixtures__/pkg.rust-workspace-root-deps/pkg-a/Cargo.toml
+++ b/__fixtures__/pkg.rust-workspace-root-deps/pkg-a/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rust_root_pkg_a_fixture"
+version = "0.5.0"
+
+[dependencies]
+serde = { workspace = true }
+rust_root_pkg_b_fixture = { workspace = true }
+rust_root_pkg_c_fixture = { workspace = true }
+
+[dev-dependencies]
+rust_root_pkg_d_fixture = { workspace = true }

--- a/__fixtures__/pkg.rust-workspace-root-deps/pkg-a/Cargo.toml
+++ b/__fixtures__/pkg.rust-workspace-root-deps/pkg-a/Cargo.toml
@@ -9,3 +9,6 @@ rust_root_pkg_c_fixture = { workspace = true }
 
 [dev-dependencies]
 rust_root_pkg_d_fixture = { workspace = true }
+
+[target."cfg(windows)".dependencies]
+rust_root_pkg_g_fixture = { workspace = true }

--- a/__fixtures__/pkg.rust-workspace-root-deps/pkg-b/Cargo.toml
+++ b/__fixtures__/pkg.rust-workspace-root-deps/pkg-b/Cargo.toml
@@ -1,0 +1,3 @@
+[package]
+name = "rust_root_pkg_b_fixture"
+version = "0.8.0"

--- a/__fixtures__/pkg.rust-workspace-root-deps/pkg-c/Cargo.toml
+++ b/__fixtures__/pkg.rust-workspace-root-deps/pkg-c/Cargo.toml
@@ -1,0 +1,3 @@
+[package]
+name = "rust_root_pkg_c_fixture"
+version = "0.3.0"

--- a/__fixtures__/pkg.rust-workspace-root-deps/pkg-d/Cargo.toml
+++ b/__fixtures__/pkg.rust-workspace-root-deps/pkg-d/Cargo.toml
@@ -1,0 +1,3 @@
+[package]
+name = "rust_root_pkg_d_fixture"
+version = "0.2.0"

--- a/__fixtures__/pkg.rust-workspace-root-deps/pkg-e/Cargo.toml
+++ b/__fixtures__/pkg.rust-workspace-root-deps/pkg-e/Cargo.toml
@@ -1,0 +1,3 @@
+[package]
+name = "rust_root_pkg_e_fixture"
+version = "0.2.0"

--- a/__fixtures__/pkg.rust-workspace-root-deps/pkg-f/Cargo.toml
+++ b/__fixtures__/pkg.rust-workspace-root-deps/pkg-f/Cargo.toml
@@ -1,0 +1,3 @@
+[package]
+name = "rust_root_pkg_f_fixture"
+version = "0.1.0"

--- a/__fixtures__/pkg.rust-workspace-root-deps/pkg-g/Cargo.toml
+++ b/__fixtures__/pkg.rust-workspace-root-deps/pkg-g/Cargo.toml
@@ -1,0 +1,3 @@
+[package]
+name = "rust_root_pkg_g_fixture"
+version = "0.5.0"

--- a/packages/apply/src/apply.ts
+++ b/packages/apply/src/apply.ts
@@ -3,6 +3,8 @@ import {
   writePkgFile,
   saveFile,
   readCargoWorkspaceRoots,
+  readPnpmWorkspaceRoots,
+  getPnpmCatalogEntries,
   getPackageFileVersion,
   setPackageFileVersion,
   testSerializePkgFile,
@@ -136,9 +138,10 @@ const writeAll = function* ({
   }
 };
 
-// a cargo workspace's root manifest can declare version requirements for
-// member crates in its [workspace.dependencies] table; those requirements
-// live outside the member manifests, so bump them here to track each bumped
+// workspace root manifests can declare version requirements for member
+// packages outside the members' own manifests: cargo's root
+// [workspace.dependencies] table and pnpm's catalog tables in
+// pnpm-workspace.yaml. bump those requirements here to track each bumped
 // member's new version. entries without a version (path-only) and `*`
 // requirements float on the workspace and are left untouched
 function* applyWorkspaceRootDepBumps({
@@ -160,56 +163,109 @@ function* applyWorkspaceRootDepBumps({
     (b) =>
       !!b.name && b.file?.filename === "Cargo" && b.file?.extname === ".toml",
   );
-  if (cargoBumps.length === 0) return;
+  const jsBumps = bumps.filter(
+    (b) =>
+      !!b.name && b.file?.filename === "package" && b.file?.extname === ".json",
+  );
+  if (cargoBumps.length === 0 && jsBumps.length === 0) return;
 
   // deriveVersionConsideringPartials reads the bumped version off the
   // package file record
   const packageFiles = { ...allPackages };
-  for (const b of cargoBumps) {
+  for (const b of [...cargoBumps, ...jsBumps]) {
     packageFiles[b.name!] = b;
   }
 
-  const roots = yield* readCargoWorkspaceRoots({
-    memberManifestPaths: cargoBumps.map((b) => b.file!.path),
-    cwd,
-  });
+  const bumpRequirement = ({
+    prevVersion,
+    dependency,
+  }: {
+    prevVersion: string;
+    dependency: string;
+  }) => {
+    // `*` floats on whatever version the workspace holds
+    if (prevVersion === "*") return null;
+    const versionRequirementMatch = /[\^=~]/.exec(prevVersion);
+    const versionRequirement = versionRequirementMatch
+      ? versionRequirementMatch[0]
+      : "";
+    const version = deriveVersionConsideringPartials({
+      dependency,
+      prevVersion,
+      versionRequirement,
+      previewVersion,
+      packageFiles,
+    });
+    // a partial pin such as `"2.11"` may already cover the bumped version
+    if (!version || version === prevVersion) return null;
+    return version;
+  };
 
-  for (const root of roots) {
-    let modified = false;
-    for (const b of cargoBumps) {
-      const depName = b.pkg.package?.name || b.pkg.name || b.name!;
-      const key = `workspace.dependencies.${depName}`;
-      if (!root.doc.has(key)) continue;
-      const entry = root.doc.get(key);
-      const prevVersion = typeof entry === "string" ? entry : entry?.version;
-      if (typeof prevVersion !== "string" || prevVersion === "") continue;
-      // `*` floats on whatever version the workspace holds
-      if (prevVersion === "*") continue;
+  if (cargoBumps.length > 0) {
+    const roots = yield* readCargoWorkspaceRoots({
+      memberManifestPaths: cargoBumps.map((b) => b.file!.path),
+      cwd,
+    });
 
-      const versionRequirementMatch = /[\^=~]/.exec(prevVersion);
-      const versionRequirement = versionRequirementMatch
-        ? versionRequirementMatch[0]
-        : "";
-      const version = deriveVersionConsideringPartials({
-        dependency: b.name!,
-        prevVersion,
-        versionRequirement,
-        previewVersion,
-        packageFiles,
-      });
-      // a partial pin such as `"2.11"` may already cover the bumped version
-      if (!version || version === prevVersion) continue;
+    for (const root of roots) {
+      let modified = false;
+      for (const b of cargoBumps) {
+        const depName = b.pkg.package?.name || b.pkg.name || b.name!;
+        const key = `workspace.dependencies.${depName}`;
+        if (!root.doc.has(key)) continue;
+        const entry = root.doc.get(key);
+        const prevVersion = typeof entry === "string" ? entry : entry?.version;
+        if (typeof prevVersion !== "string" || prevVersion === "") continue;
 
-      root.doc.set(typeof entry === "string" ? key : `${key}.version`, version);
-      modified = true;
-      if (logs) {
-        yield* logger.info(
-          `bumping ${depName} in ${root.file.path} [workspace.dependencies] to ${version}`,
+        const version = bumpRequirement({ prevVersion, dependency: b.name! });
+        if (!version) continue;
+
+        root.doc.set(
+          typeof entry === "string" ? key : `${key}.version`,
+          version,
         );
+        modified = true;
+        if (logs) {
+          yield* logger.info(
+            `bumping ${depName} in ${root.file.path} [workspace.dependencies] to ${version}`,
+          );
+        }
+      }
+      if (modified) {
+        yield* saveFile({ ...root.file, content: root.doc.toString() }, cwd);
       }
     }
-    if (modified) {
-      yield* saveFile({ ...root.file, content: root.doc.toString() }, cwd);
+  }
+
+  if (jsBumps.length > 0) {
+    const roots = yield* readPnpmWorkspaceRoots({
+      memberManifestPaths: jsBumps.map((b) => b.file!.path),
+      cwd,
+    });
+
+    for (const root of roots) {
+      let modified = false;
+      for (const b of jsBumps) {
+        const depName = b.pkg.name || b.name!;
+        for (const entry of getPnpmCatalogEntries({ root, dep: depName })) {
+          const version = bumpRequirement({
+            prevVersion: entry.version,
+            dependency: b.name!,
+          });
+          if (!version) continue;
+
+          root.doc.setIn(entry.keyPath, version);
+          modified = true;
+          if (logs) {
+            yield* logger.info(
+              `bumping ${depName} in ${root.file.path} ${entry.label} to ${version}`,
+            );
+          }
+        }
+      }
+      if (modified) {
+        yield* saveFile({ ...root.file, content: root.doc.toString() }, cwd);
+      }
     }
   }
 }
@@ -435,6 +491,11 @@ const getDepBumpVersion = ({
     // if pkg is in dep list
     if (existingDep === depName) {
       const prevVersion = getPreviousVersion();
+      // a pnpm catalog reference (`catalog:` or `catalog:groupname`) points at
+      // a range kept in pnpm-workspace.yaml and is rewritten by pnpm at
+      // publish time, so there is no version in the declaration to bump; the
+      // catalog table itself is bumped alongside the workspace root manifests
+      if (prevVersion.startsWith("catalog:")) return null;
       // the pnpm/yarn workspace protocol pins `workspace:*` / `workspace:^` /
       // `workspace:~` deps to whatever version the workspace holds, and the
       // package manager rewrites them at publish time, so there is no version

--- a/packages/apply/src/apply.ts
+++ b/packages/apply/src/apply.ts
@@ -1,6 +1,8 @@
 import { type Operation } from "effection";
 import {
   writePkgFile,
+  saveFile,
+  readCargoWorkspaceRoots,
   getPackageFileVersion,
   setPackageFileVersion,
   testSerializePkgFile,
@@ -54,13 +56,19 @@ export function* apply({
   });
 
   if (bump) {
-    yield* writeAll({
-      bumps: bumps.reduce(
-        (final: PackageFile[], current) =>
-          !current.file ? final : final.concat([current]),
-        [],
-      ),
+    const bumpsToWrite = bumps.reduce(
+      (final: PackageFile[], current) =>
+        !current.file ? final : final.concat([current]),
+      [],
+    );
+    yield* writeAll({ bumps: bumpsToWrite, cwd });
+    yield* applyWorkspaceRootDepBumps({
+      logger,
+      bumps: bumpsToWrite,
+      allPackages,
       cwd,
+      previewVersion,
+      logs,
     });
   } else {
     for (const b of bumps) {
@@ -127,6 +135,84 @@ const writeAll = function* ({
     yield* writePkgFile({ packageFile: bump, cwd });
   }
 };
+
+// a cargo workspace's root manifest can declare version requirements for
+// member crates in its [workspace.dependencies] table; those requirements
+// live outside the member manifests, so bump them here to track each bumped
+// member's new version. entries without a version (path-only) and `*`
+// requirements float on the workspace and are left untouched
+function* applyWorkspaceRootDepBumps({
+  logger,
+  bumps,
+  allPackages,
+  cwd,
+  previewVersion = "",
+  logs = true,
+}: {
+  logger: Logger;
+  bumps: PackageFile[];
+  allPackages: Record<string, PackageFile>;
+  cwd: string;
+  previewVersion?: string;
+  logs?: boolean;
+}): Operation<void> {
+  const cargoBumps = bumps.filter(
+    (b) =>
+      !!b.name && b.file?.filename === "Cargo" && b.file?.extname === ".toml",
+  );
+  if (cargoBumps.length === 0) return;
+
+  // deriveVersionConsideringPartials reads the bumped version off the
+  // package file record
+  const packageFiles = { ...allPackages };
+  for (const b of cargoBumps) {
+    packageFiles[b.name!] = b;
+  }
+
+  const roots = yield* readCargoWorkspaceRoots({
+    memberManifestPaths: cargoBumps.map((b) => b.file!.path),
+    cwd,
+  });
+
+  for (const root of roots) {
+    let modified = false;
+    for (const b of cargoBumps) {
+      const depName = b.pkg.package?.name || b.pkg.name || b.name!;
+      const key = `workspace.dependencies.${depName}`;
+      if (!root.doc.has(key)) continue;
+      const entry = root.doc.get(key);
+      const prevVersion = typeof entry === "string" ? entry : entry?.version;
+      if (typeof prevVersion !== "string" || prevVersion === "") continue;
+      // `*` floats on whatever version the workspace holds
+      if (prevVersion === "*") continue;
+
+      const versionRequirementMatch = /[\^=~]/.exec(prevVersion);
+      const versionRequirement = versionRequirementMatch
+        ? versionRequirementMatch[0]
+        : "";
+      const version = deriveVersionConsideringPartials({
+        dependency: b.name!,
+        prevVersion,
+        versionRequirement,
+        previewVersion,
+        packageFiles,
+      });
+      // a partial pin such as `"2.11"` may already cover the bumped version
+      if (!version || version === prevVersion) continue;
+
+      root.doc.set(typeof entry === "string" ? key : `${key}.version`, version);
+      modified = true;
+      if (logs) {
+        yield* logger.info(
+          `bumping ${depName} in ${root.file.path} [workspace.dependencies] to ${version}`,
+        );
+      }
+    }
+    if (modified) {
+      yield* saveFile({ ...root.file, content: root.doc.toString() }, cwd);
+    }
+  }
+}
 
 function* bumpAll({
   logger,

--- a/packages/apply/src/apply.ts
+++ b/packages/apply/src/apply.ts
@@ -3,8 +3,6 @@ import {
   writePkgFile,
   saveFile,
   readCargoWorkspaceRoots,
-  readPnpmWorkspaceRoots,
-  getPnpmCatalogEntries,
   getPackageFileVersion,
   setPackageFileVersion,
   testSerializePkgFile,
@@ -138,10 +136,9 @@ const writeAll = function* ({
   }
 };
 
-// workspace root manifests can declare version requirements for member
-// packages outside the members' own manifests: cargo's root
-// [workspace.dependencies] table and pnpm's catalog tables in
-// pnpm-workspace.yaml. bump those requirements here to track each bumped
+// a cargo workspace root manifest can declare version requirements for
+// member packages in its [workspace.dependencies] table, outside the
+// members' own manifests. bump those requirements here to track each bumped
 // member's new version. entries without a version (path-only) and `*`
 // requirements float on the workspace and are left untouched
 function* applyWorkspaceRootDepBumps({
@@ -163,16 +160,12 @@ function* applyWorkspaceRootDepBumps({
     (b) =>
       !!b.name && b.file?.filename === "Cargo" && b.file?.extname === ".toml",
   );
-  const jsBumps = bumps.filter(
-    (b) =>
-      !!b.name && b.file?.filename === "package" && b.file?.extname === ".json",
-  );
-  if (cargoBumps.length === 0 && jsBumps.length === 0) return;
+  if (cargoBumps.length === 0) return;
 
   // deriveVersionConsideringPartials reads the bumped version off the
   // package file record
   const packageFiles = { ...allPackages };
-  for (const b of [...cargoBumps, ...jsBumps]) {
+  for (const b of cargoBumps) {
     packageFiles[b.name!] = b;
   }
 
@@ -207,71 +200,34 @@ function* applyWorkspaceRootDepBumps({
     return version;
   };
 
-  if (cargoBumps.length > 0) {
-    const roots = yield* readCargoWorkspaceRoots({
-      memberManifestPaths: cargoBumps.map((b) => b.file!.path),
-      cwd,
-    });
+  const roots = yield* readCargoWorkspaceRoots({
+    memberManifestPaths: cargoBumps.map((b) => b.file!.path),
+    cwd,
+  });
 
-    for (const root of roots) {
-      let modified = false;
-      for (const b of cargoBumps) {
-        const depName = b.pkg.package?.name || b.pkg.name || b.name!;
-        const key = `workspace.dependencies.${depName}`;
-        if (!root.doc.has(key)) continue;
-        const entry = root.doc.get(key);
-        const prevVersion = typeof entry === "string" ? entry : entry?.version;
-        if (typeof prevVersion !== "string" || prevVersion === "") continue;
+  for (const root of roots) {
+    let modified = false;
+    for (const b of cargoBumps) {
+      const depName = b.pkg.package?.name || b.pkg.name || b.name!;
+      const key = `workspace.dependencies.${depName}`;
+      if (!root.doc.has(key)) continue;
+      const entry = root.doc.get(key);
+      const prevVersion = typeof entry === "string" ? entry : entry?.version;
+      if (typeof prevVersion !== "string" || prevVersion === "") continue;
 
-        const version = bumpRequirement({ prevVersion, dependency: b.name! });
-        if (!version) continue;
+      const version = bumpRequirement({ prevVersion, dependency: b.name! });
+      if (!version) continue;
 
-        root.doc.set(
-          typeof entry === "string" ? key : `${key}.version`,
-          version,
+      root.doc.set(typeof entry === "string" ? key : `${key}.version`, version);
+      modified = true;
+      if (logs) {
+        yield* logger.info(
+          `bumping ${depName} in ${root.file.path} [workspace.dependencies] to ${version}`,
         );
-        modified = true;
-        if (logs) {
-          yield* logger.info(
-            `bumping ${depName} in ${root.file.path} [workspace.dependencies] to ${version}`,
-          );
-        }
-      }
-      if (modified) {
-        yield* saveFile({ ...root.file, content: root.doc.toString() }, cwd);
       }
     }
-  }
-
-  if (jsBumps.length > 0) {
-    const roots = yield* readPnpmWorkspaceRoots({
-      memberManifestPaths: jsBumps.map((b) => b.file!.path),
-      cwd,
-    });
-
-    for (const root of roots) {
-      let modified = false;
-      for (const b of jsBumps) {
-        const depName = b.pkg.name || b.name!;
-        for (const entry of getPnpmCatalogEntries({ root, dep: depName })) {
-          const version = bumpRequirement({
-            prevVersion: entry.version,
-            dependency: b.name!,
-          });
-          if (!version) continue;
-
-          root.doc.setIn(entry.keyPath, version);
-          modified = true;
-          if (logs) {
-            yield* logger.info(
-              `bumping ${depName} in ${root.file.path} ${entry.label} to ${version}`,
-            );
-          }
-        }
-      }
-      if (modified) {
-        yield* saveFile({ ...root.file, content: root.doc.toString() }, cwd);
-      }
+    if (modified) {
+      yield* saveFile({ ...root.file, content: root.doc.toString() }, cwd);
     }
   }
 }
@@ -499,8 +455,7 @@ const getDepBumpVersion = ({
       const prevVersion = getPreviousVersion();
       // a pnpm catalog reference (`catalog:` or `catalog:groupname`) points at
       // a range kept in pnpm-workspace.yaml and is rewritten by pnpm at
-      // publish time, so there is no version in the declaration to bump; the
-      // catalog table itself is bumped alongside the workspace root manifests
+      // publish time, so there is no version in the declaration to bump
       if (prevVersion.startsWith("catalog:")) return null;
       // the pnpm/yarn workspace protocol pins `workspace:*` / `workspace:^` /
       // `workspace:~` deps to whatever version the workspace holds, and the

--- a/packages/apply/src/apply.ts
+++ b/packages/apply/src/apply.ts
@@ -185,6 +185,12 @@ function* applyWorkspaceRootDepBumps({
   }) => {
     // `*` floats on whatever version the workspace holds
     if (prevVersion === "*") return null;
+    // comparator/compound ranges (`>=1.2, <2`) and wildcard requirements
+    // (`1.*`, `1.x`) float by design and have no single-pin rewrite; leave
+    // them untouched rather than collapsing them to a pin (range bump
+    // policy is tracked in #184)
+    if (/[<>,| ]/.test(prevVersion) || /(^|\.)[xX*](\.|$)/.test(prevVersion))
+      return null;
     const versionRequirementMatch = /[\^=~]/.exec(prevVersion);
     const versionRequirement = versionRequirementMatch
       ? versionRequirementMatch[0]

--- a/packages/apply/src/apply.ts
+++ b/packages/apply/src/apply.ts
@@ -169,37 +169,6 @@ function* applyWorkspaceRootDepBumps({
     packageFiles[b.name!] = b;
   }
 
-  const bumpRequirement = ({
-    prevVersion,
-    dependency,
-  }: {
-    prevVersion: string;
-    dependency: string;
-  }) => {
-    // `*` floats on whatever version the workspace holds
-    if (prevVersion === "*") return null;
-    // comparator/compound ranges (`>=1.2, <2`) and wildcard requirements
-    // (`1.*`, `1.x`) float by design and have no single-pin rewrite; leave
-    // them untouched rather than collapsing them to a pin (range bump
-    // policy is tracked in #184)
-    if (/[<>,| ]/.test(prevVersion) || /(^|\.)[xX*](\.|$)/.test(prevVersion))
-      return null;
-    const versionRequirementMatch = /[\^=~]/.exec(prevVersion);
-    const versionRequirement = versionRequirementMatch
-      ? versionRequirementMatch[0]
-      : "";
-    const version = deriveVersionConsideringPartials({
-      dependency,
-      prevVersion,
-      versionRequirement,
-      previewVersion,
-      packageFiles,
-    });
-    // a partial pin such as `"2.11"` may already cover the bumped version
-    if (!version || version === prevVersion) return null;
-    return version;
-  };
-
   const roots = yield* readCargoWorkspaceRoots({
     memberManifestPaths: cargoBumps.map((b) => b.file!.path),
     cwd,
@@ -214,8 +183,17 @@ function* applyWorkspaceRootDepBumps({
       const entry = root.doc.get(key);
       const prevVersion = typeof entry === "string" ? entry : entry?.version;
       if (typeof prevVersion !== "string" || prevVersion === "") continue;
+      // a requirement that floats or spans a range has no single pin to
+      // rewrite, so leave it untouched rather than collapse it
+      if (requirementFloats(prevVersion) || requirementSpansRange(prevVersion))
+        continue;
 
-      const version = bumpRequirement({ prevVersion, dependency: b.name! });
+      const version = bumpRequirement({
+        requirement: prevVersion,
+        dependency: b.name!,
+        previewVersion,
+        packageFiles,
+      });
       if (!version) continue;
 
       root.doc.set(typeof entry === "string" ? key : `${key}.version`, version);
@@ -469,33 +447,69 @@ const getDepBumpVersion = ({
       // also left alone); an embedded range such as `workspace:^1.2.3` keeps
       // the protocol prefix and bumps the range within it
       const workspaceProtocol = prevVersion.startsWith("workspace:");
-      const range = workspaceProtocol
+      const requirement = workspaceProtocol
         ? prevVersion.slice("workspace:".length)
         : prevVersion;
       if (
         workspaceProtocol &&
-        (range === "*" || range === "^" || range === "~" || range.includes("@"))
+        (requirement === "*" ||
+          requirement === "^" ||
+          requirement === "~" ||
+          requirement.includes("@"))
       ) {
         return null;
       }
 
-      const versionRequirementMatch = /[\^=~]/.exec(range);
-      const versionRequirement = versionRequirementMatch
-        ? versionRequirementMatch[0]
-        : "";
-
-      const version = deriveVersionConsideringPartials({
+      const version = bumpRequirement({
+        requirement,
         dependency: dep,
-        prevVersion: range,
-        versionRequirement,
         previewVersion,
         packageFiles,
       });
-      if (!version) return version;
+      if (!version) return null;
       return workspaceProtocol ? `workspace:${version}` : version;
     }
   }
   return null;
+};
+
+// a requirement floats when it names no version to bump toward: `*` takes
+// whatever version the workspace resolves, and a wildcard such as `1.*` or
+// `1.x` takes any version below the wildcard
+const requirementFloats = (requirement: string) =>
+  !/\d/.test(requirement) || /(^|\.)[xX*](\.|$)/.test(requirement);
+
+// a comparator range such as `>=0.2, <0.4` spans versions instead of naming
+// one, so there is no single pin to rewrite (range bump policy is tracked in
+// #184)
+const requirementSpansRange = (requirement: string) =>
+  /[<>,| ]/.test(requirement);
+
+// rewrite a version requirement around the dependency's bumped version,
+// keeping both the comparator it was written with (`^`, `=`, `~`) and its
+// precision: `^1.2` stays two part, `1` stays one part. returns null when the
+// requirement already covers the bumped version, as a partial pin often does
+const bumpRequirement = ({
+  requirement,
+  dependency,
+  previewVersion,
+  packageFiles,
+}: {
+  requirement: string;
+  dependency: string;
+  previewVersion: string;
+  packageFiles: Record<string, PackageFile>;
+}) => {
+  const comparatorMatch = /[\^=~]/.exec(requirement);
+  const version = deriveVersionConsideringPartials({
+    dependency,
+    prevVersion: requirement,
+    versionRequirement: comparatorMatch ? comparatorMatch[0] : "",
+    previewVersion,
+    packageFiles,
+  });
+  if (!version || version === requirement) return null;
+  return version;
 };
 
 const deriveVersionConsideringPartials = ({

--- a/packages/apply/src/apply.ts
+++ b/packages/apply/src/apply.ts
@@ -444,7 +444,7 @@ const getDepBumpVersion = ({
   dep: string;
   previewVersion: string;
   packageFiles: Record<string, PackageFile>;
-  getPreviousVersion: () => string;
+  getPreviousVersion: () => string | undefined;
 }) => {
   const pkgProperties = Object.keys(currentPkg[property] as object) as Array<
     keyof Pkg
@@ -453,6 +453,11 @@ const getDepBumpVersion = ({
     // if pkg is in dep list
     if (existingDep === depName) {
       const prevVersion = getPreviousVersion();
+      // a dependency can carry no version of its own: a cargo
+      // `{ workspace = true }` or path-only declaration reads back empty,
+      // and one within a `[target]` table reads back undefined. either way
+      // there is nothing here to bump
+      if (!prevVersion) return null;
       // a pnpm catalog reference (`catalog:` or `catalog:groupname`) points at
       // a range kept in pnpm-workspace.yaml and is rewritten by pnpm at
       // publish time, so there is no version in the declaration to bump

--- a/packages/apply/src/apply.ts
+++ b/packages/apply/src/apply.ts
@@ -440,25 +440,27 @@ const getDepBumpVersion = ({
       // a range kept in pnpm-workspace.yaml and is rewritten by pnpm at
       // publish time, so there is no version in the declaration to bump
       if (prevVersion.startsWith("catalog:")) return null;
-      // the pnpm/yarn workspace protocol pins `workspace:*` / `workspace:^` /
-      // `workspace:~` deps to whatever version the workspace holds, and the
-      // package manager rewrites them at publish time, so there is no version
-      // in the declaration to bump (aliased deps, `workspace:name@range`, are
-      // also left alone); an embedded range such as `workspace:^1.2.3` keeps
-      // the protocol prefix and bumps the range within it
+      // the pnpm/yarn workspace protocol hands resolution to the package
+      // manager, which rewrites the declaration at publish time. an aliased
+      // dep (`workspace:name@range`), and anything the protocol leaves to the
+      // workspace to resolve (`workspace:*`, `workspace:^`, `workspace:1.x`,
+      // `workspace:>=1.2 <2`), names no version to bump toward; an embedded
+      // pin such as `workspace:^1.2.3` keeps the prefix and bumps within it
       const workspaceProtocol = prevVersion.startsWith("workspace:");
       const requirement = workspaceProtocol
         ? prevVersion.slice("workspace:".length)
         : prevVersion;
       if (
         workspaceProtocol &&
-        (requirement === "*" ||
-          requirement === "^" ||
-          requirement === "~" ||
+        (requirementFloats(requirement) ||
+          requirementSpansRange(requirement) ||
           requirement.includes("@"))
       ) {
         return null;
       }
+
+      if (requirementFloats(requirement) || requirementSpansRange(requirement))
+        return null;
 
       const version = bumpRequirement({
         requirement,
@@ -473,9 +475,10 @@ const getDepBumpVersion = ({
   return null;
 };
 
-// a requirement floats when it names no version to bump toward: `*` takes
-// whatever version the workspace resolves, and a wildcard such as `1.*` or
-// `1.x` takes any version below the wildcard
+// a requirement floats when it names no version to bump toward: `*` and the
+// bare `^` / `~` of the workspace protocol take whatever version the
+// workspace resolves, and a wildcard such as `1.*` or `1.x` takes any
+// version below the wildcard
 const requirementFloats = (requirement: string) =>
   !/\d/.test(requirement) || /(^|\.)[xX*](\.|$)/.test(requirement);
 

--- a/packages/apply/test/apply.test.ts
+++ b/packages/apply/test/apply.test.ts
@@ -672,6 +672,141 @@ describe("package file apply bump (snapshot)", () => {
       ]);
     });
 
+    it("bumps multi with workspace root dependency requirements", function* () {
+      const log = yield* logTest.useCapturedLogger();
+      const rustFolder = f.copy("pkg.rust-workspace-root-deps");
+
+      const commands = [
+        {
+          dependencies: [
+            "rust_root_pkg_b_fixture",
+            "rust_root_pkg_c_fixture",
+            "rust_root_pkg_d_fixture",
+          ],
+          manager: "rust",
+          path: "./pkg-a/",
+          pkg: "rust_root_pkg_a_fixture",
+          type: "minor",
+          parents: {},
+        },
+        {
+          dependencies: undefined,
+          manager: "rust",
+          path: "./pkg-b/",
+          pkg: "rust_root_pkg_b_fixture",
+          type: "minor",
+          parents: {},
+        },
+        {
+          dependencies: undefined,
+          manager: "rust",
+          path: "./pkg-c/",
+          pkg: "rust_root_pkg_c_fixture",
+          type: "minor",
+          parents: {},
+        },
+        {
+          dependencies: undefined,
+          manager: "rust",
+          path: "./pkg-d/",
+          pkg: "rust_root_pkg_d_fixture",
+          type: "minor",
+          parents: {},
+        },
+      ];
+
+      const config = {
+        ...configDefaults,
+        packages: {
+          rust_root_pkg_a_fixture: {
+            path: "./pkg-a/",
+            manager: "rust",
+          },
+          rust_root_pkg_b_fixture: {
+            path: "./pkg-b/",
+            manager: "rust",
+          },
+          rust_root_pkg_c_fixture: {
+            path: "./pkg-c/",
+            manager: "rust",
+          },
+          rust_root_pkg_d_fixture: {
+            path: "./pkg-d/",
+            manager: "rust",
+          },
+        },
+      };
+
+      const allPackages = yield* readAllPkgFiles({ config, cwd: rustFolder });
+
+      yield* apply({
+        logger: logger.operations,
+        //@ts-expect-error
+        commands,
+        config,
+        allPackages,
+        cwd: rustFolder,
+      });
+
+      // requirements for member crates in the root [workspace.dependencies]
+      // table track the bumped versions: partial pins stay partial, range
+      // prefixes are kept, and path-only or `*` entries are left untouched
+      const modifiedRootFile = yield* loadFile("Cargo.toml", rustFolder);
+      expect(modifiedRootFile.content).toBe(
+        "[workspace]\n" +
+          'members = ["pkg-a", "pkg-b", "pkg-c", "pkg-d"]\n' +
+          "\n" +
+          "[workspace.dependencies]\n" +
+          'serde = "1.0"\n' +
+          'rust_root_pkg_a_fixture = { version = "0.6", path = "pkg-a", default-features = false }\n' +
+          'rust_root_pkg_b_fixture = "^0.9.0"\n' +
+          'rust_root_pkg_c_fixture = { path = "pkg-c", version = "*" }\n' +
+          'rust_root_pkg_d_fixture = { path = "pkg-d" }\n',
+      );
+
+      const modifiedAPKGFile = yield* loadFile("pkg-a/Cargo.toml", rustFolder);
+      expect(modifiedAPKGFile.content).toBe(
+        "[package]\n" +
+          'name = "rust_root_pkg_a_fixture"\n' +
+          'version = "0.6.0"\n' +
+          "\n" +
+          "[dependencies]\n" +
+          "serde = { workspace = true }\n" +
+          "rust_root_pkg_b_fixture = { workspace = true }\n" +
+          "rust_root_pkg_c_fixture = { workspace = true }\n" +
+          "\n" +
+          "[dev-dependencies]\n" +
+          "rust_root_pkg_d_fixture = { workspace = true }\n",
+      );
+
+      yield* logTest.consecutive(log.all, [
+        {
+          msg: "bumping rust_root_pkg_a_fixture with minor",
+          level: "info",
+        },
+        {
+          msg: "bumping rust_root_pkg_b_fixture with minor",
+          level: "info",
+        },
+        {
+          msg: "bumping rust_root_pkg_c_fixture with minor",
+          level: "info",
+        },
+        {
+          msg: "bumping rust_root_pkg_d_fixture with minor",
+          level: "info",
+        },
+        {
+          msg: "bumping rust_root_pkg_a_fixture in Cargo.toml [workspace.dependencies] to 0.6",
+          level: "info",
+        },
+        {
+          msg: "bumping rust_root_pkg_b_fixture in Cargo.toml [workspace.dependencies] to ^0.9.0",
+          level: "info",
+        },
+      ]);
+    });
+
     it("bumps multi with object dep", function* () {
       const log = yield* logTest.useCapturedLogger();
         const rustFolder = f.copy("pkg.rust-multi-object-dep");

--- a/packages/apply/test/apply.test.ts
+++ b/packages/apply/test/apply.test.ts
@@ -320,6 +320,124 @@ describe("package file apply bump (snapshot)", () => {
       ]);
     });
 
+    it("bumps multi with pnpm catalog deps", function* () {
+      const log = yield* logTest.useCapturedLogger();
+      const jsonFolder = f.copy("pkg.js-pnpm-catalog");
+
+      const commands = [
+        {
+          dependencies: ["js-catalog-pkg-b", "js-catalog-pkg-c"],
+          manager: "javascript",
+          path: "./packages/pkg-a/",
+          pkg: "js-catalog-pkg-a",
+          type: "minor",
+          parents: {},
+        },
+        {
+          dependencies: undefined,
+          manager: "javascript",
+          path: "./packages/pkg-b/",
+          pkg: "js-catalog-pkg-b",
+          type: "minor",
+          parents: {},
+        },
+        {
+          dependencies: undefined,
+          manager: "javascript",
+          path: "./packages/pkg-c/",
+          pkg: "js-catalog-pkg-c",
+          type: "minor",
+          parents: {},
+        },
+      ];
+
+      const config = {
+        ...configDefaults,
+        packages: {
+          "js-catalog-pkg-a": {
+            path: "./packages/pkg-a/",
+            manager: "javascript",
+            dependencies: ["js-catalog-pkg-b", "js-catalog-pkg-c"],
+          },
+          "js-catalog-pkg-b": {
+            path: "./packages/pkg-b/",
+            manager: "javascript",
+          },
+          "js-catalog-pkg-c": {
+            path: "./packages/pkg-c/",
+            manager: "javascript",
+          },
+        },
+      };
+
+      const allPackages = yield* readAllPkgFiles({ config, cwd: jsonFolder });
+
+      yield* apply({
+        logger: logger.operations,
+        //@ts-expect-error
+        commands,
+        config,
+        allPackages,
+        cwd: jsonFolder,
+      });
+
+      // a `catalog:` reference points at a range kept in pnpm-workspace.yaml
+      // and is rewritten by pnpm at publish time, so the declaration itself
+      // must survive a cascade bump byte-for-byte
+      const modifiedPkgAFile = yield* loadFile(
+        "packages/pkg-a/package.json",
+        jsonFolder,
+      );
+      expect(modifiedPkgAFile.content).toBe(
+        "{\n" +
+          '  "name": "js-catalog-pkg-a",\n' +
+          '  "version": "1.1.0",\n' +
+          '  "dependencies": {\n' +
+          '    "react": "catalog:",\n' +
+          '    "js-catalog-pkg-b": "catalog:"\n' +
+          "  },\n" +
+          '  "devDependencies": {\n' +
+          '    "js-catalog-pkg-c": "catalog:tools"\n' +
+          "  }\n" +
+          "}\n",
+      );
+
+      // the catalog tables themselves track the bumped versions: range
+      // prefixes are kept, partial pins stay partial, and entries for
+      // packages outside the workspace (react) are left untouched
+      const modifiedWorkspaceFile = yield* loadFile(
+        "pnpm-workspace.yaml",
+        jsonFolder,
+      );
+      expect(modifiedWorkspaceFile.content).toBe(
+        "packages:\n" +
+          '  - "packages/*"\n' +
+          "\n" +
+          "# internal packages pinned here\n" +
+          "catalog:\n" +
+          "  react: ^18.2.0\n" +
+          "  js-catalog-pkg-b: ^1.1.0\n" +
+          "\n" +
+          "catalogs:\n" +
+          "  tools:\n" +
+          '    js-catalog-pkg-c: "1.1"\n',
+      );
+
+      yield* logTest.consecutive(log.all, [
+        { msg: "bumping js-catalog-pkg-a with minor", level: "info" },
+        { msg: "bumping js-catalog-pkg-b with minor", level: "info" },
+        { msg: "bumping js-catalog-pkg-c with minor", level: "info" },
+        {
+          msg: "bumping js-catalog-pkg-b in pnpm-workspace.yaml catalog to ^1.1.0",
+          level: "info",
+        },
+        {
+          msg: "bumping js-catalog-pkg-c in pnpm-workspace.yaml catalogs.tools to 1.1",
+          level: "info",
+        },
+      ]);
+    });
+
     it("bumps multi with parent as range", function* () {
       const log = yield* logTest.useCapturedLogger();
         const jsonFolder = f.copy("pkg.js-yarn-workspace");

--- a/packages/apply/test/apply.test.ts
+++ b/packages/apply/test/apply.test.ts
@@ -371,6 +371,10 @@ describe("package file apply bump (snapshot)", () => {
       };
 
       const allPackages = yield* readAllPkgFiles({ config, cwd: jsonFolder });
+      const originalWorkspaceFile = yield* loadFile(
+        "pnpm-workspace.yaml",
+        jsonFolder,
+      );
 
       yield* apply({
         logger: logger.operations,
@@ -404,24 +408,13 @@ describe("package file apply bump (snapshot)", () => {
 
       // the catalog tables are managed manually (pnpm does not document
       // catalog entries for workspace-internal packages), so the workspace
-      // manifest survives byte-for-byte
+      // manifest is never rewritten: it survives byte-for-byte as checked
+      // out, line endings included
       const modifiedWorkspaceFile = yield* loadFile(
         "pnpm-workspace.yaml",
         jsonFolder,
       );
-      expect(modifiedWorkspaceFile.content).toBe(
-        "packages:\n" +
-          '  - "packages/*"\n' +
-          "\n" +
-          "# internal packages pinned here\n" +
-          "catalog:\n" +
-          "  react: ^18.2.0\n" +
-          "  js-catalog-pkg-b: ^1.0.0\n" +
-          "\n" +
-          "catalogs:\n" +
-          "  tools:\n" +
-          '    js-catalog-pkg-c: "1.0"\n',
-      );
+      expect(modifiedWorkspaceFile.content).toBe(originalWorkspaceFile.content);
 
       yield* logTest.consecutive(log.all, [
         { msg: "bumping js-catalog-pkg-a with minor", level: "info" },

--- a/packages/apply/test/apply.test.ts
+++ b/packages/apply/test/apply.test.ts
@@ -402,9 +402,9 @@ describe("package file apply bump (snapshot)", () => {
           "}\n",
       );
 
-      // the catalog tables themselves track the bumped versions: range
-      // prefixes are kept, partial pins stay partial, and entries for
-      // packages outside the workspace (react) are left untouched
+      // the catalog tables are managed manually (pnpm does not document
+      // catalog entries for workspace-internal packages), so the workspace
+      // manifest survives byte-for-byte
       const modifiedWorkspaceFile = yield* loadFile(
         "pnpm-workspace.yaml",
         jsonFolder,
@@ -416,25 +416,17 @@ describe("package file apply bump (snapshot)", () => {
           "# internal packages pinned here\n" +
           "catalog:\n" +
           "  react: ^18.2.0\n" +
-          "  js-catalog-pkg-b: ^1.1.0\n" +
+          "  js-catalog-pkg-b: ^1.0.0\n" +
           "\n" +
           "catalogs:\n" +
           "  tools:\n" +
-          '    js-catalog-pkg-c: "1.1"\n',
+          '    js-catalog-pkg-c: "1.0"\n',
       );
 
       yield* logTest.consecutive(log.all, [
         { msg: "bumping js-catalog-pkg-a with minor", level: "info" },
         { msg: "bumping js-catalog-pkg-b with minor", level: "info" },
         { msg: "bumping js-catalog-pkg-c with minor", level: "info" },
-        {
-          msg: "bumping js-catalog-pkg-b in pnpm-workspace.yaml catalog to ^1.1.0",
-          level: "info",
-        },
-        {
-          msg: "bumping js-catalog-pkg-c in pnpm-workspace.yaml catalogs.tools to 1.1",
-          level: "info",
-        },
       ]);
     });
 

--- a/packages/apply/test/apply.test.ts
+++ b/packages/apply/test/apply.test.ts
@@ -945,6 +945,82 @@ describe("package file apply bump (snapshot)", () => {
       ]);
     });
 
+    it("bumps workspace root dependency requirements with an inherited version", function* () {
+      const log = yield* logTest.useCapturedLogger();
+      const rustFolder = f.copy("pkg.rust-workspace-root-deps-inherited");
+
+      const commands = [
+        {
+          dependencies: undefined,
+          manager: "rust",
+          path: "./",
+          pkg: "rust_root_inherited_fixture",
+          type: "minor",
+          parents: {},
+        },
+      ];
+
+      const config = {
+        ...configDefaults,
+        packages: {
+          rust_root_inherited_fixture: {
+            path: "./",
+            manager: "rust",
+          },
+        },
+      };
+
+      // the member manifests inherit their version from the workspace root
+      // (`version.workspace = true`) and are never rewritten, so they keep
+      // their checked-out bytes; compare them against their original content
+      const originalAPKGFile = yield* loadFile("pkg-a/Cargo.toml", rustFolder);
+      const originalBPKGFile = yield* loadFile("pkg-b/Cargo.toml", rustFolder);
+
+      const allPackages = yield* readAllPkgFiles({ config, cwd: rustFolder });
+
+      yield* apply({
+        logger: logger.operations,
+        //@ts-expect-error
+        commands,
+        config,
+        allPackages,
+        cwd: rustFolder,
+      });
+
+      // the package's version lives at [workspace.package] in the root
+      // manifest, so the root carries both the bumped version and the bumped
+      // [workspace.dependencies] requirement, while the entry without a
+      // version (path and features only) is left untouched
+      const modifiedRootFile = yield* loadFile("Cargo.toml", rustFolder);
+      expect(modifiedRootFile.content).toBe(
+        "[workspace]\n" +
+          'members = ["pkg-a", "pkg-b"]\n' +
+          "\n" +
+          "[workspace.package]\n" +
+          'version = "1.3.0"\n' +
+          "\n" +
+          "[workspace.dependencies]\n" +
+          'rust_root_inherited_fixture = { version = "1.3", path = "pkg-a" }\n' +
+          'rust_root_inherited_helper_fixture = { path = "pkg-b", default-features = false }\n',
+      );
+
+      const modifiedAPKGFile = yield* loadFile("pkg-a/Cargo.toml", rustFolder);
+      expect(modifiedAPKGFile.content).toBe(originalAPKGFile.content);
+      const modifiedBPKGFile = yield* loadFile("pkg-b/Cargo.toml", rustFolder);
+      expect(modifiedBPKGFile.content).toBe(originalBPKGFile.content);
+
+      yield* logTest.consecutive(log.all, [
+        {
+          msg: "bumping rust_root_inherited_fixture with minor",
+          level: "info",
+        },
+        {
+          msg: "bumping rust_root_inherited_fixture in Cargo.toml [workspace.dependencies] to 1.3",
+          level: "info",
+        },
+      ]);
+    });
+
     it("bumps multi with object dep", function* () {
       const log = yield* logTest.useCapturedLogger();
         const rustFolder = f.copy("pkg.rust-multi-object-dep");

--- a/packages/apply/test/apply.test.ts
+++ b/packages/apply/test/apply.test.ts
@@ -831,6 +831,22 @@ describe("package file apply bump (snapshot)", () => {
           type: "minor",
           parents: {},
         },
+        {
+          dependencies: undefined,
+          manager: "rust",
+          path: "./pkg-e/",
+          pkg: "rust_root_pkg_e_fixture",
+          type: "minor",
+          parents: {},
+        },
+        {
+          dependencies: undefined,
+          manager: "rust",
+          path: "./pkg-f/",
+          pkg: "rust_root_pkg_f_fixture",
+          type: "minor",
+          parents: {},
+        },
       ];
 
       const config = {
@@ -852,6 +868,14 @@ describe("package file apply bump (snapshot)", () => {
             path: "./pkg-d/",
             manager: "rust",
           },
+          rust_root_pkg_e_fixture: {
+            path: "./pkg-e/",
+            manager: "rust",
+          },
+          rust_root_pkg_f_fixture: {
+            path: "./pkg-f/",
+            manager: "rust",
+          },
         },
       };
 
@@ -868,18 +892,21 @@ describe("package file apply bump (snapshot)", () => {
 
       // requirements for member crates in the root [workspace.dependencies]
       // table track the bumped versions: partial pins stay partial, range
-      // prefixes are kept, and path-only or `*` entries are left untouched
+      // prefixes are kept, and path-only, `*`, comparator-range, or wildcard
+      // entries are left untouched
       const modifiedRootFile = yield* loadFile("Cargo.toml", rustFolder);
       expect(modifiedRootFile.content).toBe(
         "[workspace]\n" +
-          'members = ["pkg-a", "pkg-b", "pkg-c", "pkg-d"]\n' +
+          'members = ["pkg-a", "pkg-b", "pkg-c", "pkg-d", "pkg-e", "pkg-f"]\n' +
           "\n" +
           "[workspace.dependencies]\n" +
           'serde = "1.0"\n' +
           'rust_root_pkg_a_fixture = { version = "0.6", path = "pkg-a", default-features = false }\n' +
           'rust_root_pkg_b_fixture = "^0.9.0"\n' +
           'rust_root_pkg_c_fixture = { path = "pkg-c", version = "*" }\n' +
-          'rust_root_pkg_d_fixture = { path = "pkg-d" }\n',
+          'rust_root_pkg_d_fixture = { path = "pkg-d" }\n' +
+          'rust_root_pkg_e_fixture = ">=0.2, <0.4"\n' +
+          'rust_root_pkg_f_fixture = "0.*"\n',
       );
 
       const modifiedAPKGFile = yield* loadFile("pkg-a/Cargo.toml", rustFolder);
@@ -912,6 +939,14 @@ describe("package file apply bump (snapshot)", () => {
         },
         {
           msg: "bumping rust_root_pkg_d_fixture with minor",
+          level: "info",
+        },
+        {
+          msg: "bumping rust_root_pkg_e_fixture with minor",
+          level: "info",
+        },
+        {
+          msg: "bumping rust_root_pkg_f_fixture with minor",
           level: "info",
         },
         {

--- a/packages/apply/test/apply.test.ts
+++ b/packages/apply/test/apply.test.ts
@@ -832,6 +832,14 @@ describe("package file apply bump (snapshot)", () => {
           type: "minor",
           parents: {},
         },
+        {
+          dependencies: undefined,
+          manager: "rust",
+          path: "./pkg-g/",
+          pkg: "rust_root_pkg_g_fixture",
+          type: "minor",
+          parents: {},
+        },
       ];
 
       const config = {
@@ -861,6 +869,10 @@ describe("package file apply bump (snapshot)", () => {
             path: "./pkg-f/",
             manager: "rust",
           },
+          rust_root_pkg_g_fixture: {
+            path: "./pkg-g/",
+            manager: "rust",
+          },
         },
       };
 
@@ -876,13 +888,13 @@ describe("package file apply bump (snapshot)", () => {
       });
 
       // requirements for member crates in the root [workspace.dependencies]
-      // table track the bumped versions: partial pins stay partial, range
-      // prefixes are kept, and path-only, `*`, comparator-range, or wildcard
-      // entries are left untouched
+      // table track the bumped versions: partial pins stay partial, exact
+      // pins and range prefixes are kept, and path-only, `*`,
+      // comparator-range, or wildcard entries are left untouched
       const modifiedRootFile = yield* loadFile("Cargo.toml", rustFolder);
       expect(modifiedRootFile.content).toBe(
         "[workspace]\n" +
-          'members = ["pkg-a", "pkg-b", "pkg-c", "pkg-d", "pkg-e", "pkg-f"]\n' +
+          'members = ["pkg-a", "pkg-b", "pkg-c", "pkg-d", "pkg-e", "pkg-f", "pkg-g"]\n' +
           "\n" +
           "[workspace.dependencies]\n" +
           'serde = "1.0"\n' +
@@ -891,7 +903,8 @@ describe("package file apply bump (snapshot)", () => {
           'rust_root_pkg_c_fixture = { path = "pkg-c", version = "*" }\n' +
           'rust_root_pkg_d_fixture = { path = "pkg-d" }\n' +
           'rust_root_pkg_e_fixture = ">=0.2, <0.4"\n' +
-          'rust_root_pkg_f_fixture = "0.*"\n',
+          'rust_root_pkg_f_fixture = "0.*"\n' +
+          'rust_root_pkg_g_fixture = "=0.6"\n',
       );
 
       const modifiedAPKGFile = yield* loadFile("pkg-a/Cargo.toml", rustFolder);
@@ -935,11 +948,137 @@ describe("package file apply bump (snapshot)", () => {
           level: "info",
         },
         {
+          msg: "bumping rust_root_pkg_g_fixture with minor",
+          level: "info",
+        },
+        {
           msg: "bumping rust_root_pkg_a_fixture in Cargo.toml [workspace.dependencies] to 0.6",
           level: "info",
         },
         {
           msg: "bumping rust_root_pkg_b_fixture in Cargo.toml [workspace.dependencies] to ^0.9.0",
+          level: "info",
+        },
+        {
+          msg: "bumping rust_root_pkg_g_fixture in Cargo.toml [workspace.dependencies] to =0.6",
+          level: "info",
+        },
+      ]);
+    });
+
+    it("bumps workspace root dependency requirements across multiple roots", function* () {
+      const log = yield* logTest.useCapturedLogger();
+      const rustFolder = f.copy("pkg.rust-workspace-root-deps-multi");
+
+      const commands = [
+        {
+          dependencies: undefined,
+          manager: "rust",
+          path: "./core/pkg-a/",
+          pkg: "rust_multi_root_pkg_a_fixture",
+          type: "minor",
+          parents: {},
+        },
+        {
+          dependencies: undefined,
+          manager: "rust",
+          path: "./core/pkg-b/",
+          pkg: "rust_multi_root_pkg_b_fixture",
+          type: "minor",
+          parents: {},
+        },
+        {
+          dependencies: ["rust_multi_root_pkg_a_fixture"],
+          manager: "rust",
+          path: "./tools/pkg-c/",
+          pkg: "rust_multi_root_pkg_c_fixture",
+          type: "minor",
+          parents: {},
+        },
+      ];
+
+      const config = {
+        ...configDefaults,
+        packages: {
+          rust_multi_root_pkg_a_fixture: {
+            path: "./core/pkg-a/",
+            manager: "rust",
+          },
+          rust_multi_root_pkg_b_fixture: {
+            path: "./core/pkg-b/",
+            manager: "rust",
+          },
+          rust_multi_root_pkg_c_fixture: {
+            path: "./tools/pkg-c/",
+            manager: "rust",
+          },
+        },
+      };
+
+      const allPackages = yield* readAllPkgFiles({ config, cwd: rustFolder });
+
+      yield* apply({
+        logger: logger.operations,
+        //@ts-expect-error
+        commands,
+        config,
+        allPackages,
+        cwd: rustFolder,
+      });
+
+      // each workspace root in the repo is bumped, and a member that no root
+      // declares (pkg-b) leaves every [workspace.dependencies] table alone
+      const modifiedCoreRootFile = yield* loadFile(
+        "core/Cargo.toml",
+        rustFolder,
+      );
+      expect(modifiedCoreRootFile.content).toBe(
+        "[workspace]\n" +
+          'members = ["pkg-a", "pkg-b"]\n' +
+          "\n" +
+          "[workspace.dependencies]\n" +
+          'serde = "1.0"\n' +
+          'rust_multi_root_pkg_a_fixture = { version = "0.6", path = "pkg-a" }\n',
+      );
+
+      // a root can declare a crate from a sibling workspace by path, so the
+      // requirement is bumped wherever it is declared
+      const modifiedToolsRootFile = yield* loadFile(
+        "tools/Cargo.toml",
+        rustFolder,
+      );
+      expect(modifiedToolsRootFile.content).toBe(
+        "[workspace]\n" +
+          'members = ["pkg-c"]\n' +
+          "\n" +
+          "[workspace.dependencies]\n" +
+          'rust_multi_root_pkg_a_fixture = { version = "^0.6", path = "../core/pkg-a" }\n' +
+          'rust_multi_root_pkg_c_fixture = { version = "1.1", path = "pkg-c" }\n',
+      );
+
+      yield* logTest.consecutive(log.all, [
+        {
+          msg: "bumping rust_multi_root_pkg_a_fixture with minor",
+          level: "info",
+        },
+        {
+          msg: "bumping rust_multi_root_pkg_b_fixture with minor",
+          level: "info",
+        },
+        {
+          msg: "bumping rust_multi_root_pkg_c_fixture with minor",
+          level: "info",
+        },
+        {
+          msg: "bumping rust_multi_root_pkg_a_fixture in core/Cargo.toml [workspace.dependencies] to 0.6",
+          level: "info",
+        },
+        {
+          msg: "bumping rust_multi_root_pkg_a_fixture in tools/Cargo.toml [workspace.dependencies] to ^0.6",
+          level: "info",
+        },
+        {
+          msg: "bumping rust_multi_root_pkg_c_fixture in tools/Cargo.toml [workspace.dependencies] to 1.1",
           level: "info",
         },
       ]);

--- a/packages/apply/test/apply.test.ts
+++ b/packages/apply/test/apply.test.ts
@@ -785,6 +785,7 @@ describe("package file apply bump (snapshot)", () => {
             "rust_root_pkg_b_fixture",
             "rust_root_pkg_c_fixture",
             "rust_root_pkg_d_fixture",
+            "rust_root_pkg_g_fixture",
           ],
           manager: "rust",
           path: "./pkg-a/",
@@ -907,6 +908,8 @@ describe("package file apply bump (snapshot)", () => {
           'rust_root_pkg_g_fixture = "=0.6"\n',
       );
 
+      // the `{ workspace = true }` declarations carry no version of their
+      // own, in a [target] table as much as anywhere else
       const modifiedAPKGFile = yield* loadFile("pkg-a/Cargo.toml", rustFolder);
       expect(modifiedAPKGFile.content).toBe(
         "[package]\n" +
@@ -919,7 +922,10 @@ describe("package file apply bump (snapshot)", () => {
           "rust_root_pkg_c_fixture = { workspace = true }\n" +
           "\n" +
           "[dev-dependencies]\n" +
-          "rust_root_pkg_d_fixture = { workspace = true }\n",
+          "rust_root_pkg_d_fixture = { workspace = true }\n" +
+          "\n" +
+          '[target."cfg(windows)".dependencies]\n' +
+          "rust_root_pkg_g_fixture = { workspace = true }\n",
       );
 
       yield* logTest.consecutive(log.all, [

--- a/packages/apply/test/apply.test.ts
+++ b/packages/apply/test/apply.test.ts
@@ -205,6 +205,116 @@ describe("package file apply bump (snapshot)", () => {
         ]);
     });
 
+    it("leaves range and wildcard dependency requirements alone", function* () {
+      const log = yield* logTest.useCapturedLogger();
+      const jsonFolder = f.copy("pkg.js-range-deps");
+
+      const commands = [
+        {
+          dependencies: [
+            "range-deps-pkg-b",
+            "range-deps-pkg-c",
+            "range-deps-pkg-d",
+          ],
+          manager: "javascript",
+          path: "./packages/pkg-a/",
+          pkg: "range-deps-pkg-a",
+          type: "minor",
+          parents: {},
+        },
+        {
+          dependencies: undefined,
+          manager: "javascript",
+          path: "./packages/pkg-b/",
+          pkg: "range-deps-pkg-b",
+          type: "minor",
+          parents: {},
+        },
+        {
+          dependencies: undefined,
+          manager: "javascript",
+          path: "./packages/pkg-c/",
+          pkg: "range-deps-pkg-c",
+          type: "minor",
+          parents: {},
+        },
+        {
+          dependencies: undefined,
+          manager: "javascript",
+          path: "./packages/pkg-d/",
+          pkg: "range-deps-pkg-d",
+          type: "minor",
+          parents: {},
+        },
+      ];
+
+      const config = {
+        ...configDefaults,
+        packages: {
+          "range-deps-pkg-a": {
+            path: "./packages/pkg-a/",
+            manager: "javascript",
+            dependencies: [
+              "range-deps-pkg-b",
+              "range-deps-pkg-c",
+              "range-deps-pkg-d",
+            ],
+          },
+          "range-deps-pkg-b": {
+            path: "./packages/pkg-b/",
+            manager: "javascript",
+          },
+          "range-deps-pkg-c": {
+            path: "./packages/pkg-c/",
+            manager: "javascript",
+          },
+          "range-deps-pkg-d": {
+            path: "./packages/pkg-d/",
+            manager: "javascript",
+          },
+        },
+      };
+
+      const allPackages = yield* readAllPkgFiles({ config, cwd: jsonFolder });
+
+      yield* apply({
+        logger: logger.operations,
+        //@ts-expect-error
+        commands,
+        config,
+        allPackages,
+        cwd: jsonFolder,
+      });
+
+      // a comparator range, a wildcard, and `*` each already cover the bumped
+      // version and have no single pin to rewrite, so narrowing them onto the
+      // bumped version would take away range the package deliberately allows
+      const modifiedPkgAFile = yield* loadFile(
+        "packages/pkg-a/package.json",
+        jsonFolder,
+      );
+      expect(modifiedPkgAFile.content).toBe(
+        "{\n" +
+          '  "name": "range-deps-pkg-a",\n' +
+          '  "version": "1.1.0",\n' +
+          '  "dependencies": {\n' +
+          '    "range-deps-pkg-b": ">=1.0 <2",\n' +
+          '    "range-deps-pkg-c": "*"\n' +
+          "  },\n" +
+          '  "devDependencies": {\n' +
+          '    "range-deps-pkg-d": "1.x"\n' +
+          "  }\n" +
+          "}\n",
+      );
+
+      yield* logTest.consecutive(log.all, [
+        { msg: "bumping range-deps-pkg-a with minor", level: "info" },
+        { msg: "bumping range-deps-pkg-b with minor", level: "info" },
+        { msg: "bumping range-deps-pkg-c with minor", level: "info" },
+        { msg: "bumping range-deps-pkg-d with minor", level: "info" },
+      ]);
+    });
+
     it("bumps multi with pnpm workspace protocol deps", function* () {
       const log = yield* logTest.useCapturedLogger();
       const jsonFolder = f.copy("pkg.js-pnpm-workspace");
@@ -234,6 +344,14 @@ describe("package file apply bump (snapshot)", () => {
           type: "minor",
           parents: {},
         },
+        {
+          dependencies: ["pnpm-workspace-pkg-b", "pnpm-workspace-pkg-c"],
+          manager: "javascript",
+          path: "./packages/pkg-d/",
+          pkg: "pnpm-workspace-pkg-d",
+          type: "minor",
+          parents: {},
+        },
       ];
 
       const config = {
@@ -252,6 +370,11 @@ describe("package file apply bump (snapshot)", () => {
             path: "./packages/pkg-c/",
             manager: "javascript",
             dependencies: ["pnpm-workspace-pkg-b"],
+          },
+          "pnpm-workspace-pkg-d": {
+            path: "./packages/pkg-d/",
+            manager: "javascript",
+            dependencies: ["pnpm-workspace-pkg-b", "pnpm-workspace-pkg-c"],
           },
         },
       };
@@ -313,10 +436,31 @@ describe("package file apply bump (snapshot)", () => {
           "}\n",
       );
 
+      // a wildcard or comparator range behind the protocol prefix is the
+      // workspace's to resolve as much as a bare `workspace:*` is, so it is
+      // left alone rather than collapsed onto the bumped version
+      const modifiedPkgDFile = yield* loadFile(
+        "packages/pkg-d/package.json",
+        jsonFolder,
+      );
+      expect(modifiedPkgDFile.content).toBe(
+        "{\n" +
+          '  "name": "pnpm-workspace-pkg-d",\n' +
+          '  "version": "1.1.0",\n' +
+          '  "dependencies": {\n' +
+          '    "pnpm-workspace-pkg-b": "workspace:1.x"\n' +
+          "  },\n" +
+          '  "devDependencies": {\n' +
+          '    "pnpm-workspace-pkg-c": "workspace:>=1.0 <2"\n' +
+          "  }\n" +
+          "}\n",
+      );
+
       yield* logTest.consecutive(log.all, [
         { msg: "bumping pnpm-workspace-pkg-a with minor", level: "info" },
         { msg: "bumping pnpm-workspace-pkg-b with minor", level: "info" },
         { msg: "bumping pnpm-workspace-pkg-c with minor", level: "info" },
+        { msg: "bumping pnpm-workspace-pkg-d with minor", level: "info" },
       ]);
     });
 

--- a/packages/files/src/index.ts
+++ b/packages/files/src/index.ts
@@ -339,8 +339,12 @@ export function* readCargoWorkspaceRoots({
       } catch (error) {
         // no manifest at this level, keep walking up
       }
-      if (dir === ".") break;
-      dir = path.posix.dirname(dir);
+      // `dirname` reaches a fixed point at the top of the walk (`.` for
+      // relative paths, `/` for absolute ones), so the loop terminates even
+      // for paths outside the cwd-relative shape loadFile produces
+      const parent = path.posix.dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
     }
   }
   return Object.values(roots);

--- a/packages/files/src/index.ts
+++ b/packages/files/src/index.ts
@@ -307,6 +307,45 @@ export function* writePkgFile({
   return inputFile;
 }
 
+export type CargoWorkspaceRoot = {
+  file: LoadedFile;
+  doc: TomlDocument;
+};
+
+// a cargo workspace's root manifest can declare version requirements for
+// member crates in its [workspace.dependencies] table; find the nearest
+// ancestor manifest declaring a [workspace] (cargo's workspace resolution
+// rule) for each member manifest so those requirements can be kept in sync
+export function* readCargoWorkspaceRoots({
+  memberManifestPaths,
+  cwd,
+}: {
+  memberManifestPaths: string[];
+  cwd: string;
+}): Operation<CargoWorkspaceRoot[]> {
+  const roots: Record<string, CargoWorkspaceRoot> = {};
+  for (const manifestPath of memberManifestPaths) {
+    let dir = path.posix.dirname(manifestPath);
+    while (true) {
+      const rootManifestPath = dir === "." ? "Cargo.toml" : `${dir}/Cargo.toml`;
+      if (roots[rootManifestPath]) break;
+      try {
+        const file = yield* loadFile(rootManifestPath, cwd);
+        const doc = TomlDocument.parse(file.content);
+        if (doc.has("workspace")) {
+          roots[rootManifestPath] = { file, doc };
+          break;
+        }
+      } catch (error) {
+        // no manifest at this level, keep walking up
+      }
+      if (dir === ".") break;
+      dir = path.posix.dirname(dir);
+    }
+  }
+  return Object.values(roots);
+}
+
 export function* readPreFile({
   cwd,
   changeFolder = ".changes",

--- a/packages/files/src/index.ts
+++ b/packages/files/src/index.ts
@@ -7,14 +7,7 @@ import { fromZodError } from "zod-validation-error";
 import { glob } from "tinyglobby";
 import path from "path";
 import { TomlDocument } from "@covector/toml";
-import {
-  parse,
-  parseDocument,
-  stringify,
-  isMap,
-  isScalar,
-  type Document,
-} from "yaml";
+import { parse, stringify } from "yaml";
 import semver from "semver";
 
 export * from "./schema.ts";
@@ -352,69 +345,6 @@ export function* readCargoWorkspaceRoots({
   }
   return Object.values(roots);
 }
-
-export type PnpmWorkspaceRoot = {
-  file: LoadedFile;
-  doc: Document;
-};
-
-// pnpm workspaces can pin dependency ranges centrally in the catalog tables
-// of pnpm-workspace.yaml; find the nearest ancestor pnpm-workspace.yaml
-// (pnpm's workspace resolution rule) for each member manifest so those
-// ranges can be kept in sync
-export function* readPnpmWorkspaceRoots({
-  memberManifestPaths,
-  cwd,
-}: {
-  memberManifestPaths: string[];
-  cwd: string;
-}): Operation<PnpmWorkspaceRoot[]> {
-  const roots: Record<string, PnpmWorkspaceRoot> = {};
-  for (const manifestPath of memberManifestPaths) {
-    let dir = path.posix.dirname(manifestPath);
-    while (true) {
-      const workspaceFilePath =
-        dir === "." ? "pnpm-workspace.yaml" : `${dir}/pnpm-workspace.yaml`;
-      if (roots[workspaceFilePath]) break;
-      try {
-        const file = yield* loadFile(workspaceFilePath, cwd);
-        roots[workspaceFilePath] = { file, doc: parseDocument(file.content) };
-        break;
-      } catch (error) {
-        // no workspace manifest at this level, keep walking up
-      }
-      if (dir === ".") break;
-      dir = path.posix.dirname(dir);
-    }
-  }
-  return Object.values(roots);
-}
-
-// the catalog tables in a pnpm workspace manifest that pin a range for `dep`:
-// the default `catalog:` table plus each named group under `catalogs:`
-export const getPnpmCatalogEntries = ({
-  root,
-  dep,
-}: {
-  root: PnpmWorkspaceRoot;
-  dep: string;
-}): { label: string; keyPath: string[]; version: string }[] => {
-  const entries: { label: string; keyPath: string[]; version: string }[] = [];
-  const consider = (keyPath: string[], label: string) => {
-    const version = root.doc.getIn(keyPath);
-    if (typeof version === "string" && version !== "")
-      entries.push({ label, keyPath, version });
-  };
-  consider(["catalog", dep], "catalog");
-  const groups = root.doc.get("catalogs");
-  if (isMap(groups)) {
-    for (const item of groups.items) {
-      const group = String(isScalar(item.key) ? item.key.value : item.key);
-      consider(["catalogs", group, dep], `catalogs.${group}`);
-    }
-  }
-  return entries;
-};
 
 export function* readPreFile({
   cwd,

--- a/packages/files/src/index.ts
+++ b/packages/files/src/index.ts
@@ -385,6 +385,13 @@ export const getPackageFileVersion = ({
           return pkg.pkg.version;
         } else if (pkg.file.extname === ".toml" && pkg?.pkg?.package?.version) {
           return pkg.pkg.package.version;
+        } else if (
+          pkg.file.extname === ".toml" &&
+          pkg?.pkg?.workspace?.package?.version
+        ) {
+          // a workspace root manifest can hold the version its members
+          // inherit at [workspace.package], mirroring setPackageFileVersion
+          return pkg.pkg.workspace.package.version;
         } else if (!pkg.pkg.version) {
           return "";
         } else {

--- a/packages/files/src/index.ts
+++ b/packages/files/src/index.ts
@@ -7,7 +7,14 @@ import { fromZodError } from "zod-validation-error";
 import { glob } from "tinyglobby";
 import path from "path";
 import { TomlDocument } from "@covector/toml";
-import { parse, stringify } from "yaml";
+import {
+  parse,
+  parseDocument,
+  stringify,
+  isMap,
+  isScalar,
+  type Document,
+} from "yaml";
 import semver from "semver";
 
 export * from "./schema.ts";
@@ -345,6 +352,69 @@ export function* readCargoWorkspaceRoots({
   }
   return Object.values(roots);
 }
+
+export type PnpmWorkspaceRoot = {
+  file: LoadedFile;
+  doc: Document;
+};
+
+// pnpm workspaces can pin dependency ranges centrally in the catalog tables
+// of pnpm-workspace.yaml; find the nearest ancestor pnpm-workspace.yaml
+// (pnpm's workspace resolution rule) for each member manifest so those
+// ranges can be kept in sync
+export function* readPnpmWorkspaceRoots({
+  memberManifestPaths,
+  cwd,
+}: {
+  memberManifestPaths: string[];
+  cwd: string;
+}): Operation<PnpmWorkspaceRoot[]> {
+  const roots: Record<string, PnpmWorkspaceRoot> = {};
+  for (const manifestPath of memberManifestPaths) {
+    let dir = path.posix.dirname(manifestPath);
+    while (true) {
+      const workspaceFilePath =
+        dir === "." ? "pnpm-workspace.yaml" : `${dir}/pnpm-workspace.yaml`;
+      if (roots[workspaceFilePath]) break;
+      try {
+        const file = yield* loadFile(workspaceFilePath, cwd);
+        roots[workspaceFilePath] = { file, doc: parseDocument(file.content) };
+        break;
+      } catch (error) {
+        // no workspace manifest at this level, keep walking up
+      }
+      if (dir === ".") break;
+      dir = path.posix.dirname(dir);
+    }
+  }
+  return Object.values(roots);
+}
+
+// the catalog tables in a pnpm workspace manifest that pin a range for `dep`:
+// the default `catalog:` table plus each named group under `catalogs:`
+export const getPnpmCatalogEntries = ({
+  root,
+  dep,
+}: {
+  root: PnpmWorkspaceRoot;
+  dep: string;
+}): { label: string; keyPath: string[]; version: string }[] => {
+  const entries: { label: string; keyPath: string[]; version: string }[] = [];
+  const consider = (keyPath: string[], label: string) => {
+    const version = root.doc.getIn(keyPath);
+    if (typeof version === "string" && version !== "")
+      entries.push({ label, keyPath, version });
+  };
+  consider(["catalog", dep], "catalog");
+  const groups = root.doc.get("catalogs");
+  if (isMap(groups)) {
+    for (const item of groups.items) {
+      const group = String(isScalar(item.key) ? item.key.value : item.key);
+      consider(["catalogs", group, dep], `catalogs.${group}`);
+    }
+  }
+  return entries;
+};
 
 export function* readPreFile({
   cwd,

--- a/packages/files/src/index.ts
+++ b/packages/files/src/index.ts
@@ -325,6 +325,10 @@ export function* readCargoWorkspaceRoots({
 }): Operation<CargoWorkspaceRoot[]> {
   const roots: Record<string, CargoWorkspaceRoot> = {};
   for (const manifestPath of memberManifestPaths) {
+    // the walk starts at the member manifest itself rather than its parent:
+    // a root manifest can be a package in its own right, and one holding the
+    // version its members inherit at [workspace.package] is the package
+    // covector bumps, so its own [workspace.dependencies] table is in scope
     let dir = path.posix.dirname(manifestPath);
     while (true) {
       const rootManifestPath = dir === "." ? "Cargo.toml" : `${dir}/Cargo.toml`;

--- a/packages/files/test/toml.test.ts
+++ b/packages/files/test/toml.test.ts
@@ -8,6 +8,7 @@ import {
   setPackageFileVersion,
   getPackageFileVersion,
   writePkgFile,
+  readCargoWorkspaceRoots,
 } from "../src";
 
 const f = fixtures(__dirname);
@@ -171,6 +172,41 @@ describe("toml", () => {
         });
         expect(cargoFileModifiedPkgA.version).toBe("4.5.6");
       });
+    });
+  });
+
+  describe("cargo workspace roots", () => {
+    it("finds no root for a standalone crate", function* () {
+      const cargoFolder = f.copy("pkg.rust-single");
+
+      const roots = yield* readCargoWorkspaceRoots({
+        memberManifestPaths: ["Cargo.toml"],
+        cwd: cargoFolder,
+      });
+      expect(roots).toEqual([]);
+    });
+
+    it("finds no root for a nested crate without a workspace above it", function* () {
+      const cargoFolder = f.copy("pkg.rust-single-nested");
+
+      const roots = yield* readCargoWorkspaceRoots({
+        memberManifestPaths: ["crates/pkg-a/Cargo.toml"],
+        cwd: cargoFolder,
+      });
+      expect(roots).toEqual([]);
+    });
+
+    it("terminates on an absolute manifest path", function* () {
+      const cargoFolder = f.copy("pkg.rust-single");
+
+      // manifest paths are cwd-relative everywhere covector produces them;
+      // an absolute path is the worst case for the walk up the directory
+      // tree, which must still stop at the top rather than loop forever
+      const roots = yield* readCargoWorkspaceRoots({
+        memberManifestPaths: ["/outside/the/tree/Cargo.toml"],
+        cwd: cargoFolder,
+      });
+      expect(roots).toEqual([]);
     });
   });
 });

--- a/packages/files/test/toml.test.ts
+++ b/packages/files/test/toml.test.ts
@@ -196,6 +196,35 @@ describe("toml", () => {
       expect(roots).toEqual([]);
     });
 
+    it("finds a root per workspace when members span several", function* () {
+      const cargoFolder = f.copy("pkg.rust-workspace-root-deps-multi");
+
+      const roots = yield* readCargoWorkspaceRoots({
+        memberManifestPaths: [
+          "core/pkg-a/Cargo.toml",
+          "core/pkg-b/Cargo.toml",
+          "tools/pkg-c/Cargo.toml",
+        ],
+        cwd: cargoFolder,
+      });
+      expect(roots.map((root) => root.file.path)).toEqual([
+        "core/Cargo.toml",
+        "tools/Cargo.toml",
+      ]);
+    });
+
+    it("finds a root manifest that is the member walked up from", function* () {
+      const cargoFolder = f.copy("pkg.rust-workspace-root-deps-inherited");
+
+      // covector bumps the root manifest itself when it holds the version
+      // its members inherit at [workspace.package]
+      const roots = yield* readCargoWorkspaceRoots({
+        memberManifestPaths: ["Cargo.toml"],
+        cwd: cargoFolder,
+      });
+      expect(roots.map((root) => root.file.path)).toEqual(["Cargo.toml"]);
+    });
+
     it("terminates on an absolute manifest path", function* () {
       const cargoFolder = f.copy("pkg.rust-single");
 


### PR DESCRIPTION
Follow-up to #397 from the Discord thread: version requirements that live outside member manifests now track member bumps, covering Cargo's root `[workspace.dependencies]` table (the tauri-apps/tauri#15412 shape). Default-on: it only fires where a version requirement exists, and a stale one is a silently under-constrained publish.

- Requirements keep their form: partial pins stay partial, `^`/`~`/`=` prefixes are preserved, other keys are untouched. Path-only, `*`, comparator-range (`>=1.2, <2`), and wildcard (`1.*`) entries stay byte-identical.
- `catalog:` references in package.json are now left alone; they previously hit the partial-pin path and were rewritten to a bare major, the `workspace:*` corruption again. The catalog tables in pnpm-workspace.yaml stay manually managed (table bumping dropped per the review thread).
- Runs only when `covector version` applies bumps; `status` and validation are unchanged.

From a real `covector version` run (pkg-b takes a minor, pkg-a cascades a patch):

```toml
[workspace.dependencies]
serde = "1.0"
rust_root_pkg_a_fixture = { version = "0.5", path = "pkg-a", default-features = false }  # patch: untouched
rust_root_pkg_b_fixture = "^0.9.0"  # was "^0.8.0"
rust_root_pkg_c_fixture = { path = "pkg-c", version = "*" }
rust_root_pkg_d_fixture = { path = "pkg-d" }
```

What a bump should do to a comparator range is #184's policy question, so those are recognized and skipped here. `package = "..."` renames are not probed, matching member-level behavior today.
