### PR TITLE
Fix config load error reporting and modernize the zod schema

### DIFF
--- a/.changes/config-error-reporting.md
+++ b/.changes/config-error-reporting.md
@@ -1,0 +1,5 @@
+---
+"@covector/files": patch
+---
+
+Report the underlying error when loading `config.json` fails for a reason other than schema validation. A JSON syntax error, or an error thrown while a schema transform resolves a package `path`, was passed to a helper that only accepts a `ZodError` and surfaced as `Invalid zodError param; expected instance of ZodError` instead of the actual problem.

--- a/packages/files/src/index.ts
+++ b/packages/files/src/index.ts
@@ -3,7 +3,7 @@ import * as fs from "fs/promises";
 import { all, until, type Operation } from "effection";
 import type { Logger } from "@covector/types";
 import { configFileSchema } from "./schema.ts";
-import { fromZodError } from "zod-validation-error";
+import { fromError } from "zod-validation-error";
 import { glob } from "tinyglobby";
 import path from "path";
 import { TomlDocument } from "@covector/toml";
@@ -566,8 +566,10 @@ export function* configFile({
       file: inputFile,
       ...parsed,
     };
-  } catch (error: any) {
-    const validationError = fromZodError(error);
+  } catch (error) {
+    // this also catches the `JSON.parse` above, and anything thrown from within
+    // a schema transform, so it needs to handle errors that aren't a `ZodError`
+    const validationError = fromError(error);
     throw new Error(validationError.message);
   }
 }

--- a/packages/files/src/schema.ts
+++ b/packages/files/src/schema.ts
@@ -20,7 +20,7 @@ const processCommandSchema = commandBaseSchema.extend({
 });
 const useCommandSchema = commandBaseSchema.extend({
   use: z.enum(["fetch:check"]),
-  options: z.object({ url: z.string().url() }),
+  options: z.object({ url: z.url() }),
 });
 const complexCommandSchema = z.union([processCommandSchema, useCommandSchema]);
 const commandTypesSchema = z.union([z.string(), complexCommandSchema]);
@@ -30,27 +30,25 @@ const commandSchema = z.union([
   commandTypesSchema.array(),
 ]);
 
-export const allCommandsSchema = z
-  .object({
-    version: commandSchema.optional(),
-    prepublish: commandSchema.optional(),
-    publish: commandSchema.optional(),
-    postpublish: commandSchema.optional(),
-    errorOnVersionRange: z.string().optional(),
-    releaseTag: z.union([z.literal(false), z.string()]).optional(),
-    assets: z
-      .union([
-        z
-          .object({
-            path: z.string(),
-            name: z.string(),
-          })
-          .array(),
-        z.literal(false),
-      ])
-      .optional(),
-  })
-  .passthrough();
+export const allCommandsSchema = z.looseObject({
+  version: commandSchema.optional(),
+  prepublish: commandSchema.optional(),
+  publish: commandSchema.optional(),
+  postpublish: commandSchema.optional(),
+  errorOnVersionRange: z.string().optional(),
+  releaseTag: z.union([z.literal(false), z.string()]).optional(),
+  assets: z
+    .union([
+      z
+        .object({
+          path: z.string(),
+          name: z.string(),
+        })
+        .array(),
+      z.literal(false),
+    ])
+    .optional(),
+});
 export type CommandConfig = z.infer<typeof allCommandsSchema>;
 
 export const pkgManagerSchema = allCommandsSchema.pick({
@@ -87,17 +85,15 @@ export const packageConfigSchema = (cwd: string = ".") =>
     });
 
 export const configFileSchema = (cwd: string = ".") =>
