### PR TITLE
remove fixtures from dependabot tracking

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,25 +4,15 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    # no update PRs
-    open-pull-requests-limit: 0
-  # ignore the fixtures directory
-  - package-ecosystem: "npm"
-    directory: "/__fixtures__"
-    schedule:
-      interval: "weekly"
-    ignore:
-      - dependency-name: "*"
+    exclude-paths:
+      - "__fixtures__/**"
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
       interval: "weekly"
-    # no update PRs
-    open-pull-requests-limit: 0
-  # ignore the fixtures directory
-  - package-ecosystem: "cargo"
-    directory: "/__fixtures__"
+    exclude-paths:
+      - "__fixtures__/**"
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "*"


### PR DESCRIPTION
## Motivation

Dependabot can now ignore the fixtures directory! Finally no more noisy PRs (I hope).

## Approach

Add folder as excluded.
