### PR TITLE
publish with dist dir in subpackages

### DIFF
--- a/.changes/publish-dist-files-field.md
+++ b/.changes/publish-dist-files-field.md
@@ -1,0 +1,9 @@
+---
+"@covector/apply": patch:bug
+"@covector/assemble": patch:bug
+"@covector/changelog": patch:bug
+"@covector/command": patch:bug
+"@covector/files": patch:bug
+---
+
+Restrict published tarballs to the built `dist/` output. Internal packages were publishing without `dist/` because the root `.gitignore` excludes it and no `files` field overrode that so `tsdown` used the `.gitignore`.

--- a/packages/apply/package.json
+++ b/packages/apply/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/jbolda/covector.git"
   },
   "type": "module",
+  "files": ["dist"],
   "exports": {
     "development": "./src/index.ts",
     "import": {

--- a/packages/assemble/package.json
+++ b/packages/assemble/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/jbolda/covector.git"
   },
   "type": "module",
+  "files": ["dist"],
   "exports": {
     "development": "./src/index.ts",
     "import": {

--- a/packages/changelog/package.json
+++ b/packages/changelog/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/jbolda/covector.git"
   },
   "type": "module",
+  "files": ["dist"],
   "exports": {
     "development": "./src/index.ts",
     "import": {

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/jbolda/covector.git"
   },
   "type": "module",
+  "files": ["dist"],
   "exports": {
     "development": "./src/index.ts",
     "import": {

--- a/packages/files/package.json
+++ b/packages/files/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/jbolda/covector.git"
   },
   "type": "module",
+  "files": ["dist"],
   "exports": {
     "development": "./src/index.ts",
     "import": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/jbolda/covector.git"
   },
   "type": "module",
+  "files": ["dist"],
   "exports": {
     "development": "./src/index.ts",
     "import": {


### PR DESCRIPTION
## Motivation

Restrict published tarballs to the built `dist/` output. Internal packages were publishing without `dist/` because the root `.gitignore` excludes it and no `files` field overrode that so `tsdown` used the `.gitignore`.