-  z
-    .object({
-      changeFolder: z.string().optional(),
-      gitSiteUrl: z.string().optional(),
-      timeout: z.number().optional(),
-      additionalBumpTypes: z.string().array().optional(),
-      defaultChangeTag: z.string().optional(),
-      pkgManagers: z.record(z.string(), pkgManagerSchema).optional(),
-      packages: z.record(z.string(), packageConfigSchema(cwd)),
-      changeTags: z.record(z.string(), z.string()).optional(),
-    })
-    .strict();
+  z.strictObject({
+    changeFolder: z.string().optional(),
+    gitSiteUrl: z.string().optional(),
+    timeout: z.number().optional(),
+    additionalBumpTypes: z.string().array().optional(),
+    defaultChangeTag: z.string().optional(),
+    pkgManagers: z.record(z.string(), pkgManagerSchema).optional(),
+    packages: z.record(z.string(), packageConfigSchema(cwd)),
+    changeTags: z.record(z.string(), z.string()).optional(),
+  });
 export type ConfigFile = z.infer<ReturnType<typeof configFileSchema>>;
 export type Config = ConfigFile & { file?: File };

--- a/packages/files/test/index.test.ts
+++ b/packages/files/test/index.test.ts
@@ -1,5 +1,7 @@
 import { describe, it } from "@effectionx/vitest";
 import { expect } from "vitest";
+import { writeFileSync } from "fs";
+import path from "path";
 import * as logTest from "../../../helpers/test-logger.ts";
 // @ts-expect-error has no types
 import fixtures from "fixturez";
@@ -35,6 +37,53 @@ describe("general file test", () => {
     expect((configArray as any).gitSiteUrl).toBe(
       "https://github.com/jbolda/covector",
     );
+  });
+
+  describe("reports config errors", () => {
+    const writeConfig = (folder: string, content: string) =>
+      writeFileSync(path.join(folder, ".changes", "config.json"), content);
+
+    it("with the json syntax error", function* () {
+      const configFolder = f.copy("config.simple");
+      writeConfig(configFolder, `{ "packages": {}, }`);
+
+      let message = "";
+      try {
+        yield* configFile({ cwd: configFolder });
+      } catch (error: any) {
+        message = error.message;
+      }
+      expect(message).toMatch(/JSON/);
+    });
+
+    it("with the schema violation", function* () {
+      const configFolder = f.copy("config.simple");
+      writeConfig(configFolder, `{ "packages": {}, "bogusKey": true }`);
+
+      let message = "";
+      try {
+        yield* configFile({ cwd: configFolder });
+      } catch (error: any) {
+        message = error.message;
+      }
+      expect(message).toMatch(/Unrecognized key: "bogusKey"/);
+    });
+
+    it("with the error thrown while resolving a package path", function* () {
+      const configFolder = f.copy("config.simple");
+      writeConfig(
+        configFolder,
+        `{ "packages": { "pkg-a": { "path": "./not-a-folder" } } }`,
+      );
+
+      let message = "";
+      try {
+        yield* configFile({ cwd: configFolder });
+      } catch (error: any) {
+        message = error.message;
+      }
+      expect(message).toMatch(/ENOENT/);
+    });
   });
 
   it("reads all package files in config", function* () {


### PR DESCRIPTION
First pass at the types/zod lane. Two independent commits.

The `try` in `configFile` wraps `JSON.parse` and the schema parse together and hands whatever comes out to `fromZodError`, which only accepts a `ZodError`. A trailing comma in `config.json`, or a `packages.*.path` that isn't there (the `statSync` inside `packageConfigSchema`'s transform), reports this instead of the actual problem:

```
Invalid zodError param; expected instance of ZodError. Did you mean to use the "fromError" method instead?
```

`fromError` takes `unknown`, formats a `ZodError` identically, and passes anything else through with its own message. Three tests cover it: the JSON syntax error, the transform's `ENOENT`, and a schema violation to pin the zod formatting that was already correct.

Second commit is zod v4 object idioms — `.passthrough()` and `z.string().url()` are `@deprecated` in the installed 4.4.3, and `.strict()` reads as `z.strictObject`. No behavior change; parse results and inferred types checked against the previous schema before the swap.

Nothing here changes the config input shape, so it should stay clear of that question.